### PR TITLE
Initial scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Temporary files
+*.tmp
+*.swp
+*.swo
+*~
+
+# Backup files
+*.bak
+*.backup
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# IDE-specific files
+.vscode/
+.idea/
+*.iml
+
+# Test outputs
+test-output/
+*.log
+

--- a/DNS01-SETUP.md
+++ b/DNS01-SETUP.md
@@ -1,0 +1,262 @@
+# DNS-01 Challenge Setup Guide
+
+This guide shows you how to set up **fully local DNS-01 challenge testing** on your OpenShift cluster without any external dependencies.
+
+## What You'll Get
+
+✅ Local DNS server (acme-dns) for ACME challenges  
+✅ Pebble ACME server using your local DNS  
+✅ cert-manager configured for DNS-01  
+✅ Ability to test wildcard certificates  
+✅ **No external DNS provider needed**  
+✅ **No real DNS records needed**
+
+## Quick Start
+
+### Step 1: Install Local DNS Server
+
+```bash
+./install-local-dns.sh
+```
+
+This installs **acme-dns** - a lightweight DNS server with an API designed specifically for ACME challenges.
+
+### Step 2: Reinstall Pebble to Use Local DNS
+
+```bash
+# Delete existing Pebble
+oc delete namespace pebble
+
+# Reinstall pointing to acme-dns
+DNS_SERVER=acme-dns.acme-dns.svc.cluster.local:53 PEBBLE_ALWAYS_VALID=1 ./install-pebble.sh
+```
+
+Now Pebble will query your local acme-dns server for DNS validation!
+
+### Step 3: Install cert-manager Webhook for acme-dns
+
+The cert-manager webhook allows cert-manager to create DNS records in acme-dns.
+
+```bash
+# Install the acme-dns webhook
+helm repo add cert-manager-webhook-acmedns https://k3rnelpan1c-dev.github.io/cert-manager-webhook-acmedns
+helm repo update
+
+helm install cert-manager-webhook-acmedns \
+  cert-manager-webhook-acmedns/cert-manager-webhook-acmedns \
+  -n cert-manager \
+  --set groupName=acme.mycompany.com
+```
+
+Or manually deploy:
+```bash
+kubectl apply -f https://raw.githubusercontent.com/k3rnelpan1c-dev/cert-manager-webhook-acmedns/master/deploy/manifests.yaml
+```
+
+### Step 4: Register with acme-dns
+
+Create an account in acme-dns for each domain you want to test:
+
+```bash
+# Register a domain
+oc run --rm -i acmedns-register --image=curlimages/curl --restart=Never -- \
+  curl -X POST http://acme-dns.acme-dns.svc.cluster.local:8080/register
+
+# Save the output - you'll need the credentials
+```
+
+Example output:
+```json
+{
+  "username": "eabcdb41-d89f-4580-bb05-cd43c5d53b79",
+  "password": "pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
+  "fulldomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf.acme-dns.local",
+  "subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
+  "allowfrom": []
+}
+```
+
+### Step 5: Create DNS-01 ClusterIssuer
+
+Create a secret with your acme-dns credentials:
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: acmedns-credentials
+  namespace: cert-manager
+type: Opaque
+stringData:
+  acmedns.json: |
+    {
+      "*.example.com": {
+        "username": "YOUR_USERNAME",
+        "password": "YOUR_PASSWORD",
+        "fulldomain": "YOUR_FULLDOMAIN",
+        "subdomain": "YOUR_SUBDOMAIN",
+        "serverurl": "http://acme-dns.acme-dns.svc.cluster.local:8080"
+      }
+    }
+EOF
+```
+
+Create the ClusterIssuer:
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: pebble-dns01-issuer
+spec:
+  acme:
+    server: https://pebble.pebble.svc.cluster.local:14000/dir
+    skipTLSVerify: true
+    email: test@example.com
+    privateKeySecretRef:
+      name: pebble-dns01-account-key
+    solvers:
+    - dns01:
+        acmeDNS:
+          host: http://acme-dns.acme-dns.svc.cluster.local:8080
+          accountSecretRef:
+            name: acmedns-credentials
+            key: acmedns.json
+EOF
+```
+
+### Step 6: Test with a Wildcard Certificate
+
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-cert-test
+  namespace: default
+spec:
+  secretName: wildcard-cert-tls
+  issuerRef:
+    name: pebble-dns01-issuer
+    kind: ClusterIssuer
+  dnsNames:
+  - "*.example.com"
+  - "example.com"
+EOF
+```
+
+### Step 7: Verify
+
+```bash
+# Watch certificate status
+watch oc get certificate -n default
+
+# Check if cert is ready
+oc get certificate wildcard-cert-test -n default
+
+# View the certificate
+oc get secret wildcard-cert-tls -n default -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Your OCP Cluster                       │
+│                                                          │
+│  ┌──────────────┐      ┌─────────────┐                 │
+│  │ cert-manager │─────→│  acme-dns   │                 │
+│  │              │      │  (DNS API)  │                 │
+│  └──────┬───────┘      └──────┬──────┘                 │
+│         │                      │                         │
+│         │  ACME                │  DNS                    │
+│         │  Protocol            │  Queries                │
+│         │                      │                         │
+│         ↓                      ↓                         │
+│  ┌──────────────┐      ┌─────────────┐                 │
+│  │   Pebble     │─────→│  acme-dns   │                 │
+│  │ (ACME Server)│      │ (DNS Server)│                 │
+│  └──────────────┘      └─────────────┘                 │
+│                                                          │
+│  Everything runs locally - no external dependencies!    │
+└─────────────────────────────────────────────────────────┘
+```
+
+## How It Works
+
+1. **cert-manager** requests a certificate from **Pebble**
+2. **Pebble** says "prove ownership with DNS-01 challenge"
+3. **cert-manager** creates a TXT record in **acme-dns** via API
+4. **Pebble** queries **acme-dns** to verify the TXT record
+5. With `PEBBLE_ALWAYS_VALID=1`, validation auto-succeeds
+6. **Pebble** issues the certificate
+7. **cert-manager** stores it in a Secret
+
+## Benefits of This Setup
+
+✅ **Completely Local** - Everything runs in your cluster  
+✅ **No External Dependencies** - No Route53, CloudFlare, etc needed  
+✅ **Test Wildcard Certs** - DNS-01 is required for wildcards  
+✅ **Fast** - No waiting for DNS propagation  
+✅ **Repeatable** - Same setup works on any OCP cluster  
+✅ **Safe** - No rate limits, no real certificates  
+
+## Troubleshooting
+
+### acme-dns Not Starting
+
+```bash
+oc logs -n acme-dns deployment/acme-dns
+oc describe pod -n acme-dns
+```
+
+### Pebble Can't Reach acme-dns
+
+```bash
+# Test DNS resolution from Pebble
+oc run --rm -i dns-test --image=busybox --restart=Never -n pebble -- \
+  nslookup acme-dns.acme-dns.svc.cluster.local
+```
+
+### Certificate Stuck in Pending
+
+```bash
+# Check challenge status
+oc describe challenge -n default
+
+# Check cert-manager logs
+oc logs -n cert-manager deployment/cert-manager -f
+
+# Check Pebble logs
+oc logs -n pebble deployment/pebble -f
+```
+
+### Webhook Not Working
+
+```bash
+# Check webhook deployment
+oc get pods -n cert-manager | grep webhook
+
+# Check webhook logs
+oc logs -n cert-manager deployment/cert-manager-webhook-acmedns
+```
+
+## Alternative: Simpler Setup with Always-Valid
+
+If you just want to test the mechanics without full DNS setup:
+
+1. Keep `PEBBLE_ALWAYS_VALID=1`
+2. Use a dummy DNS-01 solver configuration
+3. Pebble will auto-validate without checking DNS
+
+This is less realistic but useful for testing cert-manager functionality.
+
+## References
+
+- [acme-dns GitHub](https://github.com/joohoi/acme-dns)
+- [cert-manager acme-dns webhook](https://github.com/k3rnelpan1c-dev/cert-manager-webhook-acmedns)
+- [Pebble Documentation](https://github.com/letsencrypt/pebble)
+- [cert-manager DNS-01 Guide](https://cert-manager.io/docs/configuration/acme/dns01/)
+

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,239 @@
-.PHONY: help install-cert-manager-operator uninstall-cert-manager-operator clean
+.PHONY: help check-network install-cert-manager-operator install-pebble install-fake-dns install-all create-issuer create-dns01-issuer create-certs test-all test-dns01 quick-test test-cert verify-cert clean clean-certs clean-pebble clean-fake-dns clean-dns-config clean-issuers clean-temp uninstall-cert-manager-operator
 
 # Default target
 help:
 	@echo "cert-manager-scripts Makefile"
 	@echo ""
 	@echo "Available targets:"
+	@echo "  check-network                   - Check cluster network configuration (IPv4/IPv6/Dual-stack)"
 	@echo "  install-cert-manager-operator   - Install cert-manager Operator for Red Hat OpenShift"
-	@echo "  uninstall-cert-manager-operator - Uninstall cert-manager Operator for Red Hat OpenShift"
-	@echo "  clean                           - Clean up temporary files"
+	@echo "  install-pebble                  - Install Pebble ACME test server"
+	@echo "  install-fake-dns                - Install fake DNS API for air-gapped DNS-01 testing"
+	@echo "  install-all                     - Install cert-manager-operator and Pebble"
+	@echo "  create-issuer                   - Create ClusterIssuer pointing to Pebble (HTTP-01)"
+	@echo "  create-dns01-issuer             - Create ClusterIssuer pointing to Pebble (DNS-01)"
+	@echo "  create-certs                    - Create test certificates (HTTP-01)"
+	@echo "  test-all                        - Complete HTTP-01 setup"
+	@echo "  test-dns01                      - Complete DNS-01 setup (air-gapped)"
+	@echo "  quick-test                      - Quick end-to-end DNS-01 test (setup + test + verify)"
+	@echo "  test-cert                       - Create a test wildcard certificate"
+	@echo "  verify-cert                     - Verify certificate status"
+	@echo "  clean                           - Clean up all resources (keeps cert-manager-operator)"
+	@echo "  clean-certs                     - Clean up certificates and challenges only"
+	@echo "  clean-pebble                    - Clean up Pebble only"
+	@echo "  clean-fake-dns                  - Clean up fake DNS only"
+	@echo "  clean-issuers                   - Clean up ClusterIssuers only"
+	@echo "  clean-temp                      - Clean up temporary files"
+	@echo "  uninstall-cert-manager-operator - Uninstall cert-manager Operator (WARNING!)"
 	@echo "  help                            - Show this help message"
 	@echo ""
+
+# Check cluster network configuration
+check-network:
+	@./check-cluster-network.sh
 
 # Install cert-manager-operator
 install-cert-manager-operator:
 	@echo "Installing cert-manager Operator for Red Hat OpenShift..."
 	@./install-cert-manager-operator.sh
 
-# Uninstall cert-manager-operator (placeholder for future script)
-uninstall-cert-manager-operator:
-	@echo "Uninstall script not yet implemented."
-	@echo "To manually uninstall, see: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-uninstalling-operator"
+# Install Pebble ACME test server
+install-pebble:
+	@echo "Installing Pebble ACME test server..."
+	@./install-pebble.sh
+
+# Install fake DNS API
+install-fake-dns:
+	@echo "Installing fake DNS API for air-gapped testing..."
+	@./install-fake-dns.sh
+
+# Install everything
+install-all: install-cert-manager-operator install-pebble
+	@echo ""
+	@echo "All components installed successfully!"
+
+# Create ClusterIssuer pointing to Pebble (HTTP-01)
+create-issuer:
+	@./create-issuer.sh
+
+# Create ClusterIssuer pointing to Pebble (DNS-01)
+create-dns01-issuer:
+	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 ./create-dns01-issuer.sh
+
+# Create test certificates
+create-certs:
+	@./create-test-certificates.sh
+
+# Complete test setup: install everything + create issuer + create certificates
+test-all: install-all create-issuer create-certs
+	@echo ""
+	@echo "========================================" 
+	@echo "  Complete Test Environment Ready!"
+	@echo "========================================"
+	@echo ""
+	@echo "You can now test certificate issuance with:"
+	@echo "  oc get certificate -A"
+	@echo "  oc get order,challenge -A"
+
+# Complete DNS-01 test setup (air-gapped)
+test-dns01: install-fake-dns
+	@echo "Reinstalling Pebble with fake DNS..."
+	@oc delete namespace pebble --ignore-not-found=true
+	@sleep 10
+	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 PEBBLE_ALWAYS_VALID=1 ./install-pebble.sh
+	@echo ""
+	@echo "Creating DNS-01 issuer..."
+	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 ./create-dns01-issuer.sh
+	@echo ""
+	@echo "========================================"
+	@echo "  DNS-01 Environment Ready!"
+	@echo "========================================"
+	@echo ""
+	@echo "Test with a wildcard certificate:"
+	@echo "  oc apply -f - <<EOF"
+	@echo "  apiVersion: cert-manager.io/v1"
+	@echo "  kind: Certificate"
+	@echo "  metadata:"
+	@echo "    name: wildcard-test"
+	@echo "    namespace: default"
+	@echo "  spec:"
+	@echo "    secretName: wildcard-test-tls"
+	@echo "    issuerRef:"
+	@echo "      name: pebble-dns01-issuer"
+	@echo "      kind: ClusterIssuer"
+	@echo "    dnsNames:"
+	@echo "    - '*.example.com'"
+	@echo "    - 'example.com'"
+	@echo "  EOF"
+	@echo ""
+	@echo "Monitor progress:"
+	@echo "  watch oc get certificate -n default"
+
+# Quick end-to-end test
+quick-test: test-dns01 test-cert
+	@echo ""
+	@echo "========================================"
+	@echo "  Quick Test Running..."
+	@echo "========================================"
+	@echo ""
+	@echo "Waiting for certificate to be issued (timeout: 5 minutes)..."
+	@timeout=300; \
+	elapsed=0; \
+	while [ $$elapsed -lt $$timeout ]; do \
+		if oc get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+			echo "✅ Certificate issued successfully!"; \
+			break; \
+		fi; \
+		if [ $$((elapsed % 10)) -eq 0 ]; then \
+			echo "  ⏳ Still waiting... ($$elapsed seconds elapsed)"; \
+		fi; \
+		sleep 2; \
+		elapsed=$$((elapsed + 2)); \
+	done
+	@echo ""
+	@$(MAKE) verify-cert
+	@echo ""
+	@echo "Quick test complete! Run 'make clean' to clean up."
+
+# Create a test wildcard certificate
+test-cert:
+	@echo "Creating test wildcard certificate..."
+	@printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: wildcard-test\n  namespace: default\nspec:\n  secretName: wildcard-test-tls\n  issuerRef:\n    name: pebble-dns01-issuer\n    kind: ClusterIssuer\n  dnsNames:\n  - "*.example.com"\n  - "example.com"\n' | oc apply -f -
+	@echo "Certificate created. Run 'make verify-cert' to check status."
+
+# Verify certificate status
+verify-cert:
+	@echo ""
+	@echo "========================================"
+	@echo "  Certificate Status"
+	@echo "========================================"
+	@echo ""
+	@oc get certificate wildcard-test -n default 2>/dev/null || echo "Certificate not found"
+	@echo ""
+	@echo "Orders:"
+	@oc get order -n default 2>/dev/null || echo "No orders found"
+	@echo ""
+	@echo "Challenges:"
+	@oc get challenge -n default 2>/dev/null || echo "No challenges found"
+	@echo ""
+	@if oc get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+		echo "✅ Certificate is READY!"; \
+		echo ""; \
+		echo "View certificate details:"; \
+		echo "  oc get secret wildcard-test-tls -n default -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout"; \
+	else \
+		echo "⏳ Certificate is still being issued..."; \
+		echo ""; \
+		echo "Monitor progress with:"; \
+		echo "  watch oc get certificate -n default"; \
+		echo ""; \
+		echo "Check challenges:"; \
+		echo "  oc get challenge -n default"; \
+		echo ""; \
+		echo "Check logs:"; \
+		echo "  oc logs -n cert-manager deployment/cert-manager --tail=50"; \
+	fi
+
+# Clean up certificates, orders, and challenges
+clean-certs:
+	@echo "Cleaning up certificates, orders, and challenges..."
+	@oc delete certificates --all -n default --ignore-not-found=true
+	@oc delete certificaterequests --all -n default --ignore-not-found=true
+	@oc delete orders --all -n default --ignore-not-found=true
+	@oc delete challenges --all -n default --ignore-not-found=true
+	@oc delete secrets wildcard-test-tls test-cert-simple-tls test-cert-app-tls test-cert-api-tls -n default --ignore-not-found=true
+	@echo "Certificates cleaned."
+
+# Clean up Pebble
+clean-pebble:
+	@echo "Cleaning up Pebble..."
+	@oc delete namespace pebble --ignore-not-found=true
+	@oc delete secret pebble-dns01-issuer-account-key pebble-issuer-account-key -n cert-manager --ignore-not-found=true
+	@echo "Pebble cleaned."
+
+# Clean up fake DNS
+clean-fake-dns:
+	@echo "Cleaning up fake DNS..."
+	@oc delete namespace fake-dns --ignore-not-found=true
+	@echo "Fake DNS cleaned."
+
+# Clean up DNS configuration
+clean-dns-config:
+	@echo "Restoring DNS configuration..."
+	@oc patch dns.operator.openshift.io/default --type=json -p='[{"op": "remove", "path": "/spec/servers"}]' 2>/dev/null || true
+	@echo "DNS configuration restored."
+
+# Clean up ClusterIssuers
+clean-issuers:
+	@echo "Cleaning up ClusterIssuers..."
+	@oc delete clusterissuer pebble-issuer pebble-dns01-issuer --ignore-not-found=true
+	@oc delete secret rfc2136-credentials -n default --ignore-not-found=true
+	@echo "ClusterIssuers cleaned."
+
+# Clean everything except cert-manager-operator
+clean: clean-certs clean-issuers clean-pebble clean-fake-dns clean-dns-config
+	@echo ""
+	@echo "========================================"
+	@echo "  Cleanup Complete!"
+	@echo "========================================"
+	@echo ""
+	@echo "cert-manager-operator is still installed."
+	@echo "To test again, run: make test-dns01"
 
 # Clean temporary files
-clean:
+clean-temp:
 	@echo "Cleaning temporary files..."
 	@find . -name "*.tmp" -delete
 	@find . -name ".*.swp" -delete
-	@echo "Clean complete."
+	@echo "Temp files cleaned."
 
+# Uninstall cert-manager-operator (use with caution)
+uninstall-cert-manager-operator:
+	@echo "WARNING: This will uninstall cert-manager-operator!"
+	@echo "Press Ctrl+C to cancel, or Enter to continue..."
+	@read confirm
+	@echo "Uninstalling cert-manager-operator..."
+	@oc delete subscription cert-manager-operator -n openshift-cert-manager-operator --ignore-not-found=true
+	@oc delete csv -n openshift-cert-manager-operator -l operators.coreos.com/cert-manager-operator.openshift-cert-manager-operator --ignore-not-found=true
+	@oc delete namespace openshift-cert-manager-operator --ignore-not-found=true
+	@echo "cert-manager-operator uninstalled."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.PHONY: help install-cert-manager-operator uninstall-cert-manager-operator clean
+
+# Default target
+help:
+	@echo "cert-manager-scripts Makefile"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  install-cert-manager-operator   - Install cert-manager Operator for Red Hat OpenShift"
+	@echo "  uninstall-cert-manager-operator - Uninstall cert-manager Operator for Red Hat OpenShift"
+	@echo "  clean                           - Clean up temporary files"
+	@echo "  help                            - Show this help message"
+	@echo ""
+
+# Install cert-manager-operator
+install-cert-manager-operator:
+	@echo "Installing cert-manager Operator for Red Hat OpenShift..."
+	@./install-cert-manager-operator.sh
+
+# Uninstall cert-manager-operator (placeholder for future script)
+uninstall-cert-manager-operator:
+	@echo "Uninstall script not yet implemented."
+	@echo "To manually uninstall, see: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-uninstalling-operator"
+
+# Clean temporary files
+clean:
+	@echo "Cleaning temporary files..."
+	@find . -name "*.tmp" -delete
+	@find . -name ".*.swp" -delete
+	@echo "Clean complete."
+

--- a/NETWORK-SUPPORT.md
+++ b/NETWORK-SUPPORT.md
@@ -1,0 +1,312 @@
+# IPv4, IPv6, and Dual-Stack Support
+
+This document explains how IPv4, IPv6, and dual-stack networking affects cert-manager testing on OpenShift.
+
+## Understanding Network Stacks
+
+OpenShift clusters can be configured with three different network stack types:
+
+### 1. IPv4 Only (Most Common)
+- **What it means**: Cluster uses only IPv4 addresses for pod and service networks
+- **Network CIDRs**: Only IPv4 CIDRs (e.g., `10.128.0.0/14`, `172.30.0.0/16`)
+- **DNS Records**: Only A records needed
+- **Typical setup**: Default for most OpenShift installations
+
+### 2. IPv6 Only
+- **What it means**: Cluster uses only IPv6 addresses for pod and service networks
+- **Network CIDRs**: Only IPv6 CIDRs (e.g., `fd00:10:128::/56`)
+- **DNS Records**: Only AAAA records needed
+- **Typical setup**: Less common, used for IPv6-only environments
+
+### 3. Dual-Stack (IPv4 + IPv6)
+- **What it means**: Cluster supports both IPv4 and IPv6 simultaneously
+- **Network CIDRs**: Both IPv4 and IPv6 CIDRs configured
+- **DNS Records**: Both A and AAAA records can be used
+- **Typical setup**: Available in OpenShift 4.14+ with OVN-Kubernetes
+- **Flexibility**: Services can use either protocol or both
+
+## Checking Your Cluster
+
+Use the provided script to check your cluster's network configuration:
+
+```bash
+make check-network
+```
+
+This will display:
+- OpenShift version
+- Network plugin type (OVN-Kubernetes or OpenShift SDN)
+- Cluster network CIDRs
+- Service network CIDRs
+- Network stack type (IPv4, IPv6, or dual-stack)
+- Node IP addresses
+- API server addresses
+
+## Impact on cert-manager Testing
+
+### cert-manager Compatibility
+
+**Good news**: cert-manager works with all network stacks!
+
+- ✅ IPv4 only clusters: Fully supported
+- ✅ IPv6 only clusters: Fully supported
+- ✅ Dual-stack clusters: Fully supported
+
+cert-manager can:
+- Communicate with ACME servers over IPv4 or IPv6
+- Handle HTTP-01 challenges on any network stack
+- Process DNS-01 challenges regardless of IP version
+- Issue certificates for domains with A, AAAA, or both record types
+
+### Pebble Compatibility
+
+Pebble (the ACME test server) also supports all network stacks:
+
+- Runs on IPv4, IPv6, or dual-stack clusters
+- Accepts ACME requests over any protocol
+- Validates challenges via IPv4 or IPv6
+- No special configuration needed
+
+### Testing Scenarios by Network Stack
+
+#### IPv4 Only Cluster
+
+**What you can test:**
+- ✅ HTTP-01 challenges with IPv4
+- ✅ DNS-01 challenges (DNS provider must be reachable via IPv4)
+- ✅ Certificate issuance for domains with A records
+- ✅ Wildcard certificates
+- ✅ apiServer certificates
+- ✅ Ingress/Route certificates
+
+**Limitations:**
+- ❌ Cannot test IPv6-specific scenarios
+- ❌ Cannot test dual-stack service behavior
+
+#### IPv6 Only Cluster
+
+**What you can test:**
+- ✅ HTTP-01 challenges with IPv6
+- ✅ DNS-01 challenges (DNS provider must be reachable via IPv6)
+- ✅ Certificate issuance for domains with AAAA records
+- ✅ Wildcard certificates
+- ✅ apiServer certificates
+- ✅ Ingress/Route certificates
+
+**Considerations:**
+- Ensure external services (like DNS providers) support IPv6
+- Some cloud providers may have limited IPv6 support
+- Routes/Ingresses must be accessible via IPv6
+
+#### Dual-Stack Cluster
+
+**What you can test:**
+- ✅ All IPv4 scenarios
+- ✅ All IPv6 scenarios
+- ✅ Services accessible via both protocols
+- ✅ Protocol preference and fallback behavior
+- ✅ Mixed environments (IPv4 clients to IPv6 services, etc.)
+
+**Advantages for testing:**
+- Most flexible configuration
+- Can test real-world scenarios where clients use different protocols
+- Can verify cert-manager works with both protocols
+
+## DNS-01 Challenges and Network Stacks
+
+### How DNS-01 Works with Different Stacks
+
+DNS-01 challenges are **network-stack agnostic** because:
+
+1. DNS providers typically accept API calls over both IPv4 and IPv6
+2. ACME servers query DNS over whatever protocol they support
+3. The actual DNS resolution happens externally
+
+**Key Point**: DNS-01 challenges care about DNS records (TXT records for validation), not the cluster's internal IP addressing.
+
+### IPv4 vs IPv6 for DNS-01
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   DNS-01 Challenge Flow                  │
+└─────────────────────────────────────────────────────────┘
+
+cert-manager → DNS Provider API (IPv4 or IPv6)
+     ↓
+DNS Provider creates TXT record
+     ↓
+ACME Server (Pebble) → DNS Query (IPv4 or IPv6) → DNS Provider
+     ↓
+Validation succeeds if TXT record matches
+```
+
+The cluster's network stack **doesn't matter** for DNS-01 as long as:
+- cert-manager can reach the DNS provider's API
+- The ACME server can query DNS
+
+## HTTP-01 Challenges and Network Stacks
+
+### How HTTP-01 Works with Different Stacks
+
+HTTP-01 challenges **are affected** by network stack because:
+
+1. ACME server must make HTTP connection to your cluster
+2. The route/ingress must be accessible from ACME server
+3. IP version must match between ACME server and cluster
+
+### IPv4 Only Cluster with HTTP-01
+
+```yaml
+# Example: HTTP-01 challenge on IPv4 cluster
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-cert
+spec:
+  dnsNames:
+  - example.com  # Must have A record pointing to IPv4 address
+  issuerRef:
+    name: pebble-issuer
+    kind: ClusterIssuer
+```
+
+**Requirements:**
+- Domain must have A record
+- Route must be accessible via IPv4
+- Pebble can reach route via IPv4
+
+### IPv6 Only Cluster with HTTP-01
+
+```yaml
+# Example: HTTP-01 challenge on IPv6 cluster
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-cert-ipv6
+spec:
+  dnsNames:
+  - example.com  # Must have AAAA record pointing to IPv6 address
+  issuerRef:
+    name: pebble-issuer
+    kind: ClusterIssuer
+```
+
+**Requirements:**
+- Domain must have AAAA record
+- Route must be accessible via IPv6
+- Pebble can reach route via IPv6
+
+### Dual-Stack Cluster with HTTP-01
+
+**Advantages:**
+- Works with domains that have A, AAAA, or both records
+- ACME server can use either protocol
+- More forgiving configuration
+
+## Testing Recommendations by Scenario
+
+### Scenario 1: Testing with Pebble (Local ACME)
+
+**With `PEBBLE_ALWAYS_VALID=1`:**
+- Network stack doesn't matter
+- All challenges auto-succeed
+- Great for initial cert-manager testing
+- No external connectivity required
+
+**With `PEBBLE_ALWAYS_VALID=0`:**
+- Must configure DNS or HTTP routes properly
+- Network stack matters for HTTP-01
+- Good for realistic testing
+
+### Scenario 2: Testing with Let's Encrypt Staging
+
+**IPv4 Only:**
+- Standard configuration
+- Ensure routes are accessible from internet via IPv4
+
+**IPv6 Only:**
+- Requires IPv6 connectivity to Let's Encrypt
+- Routes must be accessible via IPv6
+- Less common, verify Let's Encrypt IPv6 support
+
+**Dual-Stack:**
+- Most flexible
+- Let's Encrypt can use either protocol
+
+## Common Issues by Network Stack
+
+### IPv4 Only Issues
+
+**Issue**: "Connection refused" to external services
+- **Cause**: Service only supports IPv6
+- **Solution**: Ensure all external services support IPv4
+
+### IPv6 Only Issues
+
+**Issue**: "No route to host" errors
+- **Cause**: External service doesn't support IPv6
+- **Solution**: Verify external services have IPv6 connectivity
+
+**Issue**: DNS resolution failures
+- **Cause**: DNS provider doesn't have AAAA records
+- **Solution**: Ensure DNS provider supports IPv6
+
+### Dual-Stack Issues
+
+**Issue**: Unexpected protocol being used
+- **Cause**: Service prefers one protocol over another
+- **Solution**: Explicitly configure protocol preference
+
+## Network Stack Detection in Scripts
+
+### Current Behavior
+
+Our scripts **do not automatically detect** network stack, but you can check manually:
+
+```bash
+# Check cluster network configuration
+make check-network
+
+# The script will display:
+# - Network stack type (IPv4/IPv6/Dual-stack)
+# - Cluster and service CIDRs
+# - Recommendations for testing
+```
+
+### Why Not Auto-Detect in Installation Scripts?
+
+1. **cert-manager works with all stacks** - no need to modify installation
+2. **Pebble works with all stacks** - no configuration changes needed
+3. **User awareness** - better to explicitly check than silently adapt
+4. **Flexibility** - users might want to test specific scenarios
+
+### When to Check Network Configuration
+
+**Recommended to check before:**
+- Testing IPv6-specific scenarios
+- Configuring HTTP-01 challenges with external domains
+- Setting up DNS records for challenges
+- Troubleshooting connectivity issues
+
+**Not necessary for:**
+- Basic cert-manager installation
+- Pebble installation with `PEBBLE_ALWAYS_VALID=1`
+- Testing with DNS-01 challenges
+
+## Summary
+
+| Aspect | IPv4 Only | IPv6 Only | Dual-Stack |
+|--------|-----------|-----------|------------|
+| cert-manager support | ✅ Full | ✅ Full | ✅ Full |
+| Pebble support | ✅ Full | ✅ Full | ✅ Full |
+| HTTP-01 challenges | ✅ A records | ✅ AAAA records | ✅ Both |
+| DNS-01 challenges | ✅ Works | ✅ Works | ✅ Works |
+| Testing flexibility | Medium | Medium | High |
+| Most common | ✅ Yes | No | Emerging |
+
+## References
+
+- [OpenShift Dual-Stack Documentation](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html)
+- [cert-manager Documentation](https://cert-manager.io/docs/)
+- [Kubernetes IPv6 Documentation](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
+

--- a/PEBBLE-USAGE.md
+++ b/PEBBLE-USAGE.md
@@ -1,0 +1,326 @@
+# Pebble ACME Test Server - Usage Guide
+
+This guide explains how to use Pebble with cert-manager for local testing.
+
+## What is Pebble?
+
+Pebble is a lightweight ACME test server created by Let's Encrypt specifically for testing ACME clients like cert-manager. It's designed to mimic Let's Encrypt's behavior without the complexity or rate limits of a production server.
+
+## Installation
+
+```bash
+# Basic installation
+make install-pebble
+
+# Installation with auto-validation enabled
+PEBBLE_ALWAYS_VALID=1 make install-pebble
+
+# Custom namespace
+PEBBLE_NAMESPACE=acme-test make install-pebble
+```
+
+## Configuration Options
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PEBBLE_NAMESPACE` | `pebble` | Kubernetes namespace for Pebble |
+| `DNS_SERVER` | `8.8.8.8:53` | DNS server for ACME validation |
+| `PEBBLE_ALWAYS_VALID` | `0` | Auto-validate all challenges (1=yes, 0=no) |
+
+### PEBBLE_ALWAYS_VALID Explained
+
+**When set to `1` (enabled):**
+- All ACME challenges automatically succeed
+- No need for proper DNS records or HTTP routes
+- Perfect for initial testing and development
+- Doesn't validate your actual challenge setup
+
+**When set to `0` (disabled - default):**
+- Challenges must be properly configured
+- DNS records must resolve correctly
+- HTTP-01 routes must be accessible
+- Tests your real ACME infrastructure
+
+## Creating a ClusterIssuer for Pebble
+
+### Basic HTTP-01 Issuer
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: pebble-issuer
+spec:
+  acme:
+    # Pebble's ACME directory URL
+    server: https://pebble.pebble.svc.cluster.local:14000/dir
+    
+    # Skip TLS verification (Pebble uses self-signed certs)
+    skipTLSVerify: true
+    
+    # Private key for ACME account
+    privateKeySecretRef:
+      name: pebble-account-key
+    
+    # HTTP-01 challenge solver
+    solvers:
+    - http01:
+        ingress:
+          class: openshift-default
+```
+
+### DNS-01 Issuer (requires DNS provider)
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: pebble-dns-issuer
+spec:
+  acme:
+    server: https://pebble.pebble.svc.cluster.local:14000/dir
+    skipTLSVerify: true
+    privateKeySecretRef:
+      name: pebble-dns-account-key
+    solvers:
+    - dns01:
+        # Example: Using Route53
+        route53:
+          region: us-east-1
+          accessKeyID: YOUR_ACCESS_KEY_ID
+          secretAccessKeySecretRef:
+            name: route53-credentials
+            key: secret-access-key
+```
+
+## Testing Certificate Issuance
+
+### Simple Test Certificate
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-certificate
+  namespace: default
+spec:
+  secretName: test-tls
+  issuerRef:
+    name: pebble-issuer
+    kind: ClusterIssuer
+  dnsNames:
+  - test.example.com
+```
+
+### Wildcard Certificate (requires DNS-01)
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wildcard-certificate
+  namespace: default
+spec:
+  secretName: wildcard-tls
+  issuerRef:
+    name: pebble-dns-issuer
+    kind: ClusterIssuer
+  dnsNames:
+  - "*.apps.example.com"
+```
+
+## Troubleshooting
+
+### Check Pebble Status
+
+```bash
+# Check if Pebble is running
+oc get pods -n pebble
+
+# View Pebble logs
+oc logs -n pebble deployment/pebble -f
+
+# Check Pebble service
+oc get svc -n pebble
+```
+
+### Test Pebble ACME Directory
+
+```bash
+# From inside the cluster
+oc run --rm -i --tty curl-test --image=curlimages/curl --restart=Never -- \
+  curl -k https://pebble.pebble.svc.cluster.local:14000/dir
+
+# Expected output: JSON with ACME directory URLs
+```
+
+Example output:
+```json
+{
+   "keyChange": "https://pebble.pebble.svc.cluster.local:14000/rollover-account-key",
+   "meta": {
+      "externalAccountRequired": false,
+      "termsOfService": "data:text/plain,Do%20what%20thou%20wilt"
+   },
+   "newAccount": "https://pebble.pebble.svc.cluster.local:14000/sign-me-up",
+   "newNonce": "https://pebble.pebble.svc.cluster.local:14000/nonce-plz",
+   "newOrder": "https://pebble.pebble.svc.cluster.local:14000/order-plz",
+   "revokeCert": "https://pebble.pebble.svc.cluster.local:14000/revoke-cert"
+}
+```
+
+### Check Certificate Status
+
+```bash
+# Check certificate status
+oc get certificate -n default
+
+# Describe certificate for details
+oc describe certificate test-certificate -n default
+
+# Check certificate request
+oc get certificaterequest -n default
+
+# Check ACME orders
+oc get order -n default
+
+# Check ACME challenges
+oc get challenge -n default
+```
+
+### Getting Pebble's CA Certificate
+
+Pebble generates its own self-signed CA certificate at startup. To get it:
+
+```bash
+# Fetch and display the CA certificate
+oc run --rm -i --tty pebble-ca-fetch --image=curlimages/curl --restart=Never -- \
+  curl -k https://pebble.pebble.svc.cluster.local:15000/roots/0
+
+# Save to a file
+oc run --rm -i pebble-ca-fetch --image=curlimages/curl --restart=Never -- \
+  curl -k https://pebble.pebble.svc.cluster.local:15000/roots/0 > pebble-ca.crt
+```
+
+The CA certificate is available from Pebble's management API at `/roots/0`. Each time Pebble restarts, it generates a new CA certificate.
+
+**Note**: For testing purposes, it's usually easier to use `skipTLSVerify: true` in your ClusterIssuer rather than managing the CA certificate.
+
+### Common Issues
+
+#### 1. Certificate Stuck in "Pending"
+
+**Cause**: Challenge validation failing
+
+**Solution**:
+```bash
+# Check challenge status
+oc describe challenge -n default
+
+# If using HTTP-01, ensure route/ingress is accessible
+oc get routes -n default
+
+# If using DNS-01, check DNS records
+dig _acme-challenge.example.com
+```
+
+#### 2. "Connection Refused" to Pebble
+
+**Cause**: Pebble not running or service misconfigured
+
+**Solution**:
+```bash
+# Check Pebble pod status
+oc get pods -n pebble
+
+# Check Pebble service
+oc get svc -n pebble
+
+# Restart Pebble if needed
+oc rollout restart deployment/pebble -n pebble
+```
+
+#### 3. "TLS Handshake Timeout"
+
+**Cause**: Network policies or firewall blocking connections
+
+**Solution**:
+- Ensure cert-manager can reach Pebble service
+- Check network policies in both namespaces
+- Verify `skipTLSVerify: true` is set in ClusterIssuer
+
+## Advanced Usage
+
+### Custom DNS Server for DNS-01 Testing
+
+If you want to test DNS-01 with a custom DNS server:
+
+```bash
+# Install Pebble with custom DNS server
+DNS_SERVER=10.0.0.53:53 make install-pebble
+```
+
+### Accessing Pebble Management API
+
+Pebble exposes a management API on port 15000:
+
+```bash
+# Port forward to access locally
+oc port-forward -n pebble svc/pebble 15000:15000
+
+# Check Pebble metrics
+curl http://localhost:15000/metrics
+```
+
+### Testing Certificate Renewal
+
+```bash
+# Force immediate renewal (edit renewBefore)
+oc edit certificate test-certificate -n default
+
+# Or delete the secret to trigger re-issuance
+oc delete secret test-tls -n default
+```
+
+## Integration with Scripts
+
+### Full Testing Workflow
+
+```bash
+# 1. Install cert-manager-operator
+make install-cert-manager-operator
+
+# 2. Install Pebble with auto-validation
+PEBBLE_ALWAYS_VALID=1 make install-pebble
+
+# 3. Create ClusterIssuer
+oc apply -f your-pebble-issuer.yaml
+
+# 4. Create test Certificate
+oc apply -f your-test-certificate.yaml
+
+# 5. Check status
+oc get certificate -A
+```
+
+## Cleaning Up
+
+```bash
+# Delete test certificates
+oc delete certificate test-certificate -n default
+
+# Delete Pebble deployment
+oc delete namespace pebble
+
+# Delete ClusterIssuer
+oc delete clusterissuer pebble-issuer
+```
+
+## References
+
+- [Pebble GitHub Repository](https://github.com/letsencrypt/pebble)
+- [cert-manager Documentation](https://cert-manager.io/docs/)
+- [ACME Protocol (RFC 8555)](https://tools.ietf.org/html/rfc8555)
+

--- a/README.md
+++ b/README.md
@@ -21,22 +21,127 @@ This repository contains bash and Python scripts for:
 - Cluster-admin privileges
 - Bash shell (for shell scripts)
 
+## Quick Test (3 Commands!)
+
+Want to quickly test DNS-01 certificate issuance? Just run these 3 commands:
+
+```bash
+# 1. Install cert-manager-operator (if not already installed)
+make install-cert-manager-operator
+
+# 2. Run the quick test (sets up everything and tests)
+make quick-test
+
+# 3. Clean up when done
+make clean
+```
+
+That's it! The `quick-test` target will:
+- Install Pebble ACME server (air-gapped)
+- Install fake DNS server (for DNS-01 challenges)
+- Configure DNS forwarding
+- Create a DNS-01 ClusterIssuer
+- Request a wildcard certificate (`*.example.com`)
+- Verify the certificate status
+
+**Note:** If the certificate isn't ready after 30 seconds, you can check progress with:
+```bash
+make verify-cert
+```
+
+## What is Pebble?
+
+**Pebble** is a small ACME test server developed by the Let's Encrypt team. It mimics the behavior of Let's Encrypt's production ACME server but runs locally in your cluster. This is perfect for testing cert-manager without:
+- Hitting Let's Encrypt rate limits
+- Needing real public DNS records
+- Requiring internet connectivity
+- Dealing with production certificate concerns
+
+**Key Benefits:**
+- **No rate limits** - test as much as you want
+- **Fast** - instant certificate issuance
+- **Local** - runs entirely in your OpenShift cluster
+- **Safe** - doesn't issue real certificates
+- **Configurable** - can be set to auto-validate challenges for testing
+
 ## Repository Structure
 
 ```
 cert-manager-scripts/
-├── Makefile                           # Make targets for common tasks
-├── README.md                          # This file
-├── install-cert-manager-operator.sh   # Installation script
-└── yaml/                              # YAML manifests organized by purpose
-    └── cert-manager-operator/
-        ├── operatorgroup.yaml         # OperatorGroup definition
-        └── subscription.yaml          # Subscription definition
+├── Makefile                            # Make targets for common tasks
+├── README.md                           # This file
+├── PEBBLE-USAGE.md                     # Detailed Pebble usage guide
+├── NETWORK-SUPPORT.md                  # IPv4/IPv6/dual-stack guide
+├── check-cluster-network.sh            # Check IPv4/IPv6/dual-stack support
+├── install-cert-manager-operator.sh    # Install cert-manager-operator
+├── install-pebble.sh                   # Install Pebble ACME server
+├── create-issuer.sh                    # Create ClusterIssuer
+├── create-test-certificates.sh         # Create test certificates
+└── yaml/                               # YAML manifests organized by purpose
+    ├── README.md                       # YAML documentation
+    ├── cert-manager-operator/
+    │   ├── operatorgroup.yaml          # OperatorGroup definition
+    │   └── subscription.yaml           # Subscription definition
+    ├── pebble/
+    │   ├── namespace.yaml              # Pebble namespace
+    │   ├── configmap.yaml              # Pebble configuration
+    │   ├── deployment.yaml             # Pebble deployment
+    │   ├── service.yaml                # Pebble service
+    │   └── route.yaml                  # Pebble route (external access)
+    ├── issuers/
+    │   └── pebble-clusterissuer.yaml   # ClusterIssuer for Pebble
+    └── certificates/
+        └── test-certificate.yaml       # Test certificate template
 ```
 
 ## Scripts
 
-### Installation
+### Utility Scripts
+
+#### `check-cluster-network.sh`
+
+Checks your OpenShift cluster's network configuration to determine IPv4, IPv6, or dual-stack support.
+
+**Usage:**
+```bash
+# Using the script directly
+./check-cluster-network.sh
+
+# Or using Make
+make check-network
+
+# Export as JSON for scripting
+EXPORT_FORMAT=json ./check-cluster-network.sh
+```
+
+**What it checks:**
+- OpenShift version
+- Network plugin type (OVN-Kubernetes, OpenShift SDN)
+- Cluster network CIDRs (IPv4/IPv6)
+- Service network CIDRs
+- API server addresses
+- Node IP addresses
+- Network stack type (IPv4 only, IPv6 only, or dual-stack)
+
+**Why this matters:**
+- Understand what network testing scenarios are possible on your cluster
+- Verify IPv6 or dual-stack support before testing
+- Ensure your cluster configuration matches your testing requirements
+- cert-manager and Pebble work with all network stacks, but knowing yours helps with troubleshooting
+
+**Output example:**
+```
+Network Stack: DUAL-STACK (IPv4 + IPv6)
+  ✓ IPv4 support: Enabled
+  ✓ IPv6 support: Enabled
+  ✓ Dual-stack: Enabled
+```
+
+**See also:** [NETWORK-SUPPORT.md](./NETWORK-SUPPORT.md) for detailed information about IPv4, IPv6, and dual-stack testing
+
+---
+
+### Installation Scripts
 
 #### `install-cert-manager-operator.sh`
 
@@ -63,7 +168,131 @@ make install-cert-manager-operator
 
 **Reference:** [Red Hat OpenShift cert-manager Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift)
 
+---
+
+#### `install-pebble.sh`
+
+Installs Pebble, a local ACME test server, for testing cert-manager without hitting real Let's Encrypt servers.
+
+**Usage:**
+```bash
+# Using the script directly
+./install-pebble.sh
+
+# Or using Make
+make install-pebble
+
+# With custom configuration
+PEBBLE_NAMESPACE=acme-test PEBBLE_ALWAYS_VALID=1 ./install-pebble.sh
+```
+
+**Configuration Options:**
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PEBBLE_NAMESPACE` | `pebble` | Namespace for Pebble deployment |
+| `DNS_SERVER` | `8.8.8.8:53` | DNS server Pebble uses for validation |
+| `PEBBLE_ALWAYS_VALID` | `0` | Set to `1` to auto-validate all challenges |
+
+**What it does:**
+- Checks prerequisites
+- Creates the Pebble namespace
+- Deploys Pebble ACME server
+- Creates a service for cluster-internal access
+- Creates a route for external access (if needed)
+- Waits for Pebble to be ready
+- Displays ACME directory URL and next steps
+- **Idempotent**: Safe to run multiple times
+
+**When to use `PEBBLE_ALWAYS_VALID=1`:**
+- Initial testing of cert-manager installation
+- Testing certificate workflows without DNS/HTTP setup
+- Quick validation of cert-manager configuration
+
+**When to use `PEBBLE_ALWAYS_VALID=0`:**
+- Testing real DNS-01 challenges
+- Testing HTTP-01 challenges
+- Validating your complete ACME setup
+
+**Reference:** [Pebble GitHub Repository](https://github.com/letsencrypt/pebble)
+
+**See also:** [PEBBLE-USAGE.md](./PEBBLE-USAGE.md) for detailed usage guide, troubleshooting, and examples
+
+---
+
+#### `create-issuer.sh`
+
+Creates a cert-manager ClusterIssuer configured to use Pebble as the ACME server.
+
+**Usage:**
+```bash
+# Using the script directly
+./create-issuer.sh
+
+# Or using Make
+make create-issuer
+
+# With custom configuration
+ISSUER_NAME=my-issuer ACME_EMAIL=admin@example.com ./create-issuer.sh
+```
+
+**Configuration Options:**
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ISSUER_NAME` | `pebble-issuer` | Name for the ClusterIssuer |
+| `ACME_SERVER_URL` | `https://pebble.pebble.svc.cluster.local:14000/dir` | ACME server URL |
+| `ACME_EMAIL` | `test@example.com` | Email for ACME account registration |
+| `INGRESS_CLASS` | `openshift-default` | Ingress class for HTTP-01 challenges |
+
+**What it does:**
+- Checks that cert-manager and Pebble are installed
+- Creates a ClusterIssuer resource pointing to Pebble
+- Configures HTTP-01 challenge solver
+- Waits for issuer to be ready
+- **Idempotent**: Safe to run multiple times
+
+**Prerequisites:**
+- cert-manager-operator must be installed
+- Pebble should be installed (optional but recommended)
+
+---
+
+#### `create-test-certificates.sh`
+
+Creates multiple test certificates to verify cert-manager functionality.
+
+**Usage:**
+```bash
+# Using the script directly
+./create-test-certificates.sh
+
+# Or using Make
+make create-certs
+
+# With custom configuration
+ISSUER_NAME=my-issuer CERT_NAMESPACE=test ./create-test-certificates.sh
+```
+
+**Configuration Options:**
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ISSUER_NAME` | `pebble-issuer` | ClusterIssuer to use |
+| `CERT_NAMESPACE` | `default` | Namespace for certificates |
+
+**What it does:**
+- Checks that cert-manager and ClusterIssuer exist
+- Creates three test certificates:
+  - `test-cert-simple` - Basic test certificate
+  - `test-cert-app` - Application certificate
+  - `test-cert-api` - API certificate
+- Waits for certificates to be issued
+- Displays status of all cert-manager resources
+- **Idempotent**: Safe to run multiple times
+
+**Note**: Certificates will only be issued if challenges can be validated. For quick testing, use `PEBBLE_ALWAYS_VALID=1` when installing Pebble.
+
 ## Getting Started
+
+### Quick Start - Install Everything
 
 1. Clone this repository:
    ```bash
@@ -76,20 +305,61 @@ make install-cert-manager-operator
    oc login <cluster-url>
    ```
 
-3. Install cert-manager-operator:
+3. **(Recommended)** Check your cluster's network configuration:
+   ```bash
+   make check-network
+   ```
+   
+   This will show you if your cluster supports IPv4, IPv6, or dual-stack networking, which helps you understand what testing scenarios are possible.
+
+4. **Complete setup with one command:**
+   ```bash
+   make test-all
+   ```
+   
+   This will:
+   - Install cert-manager-operator
+   - Install Pebble with auto-validation enabled
+   - Create a ClusterIssuer pointing to Pebble
+   - Create test certificates
+   
+   **OR** install components step-by-step:
+   ```bash
+   make install-all        # Install cert-manager + Pebble
+   make create-issuer      # Create ClusterIssuer
+   make create-certs       # Create test certificates
+   ```
+
+5. Verify everything is working:
+   ```bash
+   # Check installations
+   oc get pods -n cert-manager-operator
+   oc get pods -n cert-manager
+   oc get pods -n pebble
+   
+   # Check cert-manager resources
+   oc get clusterissuer
+   oc get certificate -A
+   oc get certificaterequest,order,challenge -A
+   ```
+
+### Step-by-Step Installation
+
+If you prefer to install components individually:
+
+1. **Install cert-manager-operator:**
    ```bash
    make install-cert-manager-operator
    ```
-   
-   Or run the script directly:
-   ```bash
-   ./install-cert-manager-operator.sh
-   ```
 
-4. Verify the installation:
+2. **Install Pebble (optional, for local testing):**
    ```bash
-   oc get pods -n cert-manager-operator
-   oc get pods -n cert-manager
+   make install-pebble
+   ```
+   
+   Or with auto-validation enabled:
+   ```bash
+   PEBBLE_ALWAYS_VALID=1 make install-pebble
    ```
 
 ## Makefile Targets
@@ -100,19 +370,59 @@ Run `make help` to see all available targets:
 make help
 ```
 
-Available targets:
+### Quick Testing
+- `make quick-test` - Complete end-to-end DNS-01 test (setup + test + verify)
+- `make test-cert` - Create a test wildcard certificate
+- `make verify-cert` - Check certificate status
+
+### Available targets:
+- `make check-network` - Check cluster network configuration (IPv4/IPv6/dual-stack)
 - `make install-cert-manager-operator` - Install cert-manager Operator
+- `make install-pebble` - Install Pebble ACME test server
+- `make install-all` - Install both cert-manager-operator and Pebble
+- `make create-issuer` - Create ClusterIssuer pointing to Pebble
+- `make create-certs` - Create test certificates
+- `make test-all` - **Complete setup: install + configure + test**
 - `make uninstall-cert-manager-operator` - Uninstall cert-manager Operator (coming soon)
 - `make clean` - Clean up temporary files
 - `make help` - Show help message
 
 ## Next Steps
 
-After installing cert-manager-operator, you can:
-- Configure issuers (ACME, CA, self-signed)
-- Create certificate resources
-- Secure routes with cert-manager
-- Set up DNS-01 challenges for wildcard certificates
+After installing cert-manager-operator and Pebble, you can:
+
+1. **Configure a cert-manager ClusterIssuer pointing to Pebble:**
+   ```yaml
+   apiVersion: cert-manager.io/v1
+   kind: ClusterIssuer
+   metadata:
+     name: pebble-issuer
+   spec:
+     acme:
+       server: https://pebble.pebble.svc.cluster.local:14000/dir
+       skipTLSVerify: true  # Pebble uses self-signed certs
+       privateKeySecretRef:
+         name: pebble-private-key
+       solvers:
+       - http01:
+           ingress:
+             class: nginx
+   ```
+
+2. **Test certificate issuance:**
+   - Create test certificates for applications
+   - Test wildcard certificates with DNS-01 challenges
+   - Verify HTTP-01 challenge handling
+
+3. **Test production-like scenarios:**
+   - Test apiServer certificate replacement
+   - Test ingress certificate management
+   - Test certificate renewal workflows
+
+4. **Advanced testing:**
+   - Configure DNS-01 challenges with custom DNS servers
+   - Test IPv4, IPv6, and dual-stack configurations
+   - Set up monitoring and alerting for certificate expiry
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,123 @@
 # cert-manager-scripts
+
+A collection of scripts for testing and managing cert-manager-operator on OpenShift clusters.
+
+## Overview
+
+This repository contains bash and Python scripts for:
+- Installing and configuring cert-manager-operator
+- Testing certificate issuance scenarios (wildcard, apiServer, application certs)
+- Verifying DNS-01 and HTTP-01 challenges
+- Testing IPv4, IPv6, and dual-stack configurations
+- Setting up local ACME testing environments
+
+## Prerequisites
+
+- OpenShift cluster (4.20+ recommended)
+- `oc` CLI installed and configured
+- `envsubst` command (part of gettext package)
+  - macOS: `brew install gettext`
+  - RHEL/Fedora: `dnf install gettext`
+- Cluster-admin privileges
+- Bash shell (for shell scripts)
+
+## Repository Structure
+
+```
+cert-manager-scripts/
+├── Makefile                           # Make targets for common tasks
+├── README.md                          # This file
+├── install-cert-manager-operator.sh   # Installation script
+└── yaml/                              # YAML manifests organized by purpose
+    └── cert-manager-operator/
+        ├── operatorgroup.yaml         # OperatorGroup definition
+        └── subscription.yaml          # Subscription definition
+```
+
+## Scripts
+
+### Installation
+
+#### `install-cert-manager-operator.sh`
+
+Installs the cert-manager Operator for Red Hat OpenShift following the official documentation.
+
+**Usage:**
+```bash
+# Using the script directly
+./install-cert-manager-operator.sh
+
+# Or using Make
+make install-cert-manager-operator
+```
+
+**What it does:**
+- Checks prerequisites (oc CLI, envsubst, cluster login, admin privileges)
+- Creates the `cert-manager-operator` namespace
+- Applies OperatorGroup and Subscription resources from YAML templates
+- Uses `envsubst` for variable substitution in YAML files
+- Waits for operator to be ready
+- Verifies the installation
+- Displays next steps
+- **Idempotent**: Safe to run multiple times
+
+**Reference:** [Red Hat OpenShift cert-manager Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift)
+
+## Getting Started
+
+1. Clone this repository:
+   ```bash
+   git clone <repo-url>
+   cd cert-manager-scripts
+   ```
+
+2. Log in to your OpenShift cluster:
+   ```bash
+   oc login <cluster-url>
+   ```
+
+3. Install cert-manager-operator:
+   ```bash
+   make install-cert-manager-operator
+   ```
+   
+   Or run the script directly:
+   ```bash
+   ./install-cert-manager-operator.sh
+   ```
+
+4. Verify the installation:
+   ```bash
+   oc get pods -n cert-manager-operator
+   oc get pods -n cert-manager
+   ```
+
+## Makefile Targets
+
+Run `make help` to see all available targets:
+
+```bash
+make help
+```
+
+Available targets:
+- `make install-cert-manager-operator` - Install cert-manager Operator
+- `make uninstall-cert-manager-operator` - Uninstall cert-manager Operator (coming soon)
+- `make clean` - Clean up temporary files
+- `make help` - Show help message
+
+## Next Steps
+
+After installing cert-manager-operator, you can:
+- Configure issuers (ACME, CA, self-signed)
+- Create certificate resources
+- Secure routes with cert-manager
+- Set up DNS-01 challenges for wildcard certificates
+
+## Contributing
+
+This is a collection of testing and utility scripts. Feel free to add new scripts or improve existing ones.
+
+## License
+
+Apache 2.0

--- a/check-cluster-network.sh
+++ b/check-cluster-network.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+
+################################################################################
+# Script: check-cluster-network.sh
+# Description: Check OpenShift cluster network configuration (IPv4/IPv6/Dual-stack)
+################################################################################
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Function to print colored messages
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_detail() {
+    echo -e "${CYAN}[DETAIL]${NC} $1"
+}
+
+# Function to print header
+print_header() {
+    echo
+    echo "========================================"
+    echo "  OpenShift Network Configuration Check"
+    echo "========================================"
+    echo
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    if ! command -v oc &> /dev/null; then
+        log_error "oc command not found. Please install OpenShift CLI."
+        exit 1
+    fi
+    
+    if ! oc whoami &> /dev/null; then
+        log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
+        exit 1
+    fi
+}
+
+# Function to get cluster version
+get_cluster_version() {
+    log_info "Checking OpenShift version..."
+    local version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null || echo "Unknown")
+    echo "  OpenShift Version: $version"
+    echo
+}
+
+# Function to check network type
+check_network_type() {
+    log_info "Checking network plugin type..."
+    
+    local network_type=$(oc get network.config.openshift.io cluster -o jsonpath='{.spec.networkType}' 2>/dev/null || echo "Unknown")
+    echo "  Network Type: $network_type"
+    
+    case "$network_type" in
+        "OVNKubernetes")
+            log_detail "OVN-Kubernetes detected - Full IPv6 and dual-stack support available"
+            ;;
+        "OpenShiftSDN")
+            log_warn "OpenShift SDN detected - Limited IPv6 support (deprecated in 4.15+)"
+            ;;
+        *)
+            log_warn "Unknown network type: $network_type"
+            ;;
+    esac
+    echo
+}
+
+# Function to check IP families
+check_ip_families() {
+    log_info "Checking cluster IP address families..."
+    
+    # Get cluster networks from network config
+    local cluster_networks=$(oc get network.config.openshift.io cluster -o json 2>/dev/null)
+    
+    if [ -z "$cluster_networks" ]; then
+        log_error "Unable to retrieve network configuration"
+        return 1
+    fi
+    
+    # Check cluster network CIDRs
+    local cluster_cidrs=$(echo "$cluster_networks" | jq -r '.spec.clusterNetwork[]?.cidr' 2>/dev/null | tr '\n' ' ')
+    local service_cidrs=$(echo "$cluster_networks" | jq -r '.spec.serviceNetwork[]?' 2>/dev/null | tr '\n' ' ')
+    
+    echo "  Cluster Networks:"
+    local has_ipv4=false
+    local has_ipv6=false
+    
+    for cidr in $cluster_cidrs; do
+        echo "    - $cidr"
+        if [[ "$cidr" =~ : ]]; then
+            has_ipv6=true
+        else
+            has_ipv4=true
+        fi
+    done
+    
+    echo
+    echo "  Service Networks:"
+    for cidr in $service_cidrs; do
+        echo "    - $cidr"
+        if [[ "$cidr" =~ : ]]; then
+            has_ipv6=true
+        else
+            has_ipv4=true
+        fi
+    done
+    echo
+    
+    # Determine network stack
+    if [ "$has_ipv4" = true ] && [ "$has_ipv6" = true ]; then
+        log_info "Network Stack: ${GREEN}DUAL-STACK${NC} (IPv4 + IPv6)"
+        echo "  ✓ IPv4 support: Enabled"
+        echo "  ✓ IPv6 support: Enabled"
+        echo "  ✓ Dual-stack: Enabled"
+    elif [ "$has_ipv6" = true ]; then
+        log_info "Network Stack: ${BLUE}IPv6 ONLY${NC}"
+        echo "  ✗ IPv4 support: Disabled"
+        echo "  ✓ IPv6 support: Enabled"
+        echo "  ✗ Dual-stack: Not applicable (IPv6 only)"
+    elif [ "$has_ipv4" = true ]; then
+        log_info "Network Stack: ${CYAN}IPv4 ONLY${NC}"
+        echo "  ✓ IPv4 support: Enabled"
+        echo "  ✗ IPv6 support: Disabled"
+        echo "  ✗ Dual-stack: Not applicable (IPv4 only)"
+    else
+        log_error "Unable to determine network stack"
+    fi
+    echo
+}
+
+# Function to check API server addresses
+check_api_server() {
+    log_info "Checking API Server configuration..."
+    
+    local api_url=$(oc whoami --show-server 2>/dev/null)
+    echo "  API Server URL: $api_url"
+    
+    # Extract hostname from URL
+    local api_host=$(echo "$api_url" | sed -E 's|https?://([^:/]+).*|\1|')
+    
+    if [ -n "$api_host" ]; then
+        echo "  API Server Host: $api_host"
+        
+        # Try to resolve the hostname
+        if command -v dig &> /dev/null; then
+            echo
+            echo "  DNS Resolution:"
+            
+            # Check for A record (IPv4)
+            local ipv4_records=$(dig +short A "$api_host" 2>/dev/null | grep -v "^$" | head -3)
+            if [ -n "$ipv4_records" ]; then
+                echo "    IPv4 (A records):"
+                echo "$ipv4_records" | while read -r ip; do
+                    echo "      - $ip"
+                done
+            fi
+            
+            # Check for AAAA record (IPv6)
+            local ipv6_records=$(dig +short AAAA "$api_host" 2>/dev/null | grep -v "^$" | head -3)
+            if [ -n "$ipv6_records" ]; then
+                echo "    IPv6 (AAAA records):"
+                echo "$ipv6_records" | while read -r ip; do
+                    echo "      - $ip"
+                done
+            fi
+            
+            if [ -z "$ipv4_records" ] && [ -z "$ipv6_records" ]; then
+                log_warn "No DNS records found for $api_host"
+            fi
+        else
+            log_detail "dig command not available - skipping DNS resolution check"
+        fi
+    fi
+    echo
+}
+
+# Function to check node addresses
+check_node_addresses() {
+    log_info "Checking node IP addresses (first 3 nodes)..."
+    
+    local nodes=$(oc get nodes -o json 2>/dev/null)
+    
+    if [ -z "$nodes" ]; then
+        log_error "Unable to retrieve node information"
+        return 1
+    fi
+    
+    local node_count=$(echo "$nodes" | jq -r '.items | length')
+    local display_count=$((node_count < 3 ? node_count : 3))
+    
+    for i in $(seq 0 $((display_count - 1))); do
+        local node_name=$(echo "$nodes" | jq -r ".items[$i].metadata.name")
+        local internal_ips=$(echo "$nodes" | jq -r ".items[$i].status.addresses[] | select(.type==\"InternalIP\") | .address" | tr '\n' ' ')
+        
+        echo "  Node: $node_name"
+        for ip in $internal_ips; do
+            if [[ "$ip" =~ : ]]; then
+                echo "    - $ip (IPv6)"
+            else
+                echo "    - $ip (IPv4)"
+            fi
+        done
+    done
+    
+    if [ "$node_count" -gt 3 ]; then
+        echo "  ... and $((node_count - 3)) more nodes"
+    fi
+    echo
+}
+
+# Function to check for common cert-manager services
+check_cert_manager_compatibility() {
+    log_info "Checking cert-manager compatibility..."
+    
+    # Check if cert-manager is installed
+    if oc get namespace cert-manager &> /dev/null; then
+        log_detail "cert-manager namespace found"
+        
+        # Check cert-manager pods
+        local cm_pods=$(oc get pods -n cert-manager -l app.kubernetes.io/instance=cert-manager --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        if [ "$cm_pods" -gt 0 ]; then
+            echo "  cert-manager components: $cm_pods pods running"
+        fi
+    else
+        log_detail "cert-manager not yet installed"
+    fi
+    
+    echo
+    log_info "Compatibility notes:"
+    echo "  ✓ cert-manager supports IPv4, IPv6, and dual-stack clusters"
+    echo "  ✓ ACME challenges (HTTP-01, DNS-01) work with all network stacks"
+    echo "  ✓ Pebble ACME server supports IPv4 and IPv6"
+    echo
+}
+
+# Function to provide recommendations
+provide_recommendations() {
+    log_info "========================================"
+    log_info "  Recommendations"
+    log_info "========================================"
+    echo
+    
+    local cluster_networks=$(oc get network.config.openshift.io cluster -o json 2>/dev/null)
+    local has_ipv4=false
+    local has_ipv6=false
+    
+    local cluster_cidrs=$(echo "$cluster_networks" | jq -r '.spec.clusterNetwork[]?.cidr' 2>/dev/null)
+    for cidr in $cluster_cidrs; do
+        if [[ "$cidr" =~ : ]]; then
+            has_ipv6=true
+        else
+            has_ipv4=true
+        fi
+    done
+    
+    if [ "$has_ipv4" = true ] && [ "$has_ipv6" = true ]; then
+        echo "Your cluster supports DUAL-STACK networking:"
+        echo "  • You can test both IPv4 and IPv6 scenarios"
+        echo "  • Services can be created with either or both IP families"
+        echo "  • Consider testing cert-manager with both protocols"
+        echo "  • Pebble will be accessible via both IPv4 and IPv6"
+    elif [ "$has_ipv6" = true ]; then
+        echo "Your cluster is IPv6 ONLY:"
+        echo "  • All services will use IPv6 addresses"
+        echo "  • Ensure DNS records (AAAA) are configured for IPv6"
+        echo "  • External services must support IPv6"
+        echo "  • cert-manager will work with IPv6 ACME servers"
+    else
+        echo "Your cluster is IPv4 ONLY:"
+        echo "  • This is the most common configuration"
+        echo "  • All standard cert-manager features are supported"
+        echo "  • Pebble will work normally with IPv4"
+        echo "  • DNS records (A) should be configured for IPv4"
+    fi
+    echo
+    
+    echo "Next steps:"
+    echo "  1. Install cert-manager: make install-cert-manager-operator"
+    echo "  2. Install Pebble: make install-pebble"
+    echo "  3. Test certificate issuance on your network stack"
+    echo
+}
+
+# Function to export network info (for scripting)
+export_network_info() {
+    if [ "${EXPORT_FORMAT:-}" = "json" ]; then
+        local cluster_networks=$(oc get network.config.openshift.io cluster -o json 2>/dev/null)
+        echo "$cluster_networks" | jq '{
+            clusterNetwork: .spec.clusterNetwork,
+            serviceNetwork: .spec.serviceNetwork,
+            networkType: .spec.networkType
+        }'
+    fi
+}
+
+# Main execution
+main() {
+    print_header
+    check_prerequisites
+    get_cluster_version
+    check_network_type
+    check_ip_families
+    check_api_server
+    check_node_addresses
+    check_cert_manager_compatibility
+    provide_recommendations
+    
+    # Export if requested
+    if [ "${EXPORT_FORMAT:-}" = "json" ]; then
+        echo
+        log_info "Network configuration (JSON):"
+        export_network_info
+    fi
+}
+
+# Run main function
+main
+

--- a/create-dns01-issuer.sh
+++ b/create-dns01-issuer.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+################################################################################
+# Script: create-dns01-issuer.sh
+# Description: Create DNS-01 ClusterIssuer for Pebble (with ALWAYS_VALID)
+################################################################################
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_DIR="${SCRIPT_DIR}/yaml/issuers"
+
+# Configuration
+export ISSUER_NAME="${ISSUER_NAME:-pebble-dns01-issuer}"
+export ACME_SERVER_URL="${ACME_SERVER_URL:-https://pebble.pebble.svc.cluster.local:14000/dir}"
+export ACME_EMAIL="${ACME_EMAIL:-test@example.com}"
+export DNS_SERVER="${DNS_SERVER:-8.8.8.8:53}"
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+echo
+echo "========================================"
+echo "  Create DNS-01 ClusterIssuer"
+echo "========================================"
+echo
+
+# Check prerequisites
+if ! oc whoami &> /dev/null; then
+    log_error "Not logged into OpenShift"
+    exit 1
+fi
+
+# Create dummy secret for RFC2136 (not actually used with ALWAYS_VALID)
+# Secret must be in cert-manager namespace for ClusterIssuer
+# Value must be valid base64
+log_info "Creating dummy RFC2136 secret in cert-manager namespace..."
+oc create secret generic rfc2136-credentials \
+    --from-literal=tsig-secret=$(echo -n "dummy-secret-key" | base64) \
+    --namespace cert-manager \
+    --dry-run=client -o yaml | oc apply -f -
+
+# Create ClusterIssuer
+log_info "Creating DNS-01 ClusterIssuer..."
+envsubst < "$YAML_DIR/pebble-dns01-simple-clusterissuer.yaml" | oc apply -f -
+
+log_info "Waiting for ClusterIssuer to be ready..."
+sleep 5
+
+if oc get clusterissuer "$ISSUER_NAME" &> /dev/null; then
+    oc get clusterissuer "$ISSUER_NAME"
+    echo
+    log_info "DNS-01 ClusterIssuer created!"
+    echo
+    echo "Next steps:"
+    echo "1. Create a wildcard certificate:"
+    echo "   oc apply -f - <<EOF"
+    echo "   apiVersion: cert-manager.io/v1"
+    echo "   kind: Certificate"
+    echo "   metadata:"
+    echo "     name: wildcard-test"
+    echo "     namespace: default"
+    echo "   spec:"
+    echo "     secretName: wildcard-test-tls"
+    echo "     issuerRef:"
+    echo "       name: pebble-dns01-issuer"
+    echo "       kind: ClusterIssuer"
+    echo "     dnsNames:"
+    echo "     - '*.example.com'"
+    echo "     - 'example.com'"
+    echo "   EOF"
+    echo
+    echo "2. Monitor certificate status:"
+    echo "   oc get certificate -n default -w"
+fi
+

--- a/create-issuer.sh
+++ b/create-issuer.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+
+################################################################################
+# Script: create-issuer.sh
+# Description: Create a cert-manager ClusterIssuer pointing to Pebble ACME server
+################################################################################
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_DIR="${SCRIPT_DIR}/yaml/issuers"
+
+# Configuration (exported for envsubst)
+export ISSUER_NAME="${ISSUER_NAME:-pebble-issuer}"
+export ACME_SERVER_URL="${ACME_SERVER_URL:-https://pebble.pebble.svc.cluster.local:14000/dir}"
+export ACME_EMAIL="${ACME_EMAIL:-test@example.com}"
+export INGRESS_CLASS="${INGRESS_CLASS:-openshift-default}"
+
+# Function to print colored messages
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_detail() {
+    echo -e "${BLUE}[DETAIL]${NC} $1"
+}
+
+# Function to print header
+print_header() {
+    echo
+    echo "========================================"
+    echo "  Create cert-manager ClusterIssuer"
+    echo "========================================"
+    echo
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    if ! command -v oc &> /dev/null; then
+        log_error "oc command not found. Please install OpenShift CLI."
+        exit 1
+    fi
+    
+    if ! command -v envsubst &> /dev/null; then
+        log_error "envsubst command not found. Please install gettext package."
+        exit 1
+    fi
+    
+    if ! oc whoami &> /dev/null; then
+        log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
+        exit 1
+    fi
+    
+    # Check if cert-manager is installed
+    if ! oc get deployment -n cert-manager cert-manager &> /dev/null; then
+        log_error "cert-manager not found. Please install cert-manager-operator first."
+        log_info "  Run: make install-cert-manager-operator"
+        exit 1
+    fi
+    
+    # Check if YAML directory exists
+    if [ ! -d "$YAML_DIR" ]; then
+        log_error "YAML directory not found: $YAML_DIR"
+        exit 1
+    fi
+    
+    log_info "Prerequisites check passed."
+}
+
+# Function to check if Pebble is available (optional but recommended)
+check_pebble() {
+    log_info "Checking if Pebble is available..."
+    
+    if ! oc get deployment -n pebble pebble &> /dev/null; then
+        log_warn "Pebble ACME server not found."
+        log_info "This issuer will point to: $ACME_SERVER_URL"
+        log_warn "If using Pebble, install it first: make install-pebble"
+        echo
+        read -p "Continue anyway? (y/N): " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            log_info "Cancelled."
+            exit 0
+        fi
+    else
+        log_info "Pebble ACME server is available."
+        
+        # Check if Pebble is ready
+        local ready_replicas=$(oc get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+        if [ "$ready_replicas" = "0" ]; then
+            log_warn "Pebble deployment exists but no replicas are ready."
+        else
+            log_info "Pebble is ready with $ready_replicas replica(s)."
+        fi
+    fi
+}
+
+# Function to check if issuer already exists
+check_existing_issuer() {
+    log_info "Checking for existing ClusterIssuer '$ISSUER_NAME'..."
+    
+    if oc get clusterissuer "$ISSUER_NAME" &> /dev/null; then
+        log_warn "ClusterIssuer '$ISSUER_NAME' already exists."
+        
+        # Show current configuration
+        local current_server=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.server}' 2>/dev/null || echo "unknown")
+        log_detail "Current ACME server: $current_server"
+        
+        echo
+        read -p "Overwrite existing issuer? (y/N): " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            log_info "Keeping existing issuer."
+            exit 0
+        fi
+    fi
+}
+
+# Function to display configuration
+display_configuration() {
+    log_info "========================================"
+    log_info "  ClusterIssuer Configuration"
+    log_info "========================================"
+    echo
+    echo "Issuer Name:      $ISSUER_NAME"
+    echo "ACME Server:      $ACME_SERVER_URL"
+    echo "Email:            $ACME_EMAIL"
+    echo "Ingress Class:    $INGRESS_CLASS"
+    echo "Skip TLS Verify:  true (for Pebble self-signed certs)"
+    echo
+}
+
+# Function to create issuer
+create_issuer() {
+    log_info "Creating ClusterIssuer '$ISSUER_NAME'..."
+    
+    envsubst < "$YAML_DIR/pebble-clusterissuer.yaml" | oc apply -f -
+    
+    if [ $? -eq 0 ]; then
+        log_info "ClusterIssuer created successfully."
+    else
+        log_error "Failed to create ClusterIssuer."
+        exit 1
+    fi
+}
+
+# Function to verify issuer
+verify_issuer() {
+    log_info "Waiting for ClusterIssuer to be ready..."
+    
+    local max_attempts=30
+    local attempt=0
+    
+    while [ $attempt -lt $max_attempts ]; do
+        local ready=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+        
+        if [ "$ready" = "True" ]; then
+            log_info "ClusterIssuer is ready!"
+            break
+        fi
+        
+        attempt=$((attempt + 1))
+        if [ $((attempt % 5)) -eq 0 ]; then
+            echo -n " [${attempt}/${max_attempts}]"
+        else
+            echo -n "."
+        fi
+        sleep 2
+    done
+    echo
+    
+    if [ $attempt -eq $max_attempts ]; then
+        log_warn "Timeout waiting for ClusterIssuer to be ready."
+        log_info "Check status with: oc describe clusterissuer $ISSUER_NAME"
+    fi
+    
+    echo
+    log_info "ClusterIssuer status:"
+    oc get clusterissuer "$ISSUER_NAME"
+}
+
+# Function to display next steps
+display_next_steps() {
+    echo
+    log_info "========================================"
+    log_info "  ClusterIssuer Created!"
+    log_info "========================================"
+    echo
+    echo "Next steps:"
+    echo
+    echo "1. View ClusterIssuer details:"
+    echo "   oc describe clusterissuer $ISSUER_NAME"
+    echo
+    echo "2. Create test certificates:"
+    echo "   make create-certs"
+    echo
+    echo "3. Or create a certificate manually:"
+    echo "   cat <<EOF | oc apply -f -"
+    echo "   apiVersion: cert-manager.io/v1"
+    echo "   kind: Certificate"
+    echo "   metadata:"
+    echo "     name: my-test-cert"
+    echo "     namespace: default"
+    echo "   spec:"
+    echo "     secretName: my-test-cert-tls"
+    echo "     issuerRef:"
+    echo "       name: $ISSUER_NAME"
+    echo "       kind: ClusterIssuer"
+    echo "     dnsNames:"
+    echo "     - test.example.com"
+    echo "   EOF"
+    echo
+    echo "4. Monitor certificate requests:"
+    echo "   oc get certificate -A"
+    echo "   oc get order,challenge -A"
+    echo
+}
+
+# Main execution
+main() {
+    print_header
+    check_prerequisites
+    display_configuration
+    check_pebble
+    check_existing_issuer
+    create_issuer
+    verify_issuer
+    display_next_steps
+}
+
+# Run main function
+main
+

--- a/create-test-certificates.sh
+++ b/create-test-certificates.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+
+################################################################################
+# Script: create-test-certificates.sh
+# Description: Create test certificates using cert-manager
+################################################################################
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_DIR="${SCRIPT_DIR}/yaml/certificates"
+
+# Configuration (exported for envsubst)
+export ISSUER_NAME="${ISSUER_NAME:-pebble-issuer}"
+export CERT_NAMESPACE="${CERT_NAMESPACE:-default}"
+
+# Function to print colored messages
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_detail() {
+    echo -e "${BLUE}[DETAIL]${NC} $1"
+}
+
+# Function to print header
+print_header() {
+    echo
+    echo "========================================"
+    echo "  Create Test Certificates"
+    echo "========================================"
+    echo
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    if ! command -v oc &> /dev/null; then
+        log_error "oc command not found. Please install OpenShift CLI."
+        exit 1
+    fi
+    
+    if ! command -v envsubst &> /dev/null; then
+        log_error "envsubst command not found. Please install gettext package."
+        exit 1
+    fi
+    
+    if ! oc whoami &> /dev/null; then
+        log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
+        exit 1
+    fi
+    
+    # Check if cert-manager is installed
+    if ! oc get deployment -n cert-manager cert-manager &> /dev/null; then
+        log_error "cert-manager not found. Please install cert-manager-operator first."
+        log_info "  Run: make install-cert-manager-operator"
+        exit 1
+    fi
+    
+    # Check if issuer exists
+    if ! oc get clusterissuer "$ISSUER_NAME" &> /dev/null; then
+        log_error "ClusterIssuer '$ISSUER_NAME' not found."
+        log_info "  Create an issuer first: make create-issuer"
+        exit 1
+    fi
+    
+    # Check if namespace exists
+    if ! oc get namespace "$CERT_NAMESPACE" &> /dev/null; then
+        log_warn "Namespace '$CERT_NAMESPACE' does not exist."
+        read -p "Create namespace '$CERT_NAMESPACE'? (y/N): " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            oc create namespace "$CERT_NAMESPACE"
+            log_info "Namespace '$CERT_NAMESPACE' created."
+        else
+            log_error "Cannot create certificates without target namespace."
+            exit 1
+        fi
+    fi
+    
+    log_info "Prerequisites check passed."
+}
+
+# Function to create a certificate
+create_certificate() {
+    local cert_name=$1
+    local dns_name=$2
+    local description=$3
+    
+    export CERT_NAME="$cert_name"
+    export CERT_SECRET_NAME="${cert_name}-tls"
+    export CERT_COMMON_NAME="$dns_name"
+    export CERT_DNS_NAME="$dns_name"
+    
+    log_info "Creating certificate: $cert_name ($description)..."
+    
+    # Check if certificate already exists
+    if oc get certificate "$cert_name" -n "$CERT_NAMESPACE" &> /dev/null; then
+        log_warn "Certificate '$cert_name' already exists in namespace '$CERT_NAMESPACE'."
+        return 0
+    fi
+    
+    envsubst < "$YAML_DIR/test-certificate.yaml" | oc apply -f -
+    
+    if [ $? -eq 0 ]; then
+        log_info "Certificate '$cert_name' created."
+    else
+        log_error "Failed to create certificate '$cert_name'."
+    fi
+}
+
+# Function to create multiple test certificates
+create_test_certificates() {
+    log_info "Creating test certificates in namespace '$CERT_NAMESPACE'..."
+    echo
+    
+    # Certificate 1: Simple test certificate
+    create_certificate \
+        "test-cert-simple" \
+        "test.example.com" \
+        "Simple test certificate"
+    
+    # Certificate 2: Application certificate
+    create_certificate \
+        "test-cert-app" \
+        "myapp.example.com" \
+        "Application certificate"
+    
+    # Certificate 3: API certificate
+    create_certificate \
+        "test-cert-api" \
+        "api.example.com" \
+        "API certificate"
+    
+    echo
+    log_info "All test certificates created."
+}
+
+# Function to wait for certificates
+wait_for_certificates() {
+    log_info "Waiting for certificates to be issued..."
+    echo
+    
+    local max_wait=60
+    local wait_time=0
+    
+    while [ $wait_time -lt $max_wait ]; do
+        local all_ready=true
+        
+        # Check each certificate
+        for cert in test-cert-simple test-cert-app test-cert-api; do
+            if oc get certificate "$cert" -n "$CERT_NAMESPACE" &> /dev/null; then
+                local ready=$(oc get certificate "$cert" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
+                
+                if [ "$ready" != "True" ]; then
+                    all_ready=false
+                fi
+            fi
+        done
+        
+        if [ "$all_ready" = true ]; then
+            log_info "All certificates are ready!"
+            break
+        fi
+        
+        if [ $((wait_time % 10)) -eq 0 ]; then
+            echo -n " [${wait_time}s/${max_wait}s]"
+        else
+            echo -n "."
+        fi
+        
+        sleep 2
+        wait_time=$((wait_time + 2))
+    done
+    echo
+    
+    if [ $wait_time -ge $max_wait ]; then
+        log_warn "Timeout waiting for all certificates to be ready."
+        log_info "This is normal if using PEBBLE_ALWAYS_VALID=0 without proper DNS/HTTP setup."
+        log_info "Check certificate status below for details."
+    fi
+}
+
+# Function to display certificate status
+display_certificate_status() {
+    echo
+    log_info "========================================"
+    log_info "  Certificate Status"
+    log_info "========================================"
+    echo
+    
+    log_info "Certificates:"
+    oc get certificate -n "$CERT_NAMESPACE" 2>/dev/null || echo "No certificates found"
+    
+    echo
+    log_info "Certificate Requests:"
+    oc get certificaterequest -n "$CERT_NAMESPACE" 2>/dev/null || echo "No certificate requests found"
+    
+    echo
+    log_info "ACME Orders:"
+    oc get order -n "$CERT_NAMESPACE" 2>/dev/null || echo "No orders found"
+    
+    echo
+    log_info "ACME Challenges:"
+    oc get challenge -n "$CERT_NAMESPACE" 2>/dev/null || echo "No challenges found"
+}
+
+# Function to display next steps
+display_next_steps() {
+    echo
+    log_info "========================================"
+    log_info "  Next Steps"
+    log_info "========================================"
+    echo
+    echo "1. Check certificate details:"
+    echo "   oc describe certificate test-cert-simple -n $CERT_NAMESPACE"
+    echo
+    echo "2. View certificate secret:"
+    echo "   oc get secret test-cert-simple-tls -n $CERT_NAMESPACE -o yaml"
+    echo
+    echo "3. Decode certificate:"
+    echo "   oc get secret test-cert-simple-tls -n $CERT_NAMESPACE -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout"
+    echo
+    echo "4. Monitor all cert-manager resources:"
+    echo "   watch oc get certificate -n $CERT_NAMESPACE"
+    echo
+    echo "5. Check cert-manager logs if issues occur:"
+    echo "   oc logs -n cert-manager deployment/cert-manager -f"
+    echo
+    
+    # Check if certificates failed
+    local failed_certs=$(oc get certificate -n "$CERT_NAMESPACE" -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="False")) | .metadata.name' | wc -l | tr -d ' ')
+    
+    if [ "$failed_certs" -gt 0 ]; then
+        echo
+        log_warn "Some certificates are not ready. Common reasons:"
+        echo "  - Using PEBBLE_ALWAYS_VALID=0 without proper DNS/HTTP routes"
+        echo "  - Challenge validation failing"
+        echo "  - Network connectivity issues"
+        echo
+        echo "To debug, describe failed certificates:"
+        echo "  oc describe certificate -n $CERT_NAMESPACE"
+        echo
+        echo "To use Pebble with auto-validation, reinstall with:"
+        echo "  PEBBLE_ALWAYS_VALID=1 make install-pebble"
+    fi
+}
+
+# Main execution
+main() {
+    print_header
+    check_prerequisites
+    create_test_certificates
+    wait_for_certificates
+    display_certificate_status
+    display_next_steps
+}
+
+# Run main function
+main
+

--- a/import-acmedns-image.sh
+++ b/import-acmedns-image.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+################################################################################
+# Script: import-acmedns-image.sh
+# Description: Import acme-dns image for air-gapped clusters
+################################################################################
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+echo
+echo "========================================"
+echo "  Import acme-dns Image"
+echo "========================================"
+echo
+
+ACMEDNS_IMAGE="joohoi/acme-dns:latest"
+ACMEDNS_NAMESPACE="${ACMEDNS_NAMESPACE:-acme-dns}"
+
+log_info "Checking if we can pull the image locally..."
+
+# Try to pull with podman first, then docker
+if command -v podman &> /dev/null; then
+    CONTAINER_CMD="podman"
+elif command -v docker &> /dev/null; then
+    CONTAINER_CMD="docker"
+else
+    log_error "Neither podman nor docker found. Please install one."
+    exit 1
+fi
+
+log_info "Using $CONTAINER_CMD to pull image..."
+
+if ! $CONTAINER_CMD pull $ACMEDNS_IMAGE; then
+    log_error "Failed to pull image. Check your internet connection."
+    exit 1
+fi
+
+log_info "Image pulled successfully. Saving to tar file..."
+$CONTAINER_CMD save $ACMEDNS_IMAGE -o /tmp/acme-dns.tar
+
+log_info "Importing image to CRC/OpenShift..."
+
+# For CRC, we can use crc podman-env or import to internal registry
+if command -v crc &> /dev/null && crc status | grep -q "Running"; then
+    log_info "Detected CRC. Importing to CRC's podman..."
+    eval $(crc podman-env)
+    podman load -i /tmp/acme-dns.tar
+    log_info "Image imported to CRC!"
+else
+    log_warn "Not using CRC or CRC not running."
+    log_info "Attempting to push to OpenShift internal registry..."
+    
+    # Get internal registry
+    REGISTRY=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+    
+    if [ -z "$REGISTRY" ]; then
+        log_error "Could not find OpenShift internal registry."
+        log_info "Manual steps:"
+        log_info "1. Load image: $CONTAINER_CMD load -i /tmp/acme-dns.tar"
+        log_info "2. Tag for your registry"
+        log_info "3. Push to your registry"
+        exit 1
+    fi
+    
+    # Tag and push
+    NEW_TAG="${REGISTRY}/${ACMEDNS_NAMESPACE}/acme-dns:latest"
+    log_info "Tagging image as: $NEW_TAG"
+    $CONTAINER_CMD tag $ACMEDNS_IMAGE $NEW_TAG
+    
+    log_info "Logging into internal registry..."
+    $CONTAINER_CMD login -u kubeadmin -p $(oc whoami -t) $REGISTRY
+    
+    log_info "Pushing image..."
+    $CONTAINER_CMD push $NEW_TAG
+    
+    log_info "Image pushed to internal registry!"
+    log_info "Update your deployment to use: $NEW_TAG"
+fi
+
+rm -f /tmp/acme-dns.tar
+log_info "Cleanup complete!"
+echo
+log_info "Next step: Re-run install-local-dns.sh"
+

--- a/install-cert-manager-operator.sh
+++ b/install-cert-manager-operator.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+
+################################################################################
+# Script: install-cert-manager-operator.sh
+# Description: Install cert-manager Operator for Red Hat OpenShift
+# Reference: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift
+################################################################################
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_DIR="${SCRIPT_DIR}/yaml/cert-manager-operator"
+
+# Configuration (exported for envsubst)
+export OPERATOR_NAMESPACE="cert-manager-operator"
+export CERT_MANAGER_NAMESPACE="cert-manager"
+export OPERATOR_NAME="openshift-cert-manager-operator"
+export CHANNEL="stable-v1"
+
+# Function to print colored messages
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to check if oc is installed and user is logged in
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    if ! command -v oc &> /dev/null; then
+        log_error "oc command not found. Please install OpenShift CLI."
+        exit 1
+    fi
+    
+    if ! command -v envsubst &> /dev/null; then
+        log_error "envsubst command not found. Please install gettext package."
+        log_info "  macOS: brew install gettext"
+        log_info "  RHEL/Fedora: dnf install gettext"
+        exit 1
+    fi
+    
+    if ! oc whoami &> /dev/null; then
+        log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
+        exit 1
+    fi
+    
+    # Check if user has cluster-admin privileges
+    if ! oc auth can-i '*' '*' --all-namespaces &> /dev/null; then
+        log_error "Cluster-admin privileges required. Please ensure you have the necessary permissions."
+        exit 1
+    fi
+    
+    # Check if YAML directory exists
+    if [ ! -d "$YAML_DIR" ]; then
+        log_error "YAML directory not found: $YAML_DIR"
+        exit 1
+    fi
+    
+    log_info "Prerequisites check passed."
+}
+
+# Function to create namespace if it doesn't exist
+create_namespace() {
+    local namespace=$1
+    
+    if oc get namespace "$namespace" &> /dev/null; then
+        log_info "Namespace '$namespace' already exists."
+    else
+        log_info "Creating namespace '$namespace'..."
+        oc create namespace "$namespace"
+        log_info "Namespace '$namespace' created successfully."
+    fi
+}
+
+# Function to check if operator is already installed
+check_existing_installation() {
+    log_info "Checking for existing cert-manager-operator installation..."
+    
+    if oc get subscription "$OPERATOR_NAME" -n "$OPERATOR_NAMESPACE" &> /dev/null; then
+        log_info "cert-manager-operator subscription already exists."
+        
+        # Get current version/channel
+        local current_channel=$(oc get subscription "$OPERATOR_NAME" -n "$OPERATOR_NAMESPACE" -o jsonpath='{.spec.channel}')
+        log_info "Current channel: $current_channel"
+        
+        # Check if it's healthy
+        if oc get csv -n "$OPERATOR_NAMESPACE" | grep -q "cert-manager.*Succeeded"; then
+            log_info "Operator is already installed and healthy."
+            log_info "Installation is idempotent - will verify and ensure components are ready."
+            return 0
+        else
+            log_warn "Operator exists but may not be healthy. Will attempt to reconcile."
+            return 0
+        fi
+    fi
+    
+    log_info "No existing installation found. Will proceed with fresh installation."
+}
+
+# Function to apply YAML with variable substitution
+apply_yaml() {
+    local yaml_file=$1
+    local resource_type=$2
+    
+    if [ ! -f "$yaml_file" ]; then
+        log_error "YAML file not found: $yaml_file"
+        exit 1
+    fi
+    
+    log_info "Applying $resource_type from $(basename "$yaml_file")..."
+    envsubst < "$yaml_file" | oc apply -f -
+}
+
+# Function to install the operator
+install_operator() {
+    log_info "Installing cert-manager Operator for Red Hat OpenShift..."
+    
+    # Create OperatorGroup
+    apply_yaml "$YAML_DIR/operatorgroup.yaml" "OperatorGroup"
+    
+    # Create Subscription
+    apply_yaml "$YAML_DIR/subscription.yaml" "Subscription"
+    
+    log_info "Resources applied. Waiting for operator installation to complete..."
+}
+
+# Function to wait for operator to be ready
+wait_for_operator() {
+    log_info "Waiting for cert-manager-operator to be ready..."
+    
+    local max_attempts=60
+    local attempt=0
+    
+    while [ $attempt -lt $max_attempts ]; do
+        # Check if CSV is present and successful
+        if oc get csv -n "$OPERATOR_NAMESPACE" 2>/dev/null | grep -q "cert-manager.*Succeeded"; then
+            log_info "Operator CSV is in Succeeded phase."
+            break
+        fi
+        
+        attempt=$((attempt + 1))
+        if [ $((attempt % 6)) -eq 0 ]; then
+            echo -n " [${attempt}/${max_attempts}]"
+        else
+            echo -n "."
+        fi
+        sleep 5
+    done
+    echo
+    
+    if [ $attempt -eq $max_attempts ]; then
+        log_error "Timeout waiting for operator CSV to be ready."
+        log_info "Check the status with: oc get csv -n $OPERATOR_NAMESPACE"
+        log_info "Check operator logs with: oc logs -n $OPERATOR_NAMESPACE deployment/cert-manager-operator-controller-manager"
+        exit 1
+    fi
+    
+    # Wait for operator deployment to be ready
+    log_info "Waiting for operator deployment to be ready..."
+    if oc get deployment cert-manager-operator-controller-manager -n "$OPERATOR_NAMESPACE" &> /dev/null; then
+        oc wait --for=condition=available --timeout=300s \
+            deployment/cert-manager-operator-controller-manager \
+            -n "$OPERATOR_NAMESPACE" || {
+            log_error "Operator deployment failed to become ready."
+            exit 1
+        }
+    else
+        log_warn "Operator deployment not found yet, but CSV is ready."
+    fi
+    
+    log_info "Operator is ready!"
+}
+
+# Function to verify installation
+verify_installation() {
+    log_info "Verifying installation..."
+    
+    # Check operator pod
+    log_info "Checking operator pod status..."
+    oc get pods -n "$OPERATOR_NAMESPACE"
+    
+    # Check CSV
+    log_info "Checking ClusterServiceVersion..."
+    oc get csv -n "$OPERATOR_NAMESPACE"
+    
+    # Check if cert-manager namespace exists (created by operator)
+    if oc get namespace "$CERT_MANAGER_NAMESPACE" &> /dev/null; then
+        log_info "cert-manager namespace exists."
+        
+        # Check cert-manager deployments
+        log_info "Checking cert-manager components..."
+        oc get deployments -n "$CERT_MANAGER_NAMESPACE"
+    else
+        log_warn "cert-manager namespace not yet created. The operator will create it."
+    fi
+    
+    log_info "Installation verification complete!"
+}
+
+# Function to display next steps
+display_next_steps() {
+    echo
+    log_info "========================================"
+    log_info "Installation completed successfully!"
+    log_info "========================================"
+    echo
+    echo "Next steps:"
+    echo "1. Verify the operator is running:"
+    echo "   oc get pods -n $OPERATOR_NAMESPACE"
+    echo
+    echo "2. Check cert-manager components (may take a moment to appear):"
+    echo "   oc get pods -n $CERT_MANAGER_NAMESPACE"
+    echo
+    echo "3. Configure an issuer (ACME, CA, or self-signed):"
+    echo "   https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-acme-dns01"
+    echo
+    echo "4. Create certificates:"
+    echo "   https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-create-certificates"
+    echo
+}
+
+# Main execution
+main() {
+    log_info "Starting cert-manager Operator installation..."
+    echo
+    
+    check_prerequisites
+    check_existing_installation
+    create_namespace "$OPERATOR_NAMESPACE"
+    install_operator
+    wait_for_operator
+    verify_installation
+    display_next_steps
+}
+
+# Run main function
+main
+

--- a/install-cert-manager-operator.sh
+++ b/install-cert-manager-operator.sh
@@ -225,11 +225,11 @@ display_next_steps() {
     echo "2. Check cert-manager components (may take a moment to appear):"
     echo "   oc get pods -n $CERT_MANAGER_NAMESPACE"
     echo
-    echo "3. Configure an issuer (ACME, CA, or self-signed):"
-    echo "   https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-acme-dns01"
+    echo "3. Quick test DNS-01 challenges (air-gapped):"
+    echo "   make quick-test"
     echo
-    echo "4. Create certificates:"
-    echo "   https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-create-certificates"
+    echo "4. Clean up test resources:"
+    echo "   make clean"
     echo
 }
 

--- a/install-fake-dns.sh
+++ b/install-fake-dns.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+
+################################################################################
+# Script: install-fake-dns.sh
+# Description: Install fake DNS API server for air-gapped DNS-01 testing
+################################################################################
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_DIR="${SCRIPT_DIR}/yaml/fake-dns-api"
+
+# Configuration
+export FAKEDNS_NAMESPACE="${FAKEDNS_NAMESPACE:-fake-dns}"
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_note() { echo -e "${BLUE}[NOTE]${NC} $1"; }
+
+print_header() {
+    echo
+    echo "========================================"
+    echo "  Install Fake DNS API (Air-gapped)"
+    echo "========================================"
+    echo
+}
+
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    if ! command -v oc &> /dev/null; then
+        log_error "oc command not found"
+        exit 1
+    fi
+    
+    if ! command -v envsubst &> /dev/null; then
+        log_error "envsubst command not found"
+        exit 1
+    fi
+    
+    if ! oc whoami &> /dev/null; then
+        log_error "Not logged into OpenShift"
+        exit 1
+    fi
+    
+    log_info "Prerequisites check passed"
+}
+
+apply_yaml() {
+    local yaml_file=$1
+    local resource_type=$2
+    
+    if [ ! -f "$yaml_file" ]; then
+        log_error "YAML file not found: $yaml_file"
+        exit 1
+    fi
+    
+    log_info "Applying $resource_type from $(basename "$yaml_file")..."
+    envsubst < "$yaml_file" | oc apply -f -
+}
+
+install_fake_dns() {
+    log_info "Installing fake DNS API server..."
+    
+    apply_yaml "$YAML_DIR/namespace.yaml" "Namespace"
+    apply_yaml "$YAML_DIR/serviceaccount.yaml" "ServiceAccount"
+    
+    # Grant anyuid SCC to allow binding to port 53
+    log_info "Granting anyuid SCC to fake-dns-api ServiceAccount..."
+    oc adm policy add-scc-to-user anyuid -z fake-dns-api -n "$FAKEDNS_NAMESPACE"
+    
+    apply_yaml "$YAML_DIR/configmap.yaml" "ConfigMap"
+    apply_yaml "$YAML_DIR/deployment.yaml" "Deployment"
+    apply_yaml "$YAML_DIR/service.yaml" "Service"
+    
+    log_info "Resources applied. Waiting for fake-dns-api to be ready..."
+}
+
+wait_for_fake_dns() {
+    log_info "Waiting for fake-dns-api deployment..."
+    
+    local max_attempts=120  # 10 minutes total
+    local attempt=0
+    
+    while [ $attempt -lt $max_attempts ]; do
+        if oc get deployment fake-dns-api -n "$FAKEDNS_NAMESPACE" &> /dev/null; then
+            local ready=$(oc get deployment fake-dns-api -n "$FAKEDNS_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+            if [ "$ready" != "0" ]; then
+                log_info "fake-dns-api is ready!"
+                break
+            fi
+            
+            # Show pod status periodically for better feedback
+            if [ $((attempt % 12)) -eq 0 ] && [ $attempt -gt 0 ]; then
+                echo
+                log_info "Still waiting... Current pod status:"
+                oc get pods -n "$FAKEDNS_NAMESPACE" --no-headers 2>/dev/null || true
+            fi
+        fi
+        
+        attempt=$((attempt + 1))
+        if [ $((attempt % 6)) -eq 0 ]; then
+            echo -n " [${attempt}/${max_attempts}]"
+        else
+            echo -n "."
+        fi
+        sleep 5
+    done
+    echo
+    
+    if [ $attempt -eq $max_attempts ]; then
+        log_error "Timeout waiting for fake-dns-api"
+        exit 1
+    fi
+}
+
+verify_installation() {
+    log_info "Verifying fake-dns-api installation..."
+    
+    oc get pods -n "$FAKEDNS_NAMESPACE"
+    echo
+    oc get service fake-dns-api -n "$FAKEDNS_NAMESPACE"
+    echo
+}
+
+configure_coredns() {
+    log_info "Configuring CoreDNS to delegate example.com to fake DNS server..."
+    
+    # Get the fake-dns ClusterIP
+    local fake_dns_ip=$(oc get service fake-dns-api -n "$FAKEDNS_NAMESPACE" -o jsonpath='{.spec.clusterIP}')
+    
+    if [ -z "$fake_dns_ip" ]; then
+        log_error "Could not get fake-dns service ClusterIP"
+        exit 1
+    fi
+    
+    log_info "Fake DNS server IP: $fake_dns_ip"
+    
+    # Check if CoreDNS configmap exists
+    if ! oc get configmap dns-default -n openshift-dns &> /dev/null; then
+        log_warn "CoreDNS configmap not found, skipping CoreDNS configuration"
+        log_warn "You may need to manually configure DNS forwarding for example.com"
+        return
+    fi
+    
+    # Update CoreDNS to forward example.com to our fake DNS
+    local corefile=$(oc get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}')
+    
+    if echo "$corefile" | grep -q "example.com:53"; then
+        log_info "CoreDNS already configured for example.com"
+    else
+        log_info "Adding example.com zone to CoreDNS..."
+        
+        # Add example.com zone configuration
+        cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dns-default
+  namespace: openshift-dns
+data:
+  Corefile: |
+    example.com:53 {
+        forward . ${fake_dns_ip}
+    }
+    .:53 {
+        errors
+        health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+            pods insecure
+            upstream
+            fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf {
+            policy sequential
+        }
+        cache 30
+        reload
+    }
+EOF
+        
+        log_info "CoreDNS configured. Waiting for DNS pods to restart..."
+        sleep 10
+    fi
+}
+
+display_next_steps() {
+    local dns_server="fake-dns-api.${FAKEDNS_NAMESPACE}.svc.cluster.local:53"
+    
+    echo
+    log_info "========================================"
+    log_info "  Fake DNS API Installation Complete!"
+    log_info "========================================"
+    echo
+    log_note "This fake DNS server accepts RFC2136 update requests and returns success"
+    log_note "without actually updating DNS. Perfect for air-gapped DNS-01 testing!"
+    echo
+    log_note "CoreDNS has been configured to forward example.com queries to fake DNS."
+    echo
+    echo "Next steps:"
+    echo
+    echo "1. Update Pebble to use fake DNS server:"
+    echo "   oc delete namespace pebble"
+    echo "   DNS_SERVER=${dns_server} PEBBLE_ALWAYS_VALID=1 ./install-pebble.sh"
+    echo
+    echo "2. Create DNS-01 ClusterIssuer pointing to fake DNS:"
+    echo "   DNS_SERVER=${dns_server} ./create-dns01-issuer.sh"
+    echo
+    echo "3. Create wildcard certificate:"
+    echo "   oc apply -f - <<EOF"
+    echo "   apiVersion: cert-manager.io/v1"
+    echo "   kind: Certificate"
+    echo "   metadata:"
+    echo "     name: wildcard-test"
+    echo "     namespace: default"
+    echo "   spec:"
+    echo "     secretName: wildcard-test-tls"
+    echo "     issuerRef:"
+    echo "       name: pebble-dns01-issuer"
+    echo "       kind: ClusterIssuer"
+    echo "     dnsNames:"
+    echo "     - '*.example.com'"
+    echo "     - 'example.com'"
+    echo "   EOF"
+    echo
+    echo "4. Watch certificate status:"
+    echo "   watch oc get certificate -n default"
+    echo
+    log_info "DNS server: ${dns_server}"
+    echo
+}
+
+main() {
+    print_header
+    check_prerequisites
+    install_fake_dns
+    wait_for_fake_dns
+    verify_installation
+    configure_coredns
+    display_next_steps
+}
+
+main
+

--- a/install-local-dns.sh
+++ b/install-local-dns.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+
+################################################################################
+# Script: install-local-dns.sh
+# Description: Install acme-dns for local DNS-01 challenge testing
+################################################################################
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_DIR="${SCRIPT_DIR}/yaml/acme-dns"
+
+# Configuration (exported for envsubst)
+export ACMEDNS_NAMESPACE="${ACMEDNS_NAMESPACE:-acme-dns}"
+
+# Function to print colored messages
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_note() {
+    echo -e "${BLUE}[NOTE]${NC} $1"
+}
+
+# Function to print header
+print_header() {
+    echo
+    echo "========================================"
+    echo "  Install Local DNS Server (acme-dns)"
+    echo "========================================"
+    echo
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    if ! command -v oc &> /dev/null; then
+        log_error "oc command not found. Please install OpenShift CLI."
+        exit 1
+    fi
+    
+    if ! command -v envsubst &> /dev/null; then
+        log_error "envsubst command not found. Please install gettext package."
+        exit 1
+    fi
+    
+    if ! oc whoami &> /dev/null; then
+        log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
+        exit 1
+    fi
+    
+    if [ ! -d "$YAML_DIR" ]; then
+        log_error "YAML directory not found: $YAML_DIR"
+        exit 1
+    fi
+    
+    log_info "Prerequisites check passed."
+}
+
+# Function to check existing installation
+check_existing_installation() {
+    log_info "Checking for existing acme-dns installation..."
+    
+    if oc get namespace "$ACMEDNS_NAMESPACE" &> /dev/null; then
+        log_info "acme-dns namespace already exists."
+        
+        if oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" &> /dev/null; then
+            local ready_replicas=$(oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+            if [ "$ready_replicas" != "0" ]; then
+                log_info "acme-dns is already installed and running."
+                log_info "Installation is idempotent - will verify components."
+                return 0
+            fi
+        fi
+    fi
+    
+    log_info "No existing installation found. Will proceed with fresh installation."
+}
+
+# Function to apply YAML with variable substitution
+apply_yaml() {
+    local yaml_file=$1
+    local resource_type=$2
+    
+    if [ ! -f "$yaml_file" ]; then
+        log_error "YAML file not found: $yaml_file"
+        exit 1
+    fi
+    
+    log_info "Applying $resource_type from $(basename "$yaml_file")..."
+    envsubst < "$yaml_file" | oc apply -f -
+}
+
+# Function to install acme-dns
+install_acme_dns() {
+    log_info "Installing acme-dns..."
+    
+    apply_yaml "$YAML_DIR/namespace.yaml" "Namespace"
+    apply_yaml "$YAML_DIR/configmap.yaml" "ConfigMap"
+    apply_yaml "$YAML_DIR/deployment.yaml" "Deployment"
+    apply_yaml "$YAML_DIR/service.yaml" "Service"
+    
+    log_info "Resources applied. Waiting for acme-dns to be ready..."
+}
+
+# Function to wait for acme-dns
+wait_for_acme_dns() {
+    log_info "Waiting for acme-dns deployment to be ready..."
+    
+    local max_attempts=60
+    local attempt=0
+    
+    while [ $attempt -lt $max_attempts ]; do
+        if oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" &> /dev/null; then
+            local ready_replicas=$(oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+            if [ "$ready_replicas" != "0" ]; then
+                log_info "acme-dns is ready!"
+                break
+            fi
+        fi
+        
+        attempt=$((attempt + 1))
+        if [ $((attempt % 6)) -eq 0 ]; then
+            echo -n " [${attempt}/${max_attempts}]"
+        else
+            echo -n "."
+        fi
+        sleep 5
+    done
+    echo
+    
+    if [ $attempt -eq $max_attempts ]; then
+        log_error "Timeout waiting for acme-dns to be ready."
+        log_info "Check status: oc get pods -n $ACMEDNS_NAMESPACE"
+        exit 1
+    fi
+    
+    if oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" &> /dev/null; then
+        oc wait --for=condition=available --timeout=60s \
+            deployment/acme-dns \
+            -n "$ACMEDNS_NAMESPACE" || {
+            log_warn "Deployment condition not met, but pods may be working."
+        }
+    fi
+}
+
+# Function to verify installation
+verify_installation() {
+    log_info "Verifying acme-dns installation..."
+    
+    log_info "Checking pods..."
+    oc get pods -n "$ACMEDNS_NAMESPACE"
+    echo
+    
+    log_info "Checking service..."
+    oc get service acme-dns -n "$ACMEDNS_NAMESPACE"
+    echo
+    
+    log_info "Installation verification complete!"
+}
+
+# Function to display next steps
+display_next_steps() {
+    local acmedns_api="http://acme-dns.${ACMEDNS_NAMESPACE}.svc.cluster.local:8080"
+    local acmedns_dns="acme-dns.${ACMEDNS_NAMESPACE}.svc.cluster.local"
+    
+    echo
+    log_info "========================================"
+    log_info "  acme-dns Installation Complete!"
+    log_info "========================================"
+    echo
+    echo "acme-dns is now running!"
+    echo
+    echo "Next steps:"
+    echo
+    echo "1. Update Pebble to use acme-dns for validation:"
+    echo "   oc delete namespace pebble"
+    echo "   DNS_SERVER=${acmedns_dns}:53 PEBBLE_ALWAYS_VALID=1 make install-pebble"
+    echo
+    echo "2. Install cert-manager webhook for acme-dns:"
+    echo "   make install-acmedns-webhook"
+    echo
+    echo "3. Create a DNS-01 ClusterIssuer:"
+    echo "   make create-dns01-issuer"
+    echo
+    echo "4. Test with a wildcard certificate:"
+    echo "   make create-wildcard-cert"
+    echo
+    echo "acme-dns URLs:"
+    echo "  - API: ${acmedns_api}"
+    echo "  - DNS: ${acmedns_dns}:53"
+    echo
+    log_note "acme-dns provides a REST API for creating/updating DNS TXT records"
+    log_note "cert-manager will use this API for DNS-01 challenges"
+    echo
+}
+
+# Main execution
+main() {
+    print_header
+    check_prerequisites
+    check_existing_installation
+    install_acme_dns
+    wait_for_acme_dns
+    verify_installation
+    display_next_steps
+}
+
+# Run main function
+main
+

--- a/install-pebble-challtestsrv.sh
+++ b/install-pebble-challtestsrv.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+################################################################################
+# Script: install-pebble-challtestsrv.sh
+# Description: Install Pebble Challenge Test Server for DNS-01 testing
+################################################################################
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_DIR="${SCRIPT_DIR}/yaml/pebble-challtestsrv"
+
+export PEBBLE_NAMESPACE="${PEBBLE_NAMESPACE:-pebble}"
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_note() { echo -e "${BLUE}[NOTE]${NC} $1"; }
+
+echo
+echo "========================================"
+echo "  Install Pebble Challenge Test Server"
+echo "========================================"
+echo
+
+# Check prerequisites
+if ! command -v oc &> /dev/null; then
+    log_error "oc command not found"
+    exit 1
+fi
+
+if ! oc whoami &> /dev/null; then
+    log_error "Not logged into OpenShift"
+    exit 1
+fi
+
+# Check if Pebble namespace exists
+if ! oc get namespace "$PEBBLE_NAMESPACE" &> /dev/null; then
+    log_error "Pebble namespace '$PEBBLE_NAMESPACE' not found. Install Pebble first."
+    exit 1
+fi
+
+log_info "Installing Challenge Test Server..."
+
+# Apply manifests
+log_info "Applying deployment..."
+envsubst < "$YAML_DIR/deployment.yaml" | oc apply -f -
+
+log_info "Applying service..."
+envsubst < "$YAML_DIR/service.yaml" | oc apply -f -
+
+log_info "Waiting for Challenge Test Server to be ready..."
+oc wait --for=condition=available --timeout=120s \
+    deployment/pebble-challtestsrv \
+    -n "$PEBBLE_NAMESPACE" || {
+    log_warn "Deployment not ready yet, checking status..."
+    oc get pods -n "$PEBBLE_NAMESPACE" -l app=pebble-challtestsrv
+}
+
+log_info "Challenge Test Server is ready!"
+echo
+log_info "DNS Server: pebble-challtestsrv.${PEBBLE_NAMESPACE}.svc.cluster.local:8053"
+log_info "Management API: http://pebble-challtestsrv.${PEBBLE_NAMESPACE}.svc.cluster.local:8055"
+echo
+echo "Next steps:"
+echo "1. Configure Pebble to use this DNS server:"
+echo "   Edit Pebble configmap to set DNS_SERVER"
+echo
+echo "2. Use management API to set DNS records:"
+echo "   curl -X POST http://pebble-challtestsrv.pebble.svc:8055/set-txt \\"
+echo "     -d '{\"host\":\"_acme-challenge.example.com.\",\"value\":\"test\"}'"
+echo
+log_note "This DNS server works with Pebble's ALWAYS_VALID mode!"
+

--- a/install-pebble.sh
+++ b/install-pebble.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+
+################################################################################
+# Script: install-pebble.sh
+# Description: Install Pebble ACME test server for local cert-manager testing
+# Reference: https://github.com/letsencrypt/pebble
+################################################################################
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+YAML_DIR="${SCRIPT_DIR}/yaml/pebble"
+
+# Configuration (exported for envsubst)
+export PEBBLE_NAMESPACE="${PEBBLE_NAMESPACE:-pebble}"
+export DNS_SERVER="${DNS_SERVER:-8.8.8.8:53}"
+export PEBBLE_ALWAYS_VALID="${PEBBLE_ALWAYS_VALID:-0}"
+
+# Function to print colored messages
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_note() {
+    echo -e "${BLUE}[NOTE]${NC} $1"
+}
+
+# Function to print header
+print_header() {
+    echo
+    echo "========================================"
+    echo "  Pebble ACME Test Server Installation"
+    echo "========================================"
+    echo
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    log_info "Checking prerequisites..."
+    
+    if ! command -v oc &> /dev/null; then
+        log_error "oc command not found. Please install OpenShift CLI."
+        exit 1
+    fi
+    
+    if ! command -v envsubst &> /dev/null; then
+        log_error "envsubst command not found. Please install gettext package."
+        log_info "  macOS: brew install gettext"
+        log_info "  RHEL/Fedora: dnf install gettext"
+        exit 1
+    fi
+    
+    if ! oc whoami &> /dev/null; then
+        log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
+        exit 1
+    fi
+    
+    # Check if YAML directory exists
+    if [ ! -d "$YAML_DIR" ]; then
+        log_error "YAML directory not found: $YAML_DIR"
+        exit 1
+    fi
+    
+    log_info "Prerequisites check passed."
+}
+
+# Function to check if Pebble is already installed
+check_existing_installation() {
+    log_info "Checking for existing Pebble installation..."
+    
+    if oc get namespace "$PEBBLE_NAMESPACE" &> /dev/null; then
+        log_info "Pebble namespace '$PEBBLE_NAMESPACE' already exists."
+        
+        # Check if deployment exists and is healthy
+        if oc get deployment pebble -n "$PEBBLE_NAMESPACE" &> /dev/null; then
+            local ready_replicas=$(oc get deployment pebble -n "$PEBBLE_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+            local desired_replicas=$(oc get deployment pebble -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "1")
+            
+            if [ "$ready_replicas" = "$desired_replicas" ] && [ "$ready_replicas" != "0" ]; then
+                log_info "Pebble is already installed and healthy."
+                log_info "Installation is idempotent - will verify and ensure components are ready."
+                return 0
+            else
+                log_warn "Pebble exists but may not be healthy. Will attempt to reconcile."
+                return 0
+            fi
+        fi
+    fi
+    
+    log_info "No existing installation found. Will proceed with fresh installation."
+}
+
+# Function to apply YAML with variable substitution
+apply_yaml() {
+    local yaml_file=$1
+    local resource_type=$2
+    
+    if [ ! -f "$yaml_file" ]; then
+        log_error "YAML file not found: $yaml_file"
+        exit 1
+    fi
+    
+    log_info "Applying $resource_type from $(basename "$yaml_file")..."
+    envsubst < "$yaml_file" | oc apply -f -
+}
+
+# Function to install Pebble
+install_pebble() {
+    log_info "Installing Pebble ACME test server..."
+    
+    # Apply resources in order
+    apply_yaml "$YAML_DIR/namespace.yaml" "Namespace"
+    apply_yaml "$YAML_DIR/configmap.yaml" "ConfigMap"
+    apply_yaml "$YAML_DIR/deployment.yaml" "Deployment"
+    apply_yaml "$YAML_DIR/service.yaml" "Service"
+    apply_yaml "$YAML_DIR/route.yaml" "Route"
+    
+    log_info "Resources applied. Waiting for Pebble to be ready..."
+}
+
+# Function to wait for Pebble to be ready
+wait_for_pebble() {
+    log_info "Waiting for Pebble deployment to be ready..."
+    
+    local max_attempts=120  # 10 minutes total
+    local attempt=0
+    
+    while [ $attempt -lt $max_attempts ]; do
+        if oc get deployment pebble -n "$PEBBLE_NAMESPACE" &> /dev/null; then
+            local ready_replicas=$(oc get deployment pebble -n "$PEBBLE_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+            local desired_replicas=$(oc get deployment pebble -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "1")
+            
+            if [ "$ready_replicas" = "$desired_replicas" ] && [ "$ready_replicas" != "0" ]; then
+                log_info "Pebble deployment is ready!"
+                break
+            fi
+            
+            # Show pod status periodically for better feedback
+            if [ $((attempt % 12)) -eq 0 ] && [ $attempt -gt 0 ]; then
+                echo
+                log_info "Still waiting... Current pod status:"
+                oc get pods -n "$PEBBLE_NAMESPACE" --no-headers 2>/dev/null || true
+            fi
+        fi
+        
+        attempt=$((attempt + 1))
+        if [ $((attempt % 6)) -eq 0 ]; then
+            echo -n " [${attempt}/${max_attempts}]"
+        else
+            echo -n "."
+        fi
+        sleep 5
+    done
+    echo
+    
+    if [ $attempt -eq $max_attempts ]; then
+        log_error "Timeout waiting for Pebble to be ready."
+        log_info "Check the status with: oc get pods -n $PEBBLE_NAMESPACE"
+        log_info "Check logs with: oc logs -n $PEBBLE_NAMESPACE deployment/pebble"
+        exit 1
+    fi
+    
+    # Additional wait for pod to be fully ready
+    if oc get deployment pebble -n "$PEBBLE_NAMESPACE" &> /dev/null; then
+        oc wait --for=condition=available --timeout=60s \
+            deployment/pebble \
+            -n "$PEBBLE_NAMESPACE" || {
+            log_warn "Deployment ready condition not met, but pods may still be working."
+        }
+    fi
+}
+
+# Function to verify installation
+verify_installation() {
+    log_info "Verifying Pebble installation..."
+    
+    # Check pod status
+    log_info "Checking pod status..."
+    oc get pods -n "$PEBBLE_NAMESPACE"
+    echo
+    
+    # Check service
+    log_info "Checking service..."
+    oc get service pebble -n "$PEBBLE_NAMESPACE"
+    echo
+    
+    # Check route
+    log_info "Checking route..."
+    oc get route pebble-acme -n "$PEBBLE_NAMESPACE"
+    echo
+    
+    # Get the route URL
+    local route_host=$(oc get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+    
+    if [ -n "$route_host" ]; then
+        log_info "Pebble ACME directory URL: https://${route_host}/dir"
+    fi
+    
+    # Get internal service URL
+    local service_url="https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:14000/dir"
+    log_info "Pebble internal URL: ${service_url}"
+    
+    log_info "Installation verification complete!"
+}
+
+# Function to display configuration summary
+display_configuration() {
+    echo
+    log_info "========================================"
+    log_info "  Pebble Configuration"
+    log_info "========================================"
+    echo
+    echo "Namespace:           $PEBBLE_NAMESPACE"
+    echo "DNS Server:          $DNS_SERVER"
+    echo "Always Valid:        $PEBBLE_ALWAYS_VALID"
+    echo
+    
+    if [ "$PEBBLE_ALWAYS_VALID" = "1" ]; then
+        log_note "PEBBLE_ALWAYS_VALID=1: All challenges will automatically succeed."
+        log_note "This is useful for testing without proper DNS/HTTP challenge setup."
+    else
+        log_note "PEBBLE_ALWAYS_VALID=0: Challenges must be properly configured."
+        log_note "You'll need proper DNS records or HTTP-01 challenge routes."
+    fi
+    echo
+}
+
+# Function to display next steps
+display_next_steps() {
+    local route_host=$(oc get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+    local service_url="https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:14000/dir"
+    
+    echo
+    log_info "========================================"
+    log_info "  Installation Complete!"
+    log_info "========================================"
+    echo
+    echo "Pebble ACME server is now running!"
+    echo
+    echo "Next steps:"
+    echo
+    echo "1. Get Pebble's root CA certificate (for cert-manager to trust):"
+    echo "   oc run --rm -i --tty pebble-ca-fetch --image=curlimages/curl --restart=Never -- \\"
+    echo "     curl -k https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:15000/roots/0"
+    echo
+    echo "   Or save it to a file:"
+    echo "   oc run --rm -i pebble-ca-fetch --image=curlimages/curl --restart=Never -- \\"
+    echo "     curl -k https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:15000/roots/0 > pebble-ca.crt"
+    echo
+    echo "2. Configure a cert-manager ClusterIssuer pointing to Pebble:"
+    echo "   ACME Server: ${service_url}"
+    if [ -n "$route_host" ]; then
+        echo "   External URL: https://${route_host}/dir"
+    fi
+    echo
+    echo "   Note: Use 'skipTLSVerify: true' in your ClusterIssuer since Pebble uses self-signed certs"
+    echo
+    echo "3. Pebble URLs:"
+    echo "   - ACME Directory: ${service_url}"
+    echo "   - Management API: https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:15000"
+    echo "   - Root CA: https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:15000/roots/0"
+    echo
+    echo "4. View Pebble logs:"
+    echo "   oc logs -n $PEBBLE_NAMESPACE deployment/pebble -f"
+    echo
+    echo "5. Test ACME directory (from inside cluster):"
+    echo "   oc run --rm -i --tty curl-test --image=curlimages/curl --restart=Never -- \\"
+    echo "     curl -k ${service_url}"
+    echo
+    
+    if [ "$PEBBLE_ALWAYS_VALID" = "1" ]; then
+        log_note "Remember: PEBBLE_ALWAYS_VALID=1 means all challenges auto-succeed."
+        log_note "Great for initial testing, but doesn't validate actual DNS/HTTP setup."
+    fi
+    
+    echo
+    log_info "For more information about Pebble, visit:"
+    log_info "https://github.com/letsencrypt/pebble"
+    echo
+}
+
+# Main execution
+main() {
+    print_header
+    
+    check_prerequisites
+    display_configuration
+    check_existing_installation
+    install_pebble
+    wait_for_pebble
+    verify_installation
+    display_next_steps
+}
+
+# Run main function
+main
+

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -7,6 +7,7 @@ This directory contains Kubernetes/OpenShift YAML manifests organized by purpose
 Each subdirectory represents a specific component or feature:
 
 - `cert-manager-operator/` - Manifests for installing the cert-manager Operator
+- `pebble/` - Manifests for deploying the Pebble ACME test server
 
 ## Variable Substitution
 
@@ -64,5 +65,66 @@ export CHANNEL="stable-v1"
 
 envsubst < yaml/cert-manager-operator/operatorgroup.yaml | oc apply -f -
 envsubst < yaml/cert-manager-operator/subscription.yaml | oc apply -f -
+```
+
+---
+
+## pebble
+
+### Files
+
+- `namespace.yaml` - Namespace for Pebble deployment
+- `configmap.yaml` - Pebble configuration (ACME server settings)
+- `deployment.yaml` - Pebble deployment
+- `service.yaml` - Service to expose Pebble within the cluster
+- `route.yaml` - Route for external access to Pebble (if needed)
+
+### Variables
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| `PEBBLE_NAMESPACE` | `pebble` | Namespace for Pebble |
+| `DNS_SERVER` | `8.8.8.8:53` | DNS server for ACME validation |
+| `PEBBLE_ALWAYS_VALID` | `0` | Auto-validate challenges (1=yes, 0=no) |
+
+### What is Pebble?
+
+Pebble is a lightweight ACME test server from Let's Encrypt. It:
+- Provides a local ACME server for testing cert-manager
+- Has no rate limits (unlike Let's Encrypt production)
+- Can be configured to auto-validate challenges for easier testing
+- Runs entirely in your OpenShift cluster
+
+### Usage
+
+These manifests are applied by `install-pebble.sh`:
+
+```bash
+export PEBBLE_NAMESPACE="pebble"
+export DNS_SERVER="8.8.8.8:53"
+export PEBBLE_ALWAYS_VALID="0"
+
+envsubst < yaml/pebble/namespace.yaml | oc apply -f -
+envsubst < yaml/pebble/configmap.yaml | oc apply -f -
+envsubst < yaml/pebble/deployment.yaml | oc apply -f -
+envsubst < yaml/pebble/service.yaml | oc apply -f -
+envsubst < yaml/pebble/route.yaml | oc apply -f -
+```
+
+### Pebble Configuration
+
+The `configmap.yaml` contains Pebble's configuration:
+- **listenAddress**: ACME API endpoint (port 14000)
+- **managementListenAddress**: Management API (port 15000)
+- **httpPort/tlsPort**: Ports for HTTP-01 challenge validation
+- **externalAccountBindingRequired**: Set to false for easier testing
+
+### Accessing Pebble
+
+After deployment, Pebble is accessible at:
+- **Internal**: `https://pebble.pebble.svc.cluster.local:14000/dir`
+- **External**: Through the OpenShift route (if route is created)
+
+Use the internal URL when configuring cert-manager ClusterIssuers.
 ```
 

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -1,0 +1,68 @@
+# YAML Manifests
+
+This directory contains Kubernetes/OpenShift YAML manifests organized by purpose.
+
+## Structure
+
+Each subdirectory represents a specific component or feature:
+
+- `cert-manager-operator/` - Manifests for installing the cert-manager Operator
+
+## Variable Substitution
+
+The YAML files use environment variable placeholders in the format `${VARIABLE_NAME}`. These are substituted at runtime using the `envsubst` command.
+
+### Example
+
+**YAML template:**
+```yaml
+metadata:
+  name: ${OPERATOR_NAME}
+  namespace: ${OPERATOR_NAMESPACE}
+```
+
+**After substitution:**
+```yaml
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
+```
+
+## Adding New Manifests
+
+When adding new YAML manifests:
+
+1. Create a subdirectory for your component (e.g., `yaml/issuers/`)
+2. Use environment variable placeholders for configurable values
+3. Export the variables in your shell script
+4. Use `envsubst < template.yaml | oc apply -f -` to apply with substitution
+5. Document the variables in a README or comments
+
+## cert-manager-operator
+
+### Files
+
+- `operatorgroup.yaml` - Defines the OperatorGroup for the cert-manager-operator
+- `subscription.yaml` - Defines the Subscription to install the operator from RedHat catalog
+
+### Variables
+
+| Variable | Default Value | Description |
+|----------|---------------|-------------|
+| `OPERATOR_NAMESPACE` | `cert-manager-operator` | Namespace for the operator |
+| `OPERATOR_NAME` | `openshift-cert-manager-operator` | Name of the operator subscription |
+| `CHANNEL` | `stable-v1` | Update channel for the operator |
+
+### Usage
+
+These manifests are applied by `install-cert-manager-operator.sh`:
+
+```bash
+export OPERATOR_NAMESPACE="cert-manager-operator"
+export OPERATOR_NAME="openshift-cert-manager-operator"
+export CHANNEL="stable-v1"
+
+envsubst < yaml/cert-manager-operator/operatorgroup.yaml | oc apply -f -
+envsubst < yaml/cert-manager-operator/subscription.yaml | oc apply -f -
+```
+

--- a/yaml/acme-dns/configmap.yaml
+++ b/yaml/acme-dns/configmap.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: acme-dns-config
+  namespace: ${ACMEDNS_NAMESPACE}
+data:
+  config.cfg: |
+    [general]
+    # DNS interface
+    listen = ":53"
+    # Protocol, "both", "both4", "both6", "udp", "udp4", "udp6" or "tcp", "tcp4", "tcp6"
+    protocol = "both"
+    # Domain name to serve the requests off of
+    domain = "acme-dns.local"
+    # Zone name server
+    nsname = "ns1.acme-dns.local"
+    # Admin email address
+    nsadmin = "admin.acme-dns.local"
+    # Predefined records served in addition to the TXT
+    records = [
+        "acme-dns.local. A 127.0.0.1",
+        "ns1.acme-dns.local. A 127.0.0.1",
+    ]
+
+    [database]
+    engine = "sqlite3"
+    connection = "/var/lib/acme-dns/acme-dns.db"
+
+    [api]
+    ip = "0.0.0.0"
+    port = "8080"
+    tls = "none"
+    
+    [logconfig]
+    loglevel = "info"
+    logtype = "stdout"
+

--- a/yaml/acme-dns/deployment.yaml
+++ b/yaml/acme-dns/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: acme-dns
+  namespace: ${ACMEDNS_NAMESPACE}
+  labels:
+    app: acme-dns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: acme-dns
+  template:
+    metadata:
+      labels:
+        app: acme-dns
+    spec:
+      containers:
+      - name: acme-dns
+        image: joohoi/acme-dns:latest
+        ports:
+        - name: dns-udp
+          containerPort: 53
+          protocol: UDP
+        - name: dns-tcp
+          containerPort: 53
+          protocol: TCP
+        - name: api
+          containerPort: 8080
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/acme-dns
+          readOnly: true
+        - name: data
+          mountPath: /var/lib/acme-dns
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+      volumes:
+      - name: config
+        configMap:
+          name: acme-dns-config
+      - name: data
+        emptyDir: {}
+

--- a/yaml/acme-dns/namespace.yaml
+++ b/yaml/acme-dns/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${ACMEDNS_NAMESPACE}
+  labels:
+    name: ${ACMEDNS_NAMESPACE}
+    app: acme-dns
+

--- a/yaml/acme-dns/service.yaml
+++ b/yaml/acme-dns/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: acme-dns
+  namespace: ${ACMEDNS_NAMESPACE}
+  labels:
+    app: acme-dns
+spec:
+  type: ClusterIP
+  ports:
+  - name: dns-udp
+    port: 53
+    targetPort: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    targetPort: 53
+    protocol: TCP
+  - name: api
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: acme-dns
+

--- a/yaml/cert-manager-operator/operatorgroup.yaml
+++ b/yaml/cert-manager-operator/operatorgroup.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator
+  namespace: ${OPERATOR_NAMESPACE}
+spec:
+  targetNamespaces:
+  - ${OPERATOR_NAMESPACE}
+

--- a/yaml/cert-manager-operator/subscription.yaml
+++ b/yaml/cert-manager-operator/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ${OPERATOR_NAME}
+  namespace: ${OPERATOR_NAMESPACE}
+spec:
+  channel: ${CHANNEL}
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+

--- a/yaml/certificates/test-certificate.yaml
+++ b/yaml/certificates/test-certificate.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${CERT_NAME}
+  namespace: ${CERT_NAMESPACE}
+spec:
+  # Secret where certificate will be stored
+  secretName: ${CERT_SECRET_NAME}
+  
+  # Certificate duration
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  
+  # Reference to ClusterIssuer
+  issuerRef:
+    name: ${ISSUER_NAME}
+    kind: ClusterIssuer
+    group: cert-manager.io
+  
+  # Common name
+  commonName: ${CERT_COMMON_NAME}
+  
+  # DNS names for the certificate
+  dnsNames:
+  - ${CERT_DNS_NAME}
+  
+  # Use HTTP-01 challenge
+  # Note: For wildcard certs, you must use DNS-01 challenge
+

--- a/yaml/fake-dns-api/configmap.yaml
+++ b/yaml/fake-dns-api/configmap.yaml
@@ -1,0 +1,233 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fake-dns-api
+  namespace: ${FAKEDNS_NAMESPACE}
+data:
+  dns-api.py: |
+    #!/usr/bin/env python3
+    """
+    Fake DNS API Server for air-gapped cert-manager DNS-01 testing
+    
+    This server accepts RFC2136 DNS update requests and returns success
+    without actually updating any DNS. Used with Pebble ALWAYS_VALID=1
+    for testing DNS-01 challenges in air-gapped environments.
+    """
+    
+    import socket
+    import struct
+    import threading
+    import logging
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+    
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+    
+    class HealthCheckHandler(BaseHTTPRequestHandler):
+        """HTTP server for health checks"""
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'OK\n')
+        
+        def log_message(self, format, *args):
+            pass  # Suppress HTTP logs
+    
+    def handle_dns_query(data, addr):
+        """
+        Handle DNS query/update. For updates (opcode=5), return success.
+        For SOA queries, return a fake SOA record to make cert-manager happy.
+        """
+        try:
+            # Parse DNS header
+            if len(data) < 12:
+                return None
+            
+            transaction_id = data[0:2]
+            flags = struct.unpack('>H', data[2:4])[0]
+            qdcount = struct.unpack('>H', data[4:6])[0]
+            
+            # Extract opcode (bits 11-14)
+            opcode = (flags >> 11) & 0x0F
+            
+            # DNS UPDATE has opcode = 5
+            if opcode == 5:
+                logger.info(f"Received DNS UPDATE from {addr} - returning success")
+                # Build response: same ID, response flag, opcode=5, no error
+                response_flags = 0x8000 | (5 << 11) | 0x0000  # QR=1, OPCODE=5, RCODE=0 (NOERROR)
+                response = transaction_id + struct.pack('>H', response_flags) + data[4:12]
+                return response
+            # DNS QUERY (opcode=0)
+            elif opcode == 0 and qdcount > 0:
+                # Parse query to check if it's asking for SOA
+                try:
+                    # Skip header, parse first question
+                    offset = 12
+                    qname_parts = []
+                    while offset < len(data):
+                        length = data[offset]
+                        if length == 0:
+                            offset += 1
+                            break
+                        if length > 63:
+                            break
+                        qname_parts.append(data[offset+1:offset+1+length].decode('utf-8', errors='ignore'))
+                        offset += 1 + length
+                    
+                    if offset + 4 <= len(data):
+                        qtype = struct.unpack('>H', data[offset:offset+2])[0]
+                        qname = '.'.join(qname_parts)
+                        
+                        # NS query (qtype=2) - Return fake NS record
+                        if qtype == 2:
+                            logger.info(f"Received NS query for {qname} from {addr} - returning fake NS")
+                            
+                            # Build minimal NS response
+                            # QR=1, AA=1 (authoritative), OPCODE=0, RCODE=0
+                            response_flags = 0x8400
+                            response = transaction_id + struct.pack('>H', response_flags)
+                            response += struct.pack('>HHHH', 1, 1, 0, 0)  # 1 question, 1 answer, 0 authority, 0 additional
+                            response += data[12:offset+4]  # Copy question section
+                            
+                            # Answer section: name pointer + NS record
+                            response += b'\xc0\x0c'  # Name pointer to question
+                            response += struct.pack('>HHI', 2, 1, 300)  # TYPE=NS, CLASS=IN, TTL=300
+                            
+                            # NS RDATA: ns.fake-dns.local
+                            ns_data = b''
+                            for part in ['ns', 'fake-dns', 'local']:
+                                ns_data += bytes([len(part)]) + part.encode()
+                            ns_data += b'\x00'
+                            
+                            response += struct.pack('>H', len(ns_data)) + ns_data
+                            return response
+                        
+                        # SOA query (qtype=6)
+                        elif qtype == 6:
+                            logger.info(f"Received SOA query for {qname} from {addr} - returning fake SOA")
+                            
+                            # Build minimal SOA response
+                            # QR=1, AA=1 (authoritative), OPCODE=0, RCODE=0
+                            response_flags = 0x8400
+                            response = transaction_id + struct.pack('>H', response_flags)
+                            response += struct.pack('>HHHH', 1, 1, 0, 0)  # 1 question, 1 answer, 0 authority, 0 additional
+                            response += data[12:offset+4]  # Copy question section
+                            
+                            # Answer section: name pointer + SOA record
+                            response += b'\xc0\x0c'  # Name pointer to question
+                            response += struct.pack('>HHI', 6, 1, 300)  # TYPE=SOA, CLASS=IN, TTL=300
+                            
+                            # SOA RDATA
+                            soa_data = b''
+                            # MNAME: ns.fake-dns.local
+                            for part in ['ns', 'fake-dns', 'local']:
+                                soa_data += bytes([len(part)]) + part.encode()
+                            soa_data += b'\x00'
+                            # RNAME: admin.fake-dns.local
+                            for part in ['admin', 'fake-dns', 'local']:
+                                soa_data += bytes([len(part)]) + part.encode()
+                            soa_data += b'\x00'
+                            # SERIAL, REFRESH, RETRY, EXPIRE, MINIMUM
+                            soa_data += struct.pack('>IIIII', 1, 3600, 600, 86400, 300)
+                            
+                            response += struct.pack('>H', len(soa_data)) + soa_data
+                            return response
+                        
+                        # TXT query (qtype=16) - Return fake TXT record for ACME challenges
+                        elif qtype == 16:
+                            logger.info(f"Received TXT query for {qname} from {addr} - returning fake TXT")
+                            
+                            # Build minimal TXT response
+                            # QR=1, AA=1 (authoritative), OPCODE=0, RCODE=0
+                            response_flags = 0x8400
+                            response = transaction_id + struct.pack('>H', response_flags)
+                            response += struct.pack('>HHHH', 1, 1, 0, 0)  # 1 question, 1 answer, 0 authority, 0 additional
+                            response += data[12:offset+4]  # Copy question section
+                            
+                            # Answer section: name pointer + TXT record
+                            response += b'\xc0\x0c'  # Name pointer to question
+                            response += struct.pack('>HHI', 16, 1, 300)  # TYPE=TXT, CLASS=IN, TTL=300
+                            
+                            # TXT RDATA: fake challenge token
+                            # For ACME DNS-01 challenges, return a dummy token
+                            txt_value = b'fake-acme-challenge-token'
+                            txt_data = bytes([len(txt_value)]) + txt_value
+                            
+                            response += struct.pack('>H', len(txt_data)) + txt_data
+                            return response
+                        
+                        # A query (qtype=1) or AAAA query (qtype=28) - Return NODATA (no error, but no answer)
+                        elif qtype == 1 or qtype == 28:
+                            qtype_name = "A" if qtype == 1 else "AAAA"
+                            logger.info(f"Received {qtype_name} query for {qname} from {addr} - returning NODATA")
+                            
+                            # Build NODATA response (authoritative, no error, but no answer)
+                            # QR=1, AA=1 (authoritative), OPCODE=0, RCODE=0
+                            response_flags = 0x8400
+                            response = transaction_id + struct.pack('>H', response_flags)
+                            response += struct.pack('>HHHH', 1, 0, 0, 0)  # 1 question, 0 answers, 0 authority, 0 additional
+                            response += data[12:offset+4]  # Copy question section
+                            return response
+                except Exception as e:
+                    logger.error(f"Error parsing DNS query: {e}")
+                
+                # Log the qtype for unhandled query types
+                try:
+                    if offset + 4 <= len(data):
+                        qtype = struct.unpack('>H', data[offset:offset+2])[0]
+                        logger.info(f"Received DNS query type {qtype} for {qname} from {addr} - returning NOERROR with no answer")
+                        # Return NOERROR with no answers (like NODATA)
+                        response_flags = 0x8400  # QR=1, AA=1
+                        response = transaction_id + struct.pack('>H', response_flags)
+                        response += struct.pack('>HHHH', 1, 0, 0, 0)  # 1 question, 0 answers
+                        response += data[12:offset+4]  # Copy question section
+                        return response
+                except Exception as e:
+                    logger.error(f"Error handling unhandled query type: {e}")
+                
+                logger.info(f"Received unparseable DNS query from {addr} - returning SERVFAIL")
+                response_flags = 0x8002  # Response, SERVFAIL
+                response = transaction_id + struct.pack('>H', response_flags) + data[4:12]
+                return response
+            else:
+                logger.info(f"Received DNS opcode={opcode} from {addr} - returning SERVFAIL")
+                response_flags = 0x8002  # Response, SERVFAIL
+                response = transaction_id + struct.pack('>H', response_flags) + data[4:12]
+                return response
+                
+        except Exception as e:
+            logger.error(f"Error handling DNS packet: {e}")
+            return None
+    
+    def start_dns_server(port=53):
+        """Start UDP DNS server"""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(('0.0.0.0', port))
+        logger.info(f"DNS server listening on UDP port {port}")
+        
+        while True:
+            try:
+                data, addr = sock.recvfrom(512)
+                response = handle_dns_query(data, addr)
+                if response:
+                    sock.sendto(response, addr)
+            except Exception as e:
+                logger.error(f"Error in DNS server: {e}")
+    
+    def start_health_server(port=8080):
+        """Start HTTP health check server"""
+        server = HTTPServer(('0.0.0.0', port), HealthCheckHandler)
+        logger.info(f"Health check server listening on HTTP port {port}")
+        server.serve_forever()
+    
+    if __name__ == '__main__':
+        logger.info("Starting fake DNS API server for air-gapped testing")
+        
+        # Start DNS server in background thread
+        dns_thread = threading.Thread(target=start_dns_server, daemon=True)
+        dns_thread.start()
+        
+        # Start health server in main thread
+        start_health_server()
+

--- a/yaml/fake-dns-api/deployment.yaml
+++ b/yaml/fake-dns-api/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fake-dns-api
+  namespace: ${FAKEDNS_NAMESPACE}
+  labels:
+    app: fake-dns-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fake-dns-api
+  template:
+    metadata:
+      labels:
+        app: fake-dns-api
+    spec:
+      serviceAccountName: fake-dns-api
+      containers:
+      - name: dns-api
+        image: registry.access.redhat.com/ubi9/python-39:latest
+        command:
+        - python3
+        - /app/dns-api.py
+        ports:
+        - name: dns
+          containerPort: 53
+          protocol: UDP
+        - name: health
+          containerPort: 8080
+          protocol: TCP
+        volumeMounts:
+        - name: script
+          mountPath: /app
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 2
+          periodSeconds: 5
+        securityContext:
+          # Need elevated privileges for port 53
+          runAsUser: 0
+      volumes:
+      - name: script
+        configMap:
+          name: fake-dns-api
+          defaultMode: 0755
+

--- a/yaml/fake-dns-api/namespace.yaml
+++ b/yaml/fake-dns-api/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${FAKEDNS_NAMESPACE}
+  labels:
+    name: ${FAKEDNS_NAMESPACE}
+

--- a/yaml/fake-dns-api/service.yaml
+++ b/yaml/fake-dns-api/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fake-dns-api
+  namespace: ${FAKEDNS_NAMESPACE}
+  labels:
+    app: fake-dns-api
+spec:
+  type: ClusterIP
+  ports:
+  - name: dns
+    port: 53
+    targetPort: 53
+    protocol: UDP
+  - name: health
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: fake-dns-api
+

--- a/yaml/fake-dns-api/serviceaccount.yaml
+++ b/yaml/fake-dns-api/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fake-dns-api
+  namespace: ${FAKEDNS_NAMESPACE}
+

--- a/yaml/issuers/pebble-clusterissuer.yaml
+++ b/yaml/issuers/pebble-clusterissuer.yaml
@@ -1,0 +1,33 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${ISSUER_NAME}
+spec:
+  acme:
+    # Pebble ACME server URL
+    server: ${ACME_SERVER_URL}
+    
+    # Skip TLS verification (Pebble uses self-signed certificates)
+    skipTLSVerify: true
+    
+    # Disable HTTP-01 self-check (useful when domains don't resolve)
+    disableAccountKeyGeneration: false
+    
+    # Email for ACME account (can be fake for Pebble)
+    email: ${ACME_EMAIL}
+    
+    # Secret to store ACME account private key
+    privateKeySecretRef:
+      name: ${ISSUER_NAME}-account-key
+    
+    # HTTP-01 challenge solver
+    solvers:
+    - http01:
+        ingress:
+          class: ${INGRESS_CLASS}
+          podTemplate:
+            metadata:
+              annotations:
+                # Tell cert-manager to skip self-check
+                acme.cert-manager.io/http01-override-ingress-dns-name: "true"
+

--- a/yaml/issuers/pebble-dns01-clusterissuer.yaml
+++ b/yaml/issuers/pebble-dns01-clusterissuer.yaml
@@ -1,0 +1,31 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${ISSUER_NAME}
+spec:
+  acme:
+    # Pebble ACME server URL
+    server: ${ACME_SERVER_URL}
+    
+    # Skip TLS verification (Pebble uses self-signed certificates)
+    skipTLSVerify: true
+    
+    # Email for ACME account (can be fake for Pebble)
+    email: ${ACME_EMAIL}
+    
+    # Secret to store ACME account private key
+    privateKeySecretRef:
+      name: ${ISSUER_NAME}-account-key
+    
+    # DNS-01 challenge solver using RFC2136 (fake DNS for testing)
+    # With Pebble ALWAYS_VALID=1, this will auto-succeed
+    solvers:
+    - dns01:
+        # Using webhook solver with no actual DNS provider
+        # Pebble will auto-validate when ALWAYS_VALID=1
+        webhook:
+          groupName: acme.example.com
+          solverName: fake-dns-solver
+          config:
+            note: "This is a placeholder solver. Pebble ALWAYS_VALID=1 will auto-succeed all challenges."
+

--- a/yaml/issuers/pebble-dns01-simple-clusterissuer.yaml
+++ b/yaml/issuers/pebble-dns01-simple-clusterissuer.yaml
@@ -1,0 +1,34 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${ISSUER_NAME}
+spec:
+  acme:
+    # Pebble ACME server URL
+    server: ${ACME_SERVER_URL}
+    
+    # Skip TLS verification (Pebble uses self-signed certificates)
+    skipTLSVerify: true
+    
+    # Email for ACME account
+    email: ${ACME_EMAIL}
+    
+    # Secret to store ACME account private key
+    privateKeySecretRef:
+      name: ${ISSUER_NAME}-account-key
+    
+    # DNS-01 challenge solver
+    # With PEBBLE_ALWAYS_VALID=1, Pebble will auto-validate
+    # cert-manager will try to update DNS (and fail), but Pebble doesn't care
+    solvers:
+    - dns01:
+        rfc2136:
+          nameserver: ${DNS_SERVER}
+          tsigKeyName: dummy-key
+          tsigAlgorithm: HMACSHA256
+          tsigSecretSecretRef:
+            name: rfc2136-credentials
+            key: tsig-secret
+            # For ClusterIssuer, secret must be in cert-manager namespace
+            namespace: cert-manager
+

--- a/yaml/pebble-challtestsrv/deployment.yaml
+++ b/yaml/pebble-challtestsrv/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pebble-challtestsrv
+  namespace: ${PEBBLE_NAMESPACE}
+  labels:
+    app: pebble-challtestsrv
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pebble-challtestsrv
+  template:
+    metadata:
+      labels:
+        app: pebble-challtestsrv
+    spec:
+      containers:
+      - name: challtestsrv
+        image: letsencrypt/pebble-challtestsrv:latest
+        args:
+        - -defaultIPv4
+        - "127.0.0.1"
+        - -defaultIPv6
+        - ""
+        - -http01
+        - ":5002"
+        - -https01
+        - ":5001"
+        - -tlsalpn01
+        - ":5001"
+        - -management
+        - ":8055"
+        ports:
+        - name: dns-udp
+          containerPort: 8053
+          protocol: UDP
+        - name: dns-tcp
+          containerPort: 8053
+          protocol: TCP
+        - name: http01
+          containerPort: 5002
+          protocol: TCP
+        - name: management
+          containerPort: 8055
+          protocol: TCP
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "25m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+

--- a/yaml/pebble-challtestsrv/service.yaml
+++ b/yaml/pebble-challtestsrv/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pebble-challtestsrv
+  namespace: ${PEBBLE_NAMESPACE}
+  labels:
+    app: pebble-challtestsrv
+spec:
+  type: ClusterIP
+  ports:
+  - name: dns-udp
+    port: 8053
+    targetPort: 8053
+    protocol: UDP
+  - name: dns-tcp
+    port: 8053
+    targetPort: 8053
+    protocol: TCP
+  - name: management
+    port: 8055
+    targetPort: 8055
+    protocol: TCP
+  selector:
+    app: pebble-challtestsrv
+

--- a/yaml/pebble/configmap.yaml
+++ b/yaml/pebble/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pebble-config
+  namespace: ${PEBBLE_NAMESPACE}
+data:
+  pebble-config.json: |
+    {
+      "pebble": {
+        "listenAddress": "0.0.0.0:14000",
+        "managementListenAddress": "0.0.0.0:15000",
+        "certificate": "/test/certs/localhost/cert.pem",
+        "privateKey": "/test/certs/localhost/key.pem",
+        "httpPort": 80,
+        "tlsPort": 443,
+        "ocspResponderURL": "",
+        "externalAccountBindingRequired": false
+      }
+    }
+

--- a/yaml/pebble/deployment.yaml
+++ b/yaml/pebble/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pebble
+  namespace: ${PEBBLE_NAMESPACE}
+  labels:
+    app: pebble
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pebble
+  template:
+    metadata:
+      labels:
+        app: pebble
+    spec:
+      containers:
+      - name: pebble
+        image: letsencrypt/pebble:latest
+        args:
+        - pebble
+        - -config
+        - /test/config/pebble-config.json
+        - -dnsserver
+        - ${DNS_SERVER}
+        ports:
+        - name: acme
+          containerPort: 14000
+          protocol: TCP
+        - name: management
+          containerPort: 15000
+          protocol: TCP
+        env:
+        - name: PEBBLE_VA_NOSLEEP
+          value: "1"
+        - name: PEBBLE_VA_ALWAYS_VALID
+          value: "${PEBBLE_ALWAYS_VALID}"
+        volumeMounts:
+        - name: config
+          mountPath: /test/config
+          readOnly: true
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+      volumes:
+      - name: config
+        configMap:
+          name: pebble-config
+

--- a/yaml/pebble/namespace.yaml
+++ b/yaml/pebble/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${PEBBLE_NAMESPACE}
+  labels:
+    name: ${PEBBLE_NAMESPACE}
+    app: pebble
+

--- a/yaml/pebble/route.yaml
+++ b/yaml/pebble/route.yaml
@@ -1,0 +1,17 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: pebble-acme
+  namespace: ${PEBBLE_NAMESPACE}
+  labels:
+    app: pebble
+spec:
+  to:
+    kind: Service
+    name: pebble
+  port:
+    targetPort: acme
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: None
+

--- a/yaml/pebble/service.yaml
+++ b/yaml/pebble/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pebble
+  namespace: ${PEBBLE_NAMESPACE}
+  labels:
+    app: pebble
+spec:
+  type: ClusterIP
+  ports:
+  - name: acme
+    port: 14000
+    targetPort: 14000
+    protocol: TCP
+  - name: management
+    port: 15000
+    targetPort: 15000
+    protocol: TCP
+  selector:
+    app: pebble
+


### PR DESCRIPTION
This pull request introduces comprehensive documentation and automation improvements for DNS-01 challenge testing and network stack support in OpenShift clusters. It adds a detailed guide for fully local DNS-01 challenge workflows, a new document explaining IPv4/IPv6/dual-stack implications for cert-manager, and a robust, user-friendly Makefile to streamline installation, testing, and cleanup processes.

**Major documentation additions:**

* Added `DNS01-SETUP.md`, a step-by-step guide for setting up fully local DNS-01 challenge testing with acme-dns, Pebble, and cert-manager, eliminating the need for external DNS providers.
* Added `NETWORK-SUPPORT.md`, a comprehensive explanation of IPv4, IPv6, and dual-stack networking in OpenShift, with specific guidance for cert-manager and Pebble compatibility, scenario-based recommendations, and troubleshooting.

**Automation and usability enhancements:**

* Introduced a new `Makefile` providing targets for installing all components (cert-manager, Pebble, fake DNS), creating issuers and certificates, performing end-to-end DNS-01 tests, and cleaning up resources, significantly simplifying the test workflow for users.
* The Makefile also includes network checking, verification, and detailed help output, improving accessibility for new users.