### PR TITLE
Add shared library and improve tooling to align with compliance-scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,43 @@
+# .env.example - Configuration template for cert-manager-scripts
+# Copy to .env and customize for your environment
+
+# ============================================================================
+# OPERATOR CONFIGURATION
+# ============================================================================
+
+# Namespace for cert-manager operator
+OPERATOR_NAMESPACE=cert-manager-operator
+
+# Namespace for cert-manager components
+CERT_MANAGER_NAMESPACE=cert-manager
+
+# Operator subscription channel
+CHANNEL=stable-v1
+
+# ============================================================================
+# PEBBLE TEST SERVER
+# ============================================================================
+
+# Pebble namespace
+PEBBLE_NAMESPACE=pebble
+
+# Set to 1 to make Pebble validate all challenges (no actual DNS/HTTP check)
+# Useful for quick testing without real challenge validation
+# PEBBLE_ALWAYS_VALID=1
+
+# DNS server for DNS-01 challenges (for air-gapped testing)
+# DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53
+
+# ============================================================================
+# LOGGING
+# ============================================================================
+
+# Log verbosity level: quiet, error, warn, info, debug
+LOG_LEVEL=info
+
+# ============================================================================
+# DRY-RUN MODE
+# ============================================================================
+
+# Set to true to preview changes without applying
+# DRY_RUN=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Scripts for testing and managing cert-manager-operator on OpenShift clusters with local ACME testing using Pebble. Provides a complete workflow for testing certificate issuance without requiring public DNS or internet connectivity.
+
+## Common Commands
+
+### Quick Start
+```bash
+make install-cert-manager-operator  # Install cert-manager-operator
+make quick-test                     # Setup Pebble, fake DNS, and test wildcard cert
+make clean                          # Clean up when done
+```
+
+### Verification
+```bash
+make verify-cert  # Check certificate progress
+```
+
+### Individual Steps
+```bash
+make install-pebble
+make install-fake-dns
+make create-issuer
+make request-cert
+```
+
+## Architecture
+
+- **`scripts/`** - Main automation scripts
+- **`yaml/`** - Kubernetes/OpenShift manifests
+- **`guide/`** - Step-by-step guides
+- **`docs/`** - Additional documentation
+
+## Key Documentation
+
+| File | Description |
+|------|-------------|
+| `INSTALLATION.md` | Cert-manager installation guide |
+| `DNS01-SETUP.md` | DNS-01 challenge configuration |
+| `PEBBLE-USAGE.md` | Using Pebble for local ACME testing |
+| `NETWORK-SUPPORT.md` | Network configuration details |
+| `TROUBLESHOOTING.md` | Common issues and solutions |
+| `CONTRIBUTING.md` | Contribution guidelines |
+
+## What is Pebble?
+
+Pebble is a small ACME test server from Let's Encrypt that runs locally in your cluster. Test cert-manager without rate limits, public DNS, or internet connectivity.
+
+## Requirements
+
+- OpenShift cluster (4.20+)
+- `oc` CLI with cluster-admin privileges
+- `envsubst` command (`brew install gettext` on macOS)
+
+## Code Style
+
+### Bash
+- Use `shellcheck` for linting
+- Follow Makefile conventions for targets
+- Include helpful comments and usage information

--- a/Makefile
+++ b/Makefile
@@ -1,222 +1,159 @@
-.PHONY: help lint check-network check-workload-partitioning install-cert-manager-operator install-pebble install-fake-dns install-all create-issuer create-dns01-issuer create-certs test-all test-dns01 quick-http-test quick-dns-test test-cert verify-cert troubleshoot check-cert check-issuer diagnose-http01 diagnose-dns01 clean clean-certs clean-pebble clean-fake-dns clean-dns-config clean-issuers clean-temp uninstall-cert-manager-operator
+# ────────────────────────────────────────────────────────────────────────────────
+# Color Definitions
+# ────────────────────────────────────────────────────────────────────────────────
+RESET := \033[0m
+BOLD := \033[1m
+DIM := \033[2m
+
+# Text Colors
+RED := \033[31m
+GREEN := \033[32m
+YELLOW := \033[33m
+BLUE := \033[34m
+MAGENTA := \033[35m
+CYAN := \033[36m
+WHITE := \033[37m
+
+# Background Colors
+BG_RED := \033[41m
+BG_GREEN := \033[42m
+BG_YELLOW := \033[43m
+BG_BLUE := \033[44m
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Target Definitions
+# ────────────────────────────────────────────────────────────────────────────────
+.PHONY: all help banner preflight lint install-cert-manager-operator install-pebble \
+        install-fake-dns install-all create-issuer create-dns01-issuer create-certs \
+        test-all test-dns01 quick-http-test quick-dns-test test-cert verify-cert \
+        troubleshoot check-cert check-issuer check-network check-workload-partitioning \
+        diagnose-http01 diagnose-dns01 clean clean-certs clean-pebble clean-fake-dns \
+        clean-dns-config clean-issuers clean-temp uninstall-cert-manager-operator
 
 # Default target
-help:
-	@echo "cert-manager-scripts Makefile"
+all: help
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Main Targets
+# ────────────────────────────────────────────────────────────────────────────────
+
+banner:
 	@echo ""
-	@echo "Available targets:"
-	@echo "  lint                            - Check shell script formatting with shfmt"
-	@echo "  check-network                   - Check cluster network configuration (IPv4/IPv6/Dual-stack)"
-	@echo "  check-workload-partitioning     - Verify cert-manager pods are not using workload partitioning"
-	@echo "  install-cert-manager-operator   - Install cert-manager Operator for Red Hat OpenShift"
-	@echo "  install-pebble                  - Install Pebble ACME test server"
-	@echo "  install-fake-dns                - Install fake DNS API for air-gapped DNS-01 testing"
-	@echo "  install-all                     - Install cert-manager-operator and Pebble"
-	@echo "  create-issuer                   - Create ClusterIssuer pointing to Pebble (HTTP-01)"
-	@echo "  create-dns01-issuer             - Create ClusterIssuer pointing to Pebble (DNS-01)"
-	@echo "  create-certs                    - Create test certificates (HTTP-01)"
-	@echo "  test-all                        - Complete HTTP-01 setup"
-	@echo "  test-dns01                      - Complete DNS-01 setup (air-gapped)"
-	@echo "  quick-http-test                 - Quick end-to-end HTTP-01 test (setup + test + verify)"
-	@echo "  quick-dns-test                  - Quick end-to-end DNS-01 test (setup + test + verify)"
-	@echo "  test-cert                       - Create a test wildcard certificate"
-	@echo "  verify-cert                     - Verify certificate status"
-	@echo "  troubleshoot                    - Run all troubleshooting diagnostics"
-	@echo "  check-cert CERT=<name> NS=<ns>  - Check specific certificate status"
-	@echo "  check-issuer ISSUER=<name>      - Check specific ClusterIssuer status"
-	@echo "  diagnose-http01                 - Diagnose HTTP-01 challenge issues"
-	@echo "  diagnose-dns01                  - Diagnose DNS-01 challenge issues"
-	@echo "  clean                           - Clean up all resources (keeps cert-manager-operator)"
-	@echo "  clean-certs                     - Clean up certificates and challenges only"
-	@echo "  clean-pebble                    - Clean up Pebble only"
-	@echo "  clean-fake-dns                  - Clean up fake DNS only"
-	@echo "  clean-issuers                   - Clean up ClusterIssuers only"
-	@echo "  clean-temp                      - Clean up temporary files"
-	@echo "  uninstall-cert-manager-operator - Uninstall cert-manager Operator (WARNING!)"
-	@echo "  help                            - Show this help message"
+	@echo "$(CYAN)$(BOLD)"
+	@echo "  ╔═══════════════════════════════════════════════════════════════╗"
+	@echo "  ║         CERT-MANAGER SCRIPTS TOOLKIT              ║"
+	@echo "  ║             OpenShift Automation                              ║"
+	@echo "  ╚═══════════════════════════════════════════════════════════════╝"
+	@echo "$(RESET)"
+
+help: banner ## Show this help message
+	@echo "$(BOLD)$(BLUE)Available Commands:$(RESET)"
+	@echo ""
+	@echo "$(YELLOW)Setup & Validation:$(RESET)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(preflight|lint|check-network|check-workload)"
+	@echo ""
+	@echo "$(YELLOW)Installation:$(RESET)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(install-)"
+	@echo ""
+	@echo "$(YELLOW)Issuers & Certificates:$(RESET)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(create-|test-cert|verify-cert)"
+	@echo ""
+	@echo "$(YELLOW)Quick Tests:$(RESET)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(quick-|test-all|test-dns01)"
+	@echo ""
+	@echo "$(YELLOW)Troubleshooting:$(RESET)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(troubleshoot|diagnose|check-cert|check-issuer)"
+	@echo ""
+	@echo "$(YELLOW)Cleanup:$(RESET)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(clean|uninstall)"
+	@echo ""
+	@echo "$(DIM)Usage: make <command>$(RESET)"
 	@echo ""
 
-# Lint shell scripts with shfmt
-lint:
-	@echo "Checking shell script formatting..."
-	@if command -v shfmt > /dev/null 2>&1; then \
-		shfmt -d scripts/; \
-		if [ $$? -eq 0 ]; then \
-			echo "✓ All shell scripts are properly formatted"; \
-		else \
-			echo "✗ Shell script formatting issues found"; \
-			echo "Run 'shfmt -w scripts/' to fix formatting"; \
-			exit 1; \
-		fi \
-	else \
-		echo "Error: shfmt not found. Install it with:"; \
-		echo "  macOS: brew install shfmt"; \
-		echo "  Linux: go install mvdan.cc/sh/v3/cmd/shfmt@latest"; \
-		exit 1; \
+# ────────────────────────────────────────────────────────────────────────────────
+# Setup & Validation
+# ────────────────────────────────────────────────────────────────────────────────
+
+preflight: ## Check all dependencies and prerequisites
+	@./scripts/preflight-check.sh
+	@echo ""
+
+lint: ## Check shell script formatting with shfmt and shellcheck
+	@echo "$(BOLD)$(BLUE)Linting Bash scripts...$(RESET)"
+	@if ! command -v shellcheck >/dev/null 2>&1; then \
+	  echo "$(RED)shellcheck not found. Please install it:$(RESET)"; \
+	  echo "$(DIM)  macOS: brew install shellcheck$(RESET)"; \
+	  echo "$(DIM)  Linux: apt-get install shellcheck or dnf install ShellCheck$(RESET)"; \
+	  exit 1; \
 	fi
+	@echo "$(DIM)  Running shellcheck...$(RESET)"
+	@find . -name '*.sh' -type f -not -path './venv/*' | xargs shellcheck -e SC1091,SC2034,SC2086,SC2155,SC2046,SC2181,SC2126,SC2329 || (echo "$(RED)shellcheck failed!$(RESET)" && exit 1)
+	@if ! command -v shfmt >/dev/null 2>&1; then \
+	  echo "$(RED)shfmt not found. Please install it:$(RESET)"; \
+	  echo "$(DIM)  macOS: brew install shfmt$(RESET)"; \
+	  echo "$(DIM)  Linux: go install mvdan.cc/sh/v3/cmd/shfmt@latest$(RESET)"; \
+	  exit 1; \
+	fi
+	@echo "$(DIM)  Running shfmt...$(RESET)"
+	@shfmt -d scripts/ lib/ || (echo "$(RED)shfmt formatting check failed!$(RESET)" && echo "$(YELLOW)To fix: shfmt -w scripts/ lib/$(RESET)" && exit 1)
+	@echo "$(GREEN)Bash linting passed!$(RESET)"
 
-# Check cluster network configuration
-check-network:
+check-network: ## Check cluster network configuration (IPv4/IPv6/Dual-stack)
 	@./scripts/check-cluster-network.sh
 
-# Check workload partitioning configuration
-check-workload-partitioning:
+check-workload-partitioning: ## Verify cert-manager pods are not using workload partitioning
 	@./scripts/troubleshooting/check-workload-partitioning.sh
 
-# Install cert-manager-operator
-install-cert-manager-operator:
-	@echo "Installing cert-manager Operator for Red Hat OpenShift..."
+# ────────────────────────────────────────────────────────────────────────────────
+# Installation
+# ────────────────────────────────────────────────────────────────────────────────
+
+install-cert-manager-operator: ## Install cert-manager Operator for Red Hat OpenShift
+	@echo "$(BOLD)$(BLUE)Installing cert-manager Operator...$(RESET)"
 	@./scripts/install-cert-manager-operator.sh
-
-# Install Pebble ACME test server
-install-pebble:
-	@echo "Installing Pebble ACME test server..."
-	@./scripts/install-pebble.sh
-
-# Install fake DNS API
-install-fake-dns:
-	@echo "Installing fake DNS API for air-gapped testing..."
-	@./scripts/install-fake-dns.sh
-
-# Install everything
-install-all: install-cert-manager-operator install-pebble
+	@echo "$(GREEN)cert-manager Operator installation completed!$(RESET)"
 	@echo ""
-	@echo "All components installed successfully!"
 
-# Create ClusterIssuer pointing to Pebble (HTTP-01)
-create-issuer:
+install-pebble: ## Install Pebble ACME test server
+	@echo "$(BOLD)$(BLUE)Installing Pebble ACME test server...$(RESET)"
+	@./scripts/install-pebble.sh
+	@echo ""
+
+install-fake-dns: ## Install fake DNS API for air-gapped DNS-01 testing
+	@echo "$(BOLD)$(BLUE)Installing fake DNS API for air-gapped testing...$(RESET)"
+	@./scripts/install-fake-dns.sh
+	@echo ""
+
+install-all: install-cert-manager-operator install-pebble ## Install cert-manager-operator and Pebble
+	@echo ""
+	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
+	@echo "  ╔═════════════════════════════════════════════════════════════╗"
+	@echo "  ║         All components installed successfully!              ║"
+	@echo "  ╚═════════════════════════════════════════════════════════════╝"
+	@echo "$(RESET)"
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Issuers & Certificates
+# ────────────────────────────────────────────────────────────────────────────────
+
+create-issuer: ## Create ClusterIssuer pointing to Pebble (HTTP-01)
 	@./scripts/create-issuer.sh
 
-# Create ClusterIssuer pointing to Pebble (DNS-01)
-create-dns01-issuer:
+create-dns01-issuer: ## Create ClusterIssuer pointing to Pebble (DNS-01)
 	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 ./scripts/create-dns01-issuer.sh
 
-# Create test certificates
-create-certs:
+create-certs: ## Create test certificates (HTTP-01)
 	@./scripts/create-test-certificates.sh
 
-# Complete test setup: install everything + create issuer + create certificates
-test-all: install-all create-issuer create-certs
-	@echo ""
-	@echo "========================================" 
-	@echo "  Complete Test Environment Ready!"
-	@echo "========================================"
-	@echo ""
-	@echo "You can now test certificate issuance with:"
-	@echo "  oc get certificate -A"
-	@echo "  oc get order,challenge -A"
-
-# Complete DNS-01 test setup (air-gapped)
-test-dns01: install-fake-dns
-	@echo "Reinstalling Pebble with fake DNS..."
-	@oc delete namespace pebble --ignore-not-found=true
-	@sleep 10
-	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 PEBBLE_ALWAYS_VALID=1 ./scripts/install-pebble.sh
-	@echo ""
-	@echo "Creating DNS-01 issuer..."
-	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 ./scripts/create-dns01-issuer.sh
-	@echo ""
-	@echo "========================================"
-	@echo "  DNS-01 Environment Ready!"
-	@echo "========================================"
-	@echo ""
-	@echo "Test with a wildcard certificate:"
-	@echo "  oc apply -f - <<EOF"
-	@echo "  apiVersion: cert-manager.io/v1"
-	@echo "  kind: Certificate"
-	@echo "  metadata:"
-	@echo "    name: wildcard-test"
-	@echo "    namespace: default"
-	@echo "  spec:"
-	@echo "    secretName: wildcard-test-tls"
-	@echo "    issuerRef:"
-	@echo "      name: pebble-dns01-issuer"
-	@echo "      kind: ClusterIssuer"
-	@echo "    dnsNames:"
-	@echo "    - '*.example.com'"
-	@echo "    - 'example.com'"
-	@echo "  EOF"
-	@echo ""
-	@echo "Monitor progress:"
-	@echo "  watch oc get certificate -n default"
-
-# Quick end-to-end HTTP-01 test
-quick-http-test: install-cert-manager-operator
-	@echo ""
-	@echo "========================================"
-	@echo "  Quick HTTP-01 Test Running..."
-	@echo "========================================"
-	@echo ""
-	@echo "Installing Pebble with ALWAYS_VALID..."
-	@PEBBLE_ALWAYS_VALID=1 $(MAKE) install-pebble || true
-	@echo ""
-	@echo "Creating HTTP-01 ClusterIssuer..."
-	@$(MAKE) create-issuer || true
-	@echo ""
-	@echo "Creating test certificate..."
-	@CLUSTER_DOMAIN=$$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "apps-crc.testing"); \
-	printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: test-cert-http01\n  namespace: default\nspec:\n  secretName: test-cert-http01-tls\n  issuerRef:\n    name: pebble-issuer\n    kind: ClusterIssuer\n  dnsNames:\n  - test.'"$$CLUSTER_DOMAIN"'\n' | oc apply -f -
-	@echo ""
-	@echo "Waiting for certificate to be issued (timeout: 3 minutes)..."
-	@timeout=180; \
-	elapsed=0; \
-	while [ $$elapsed -lt $$timeout ]; do \
-		if oc get certificate test-cert-http01 -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
-			echo "✅ Certificate issued successfully!"; \
-			oc get certificate test-cert-http01 -n default; \
-			break; \
-		fi; \
-		if [ $$((elapsed % 10)) -eq 0 ]; then \
-			echo "  ⏳ Still waiting... ($$elapsed seconds elapsed)"; \
-		fi; \
-		sleep 2; \
-		elapsed=$$((elapsed + 2)); \
-	done
-	@echo ""
-	@echo "Certificate details:"
-	@oc get certificate test-cert-http01 -n default 2>/dev/null || echo "Certificate not found"
-	@echo ""
-	@echo "Quick HTTP-01 test complete! Run 'make clean' to clean up."
-
-# Quick end-to-end DNS-01 test
-quick-dns-test: test-dns01 test-cert
-	@echo ""
-	@echo "========================================"
-	@echo "  Quick DNS-01 Test Running..."
-	@echo "========================================"
-	@echo ""
-	@echo "Waiting for certificate to be issued (timeout: 5 minutes)..."
-	@timeout=300; \
-	elapsed=0; \
-	while [ $$elapsed -lt $$timeout ]; do \
-		if oc get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
-			echo "✅ Certificate issued successfully!"; \
-			break; \
-		fi; \
-		if [ $$((elapsed % 10)) -eq 0 ]; then \
-			echo "  ⏳ Still waiting... ($$elapsed seconds elapsed)"; \
-		fi; \
-		sleep 2; \
-		elapsed=$$((elapsed + 2)); \
-	done
-	@echo ""
-	@$(MAKE) verify-cert
-	@echo ""
-	@echo "Quick DNS-01 test complete! Run 'make clean' to clean up."
-
-# Create a test wildcard certificate
-test-cert:
+test-cert: ## Create a test wildcard certificate (DNS-01)
 	@echo "Creating test wildcard certificate..."
 	@printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: wildcard-test\n  namespace: default\nspec:\n  secretName: wildcard-test-tls\n  issuerRef:\n    name: pebble-dns01-issuer\n    kind: ClusterIssuer\n  dnsNames:\n  - "*.example.com"\n  - "example.com"\n' | oc apply -f -
 	@echo "Certificate created. Run 'make verify-cert' to check status."
 
-# Verify certificate status
-verify-cert:
+verify-cert: ## Verify certificate status
 	@echo ""
-	@echo "========================================"
-	@echo "  Certificate Status"
-	@echo "========================================"
-	@echo ""
+	@echo "$(BOLD)Certificate Status$(RESET)"
+	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	@oc get certificate wildcard-test -n default 2>/dev/null || echo "Certificate not found"
 	@echo ""
 	@echo "Orders:"
@@ -226,114 +163,172 @@ verify-cert:
 	@oc get challenge -n default 2>/dev/null || echo "No challenges found"
 	@echo ""
 	@if oc get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
-		echo "✅ Certificate is READY!"; \
-		echo ""; \
-		echo "View certificate details:"; \
-		echo "  oc get secret wildcard-test-tls -n default -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout"; \
+		echo "$(GREEN)Certificate is READY!$(RESET)"; \
 	else \
-		echo "⏳ Certificate is still being issued..."; \
-		echo ""; \
-		echo "Monitor progress with:"; \
-		echo "  watch oc get certificate -n default"; \
-		echo ""; \
-		echo "Check challenges:"; \
-		echo "  oc get challenge -n default"; \
-		echo ""; \
-		echo "Check logs:"; \
-		echo "  oc logs -n cert-manager deployment/cert-manager --tail=50"; \
+		echo "$(YELLOW)Certificate is still being issued...$(RESET)"; \
 	fi
 
-# Run all troubleshooting diagnostics
-troubleshoot:
+# ────────────────────────────────────────────────────────────────────────────────
+# Quick Tests
+# ────────────────────────────────────────────────────────────────────────────────
+
+test-all: install-all create-issuer create-certs ## Complete HTTP-01 setup (install + issuer + certs)
+	@echo ""
+	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
+	@echo "  ╔═════════════════════════════════════════════════════════════╗"
+	@echo "  ║         Complete Test Environment Ready!                    ║"
+	@echo "  ╚═════════════════════════════════════════════════════════════╝"
+	@echo "$(RESET)"
+	@echo ""
+	@echo "You can now test certificate issuance with:"
+	@echo "  oc get certificate -A"
+	@echo "  oc get order,challenge -A"
+
+test-dns01: install-fake-dns ## Complete DNS-01 setup (air-gapped)
+	@echo "Reinstalling Pebble with fake DNS..."
+	@oc delete namespace pebble --ignore-not-found=true
+	@sleep 10
+	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 PEBBLE_ALWAYS_VALID=1 ./scripts/install-pebble.sh
+	@echo ""
+	@echo "Creating DNS-01 issuer..."
+	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 ./scripts/create-dns01-issuer.sh
+	@echo ""
+	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
+	@echo "  ╔═════════════════════════════════════════════════════════════╗"
+	@echo "  ║         DNS-01 Environment Ready!                           ║"
+	@echo "  ╚═════════════════════════════════════════════════════════════╝"
+	@echo "$(RESET)"
+	@echo ""
+	@echo "Test with: make test-cert"
+	@echo "Monitor progress: watch oc get certificate -n default"
+
+quick-http-test: install-cert-manager-operator ## Quick end-to-end HTTP-01 test
+	@echo ""
+	@echo "$(BOLD)$(BLUE)Quick HTTP-01 Test Running...$(RESET)"
+	@echo ""
+	@PEBBLE_ALWAYS_VALID=1 $(MAKE) install-pebble || true
+	@$(MAKE) create-issuer || true
+	@CLUSTER_DOMAIN=$$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "apps-crc.testing"); \
+	printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: test-cert-http01\n  namespace: default\nspec:\n  secretName: test-cert-http01-tls\n  issuerRef:\n    name: pebble-issuer\n    kind: ClusterIssuer\n  dnsNames:\n  - test.'"$$CLUSTER_DOMAIN"'\n' | oc apply -f -
+	@echo ""
+	@echo "Waiting for certificate (timeout: 3 minutes)..."
+	@timeout=180; elapsed=0; \
+	while [ $$elapsed -lt $$timeout ]; do \
+		if oc get certificate test-cert-http01 -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+			echo "$(GREEN)Certificate issued successfully!$(RESET)"; \
+			break; \
+		fi; \
+		if [ $$((elapsed % 10)) -eq 0 ]; then echo "  Still waiting... ($$elapsed seconds)"; fi; \
+		sleep 2; elapsed=$$((elapsed + 2)); \
+	done
+	@echo ""
+	@echo "Quick HTTP-01 test complete! Run 'make clean' to clean up."
+
+quick-dns-test: test-dns01 test-cert ## Quick end-to-end DNS-01 test
+	@echo ""
+	@echo "$(BOLD)$(BLUE)Quick DNS-01 Test Running...$(RESET)"
+	@echo ""
+	@echo "Waiting for certificate (timeout: 5 minutes)..."
+	@timeout=300; elapsed=0; \
+	while [ $$elapsed -lt $$timeout ]; do \
+		if oc get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+			echo "$(GREEN)Certificate issued successfully!$(RESET)"; \
+			break; \
+		fi; \
+		if [ $$((elapsed % 10)) -eq 0 ]; then echo "  Still waiting... ($$elapsed seconds)"; fi; \
+		sleep 2; elapsed=$$((elapsed + 2)); \
+	done
+	@$(MAKE) verify-cert
+	@echo ""
+	@echo "Quick DNS-01 test complete! Run 'make clean' to clean up."
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Troubleshooting
+# ────────────────────────────────────────────────────────────────────────────────
+
+troubleshoot: ## Run all troubleshooting diagnostics
 	@./scripts/troubleshooting/check-all.sh
 
-# Check specific certificate
-check-cert:
+check-cert: ## Check specific certificate (CERT=name NS=namespace)
 	@if [ -z "$(CERT)" ] || [ -z "$(NS)" ]; then \
-		echo "Usage: make check-cert CERT=<certificate-name> NS=<namespace>"; \
-		echo "Example: make check-cert CERT=test-cert-simple NS=default"; \
+		echo "$(YELLOW)Usage: make check-cert CERT=<name> NS=<namespace>$(RESET)"; \
+		echo "$(DIM)Example: make check-cert CERT=test-cert NS=default$(RESET)"; \
 		exit 1; \
 	fi
 	@./scripts/troubleshooting/check-certificate.sh $(CERT) $(NS)
 
-# Check specific issuer
-check-issuer:
+check-issuer: ## Check specific ClusterIssuer (ISSUER=name)
 	@if [ -z "$(ISSUER)" ]; then \
-		echo "Usage: make check-issuer ISSUER=<issuer-name>"; \
-		echo "Example: make check-issuer ISSUER=pebble-issuer"; \
+		echo "$(YELLOW)Usage: make check-issuer ISSUER=<name>$(RESET)"; \
+		echo "$(DIM)Example: make check-issuer ISSUER=pebble-issuer$(RESET)"; \
 		exit 1; \
 	fi
 	@./scripts/troubleshooting/check-issuer.sh $(ISSUER)
 
-# Diagnose HTTP-01 issues
-diagnose-http01:
+diagnose-http01: ## Diagnose HTTP-01 challenge issues
 	@./scripts/troubleshooting/diagnose-http01.sh
 
-# Diagnose DNS-01 issues
-diagnose-dns01:
+diagnose-dns01: ## Diagnose DNS-01 challenge issues
 	@./scripts/troubleshooting/diagnose-dns01.sh
 
+# ────────────────────────────────────────────────────────────────────────────────
+# Cleanup
+# ────────────────────────────────────────────────────────────────────────────────
 
-# Clean up certificates, orders, and challenges
-clean-certs:
-	@echo "Cleaning up certificates, orders, and challenges..."
+clean-certs: ## Clean up certificates, orders, and challenges
+	@echo "$(BOLD)$(YELLOW)Cleaning up certificates...$(RESET)"
 	@oc delete certificates --all -n default --ignore-not-found=true
 	@oc delete certificaterequests --all -n default --ignore-not-found=true
 	@oc delete orders --all -n default --ignore-not-found=true
 	@oc delete challenges --all -n default --ignore-not-found=true
-	@oc delete secrets wildcard-test-tls test-cert-simple-tls test-cert-app-tls test-cert-api-tls -n default --ignore-not-found=true
-	@echo "Certificates cleaned."
+	@oc delete secrets wildcard-test-tls test-cert-simple-tls test-cert-app-tls test-cert-api-tls test-cert-http01-tls -n default --ignore-not-found=true
+	@echo "$(GREEN)Certificates cleaned.$(RESET)"
 
-# Clean up Pebble
-clean-pebble:
-	@echo "Cleaning up Pebble..."
+clean-pebble: ## Clean up Pebble ACME test server
+	@echo "$(BOLD)$(YELLOW)Cleaning up Pebble...$(RESET)"
 	@oc delete namespace pebble --ignore-not-found=true
 	@oc delete secret pebble-dns01-issuer-account-key pebble-issuer-account-key -n cert-manager --ignore-not-found=true
-	@echo "Pebble cleaned."
+	@echo "$(GREEN)Pebble cleaned.$(RESET)"
 
-# Clean up fake DNS
-clean-fake-dns:
-	@echo "Cleaning up fake DNS..."
+clean-fake-dns: ## Clean up fake DNS API
+	@echo "$(BOLD)$(YELLOW)Cleaning up fake DNS...$(RESET)"
 	@oc delete namespace fake-dns --ignore-not-found=true
-	@echo "Fake DNS cleaned."
+	@echo "$(GREEN)Fake DNS cleaned.$(RESET)"
 
-# Clean up DNS configuration
-clean-dns-config:
+clean-dns-config: ## Restore DNS configuration
 	@echo "Restoring DNS configuration..."
 	@oc patch dns.operator.openshift.io/default --type=json -p='[{"op": "remove", "path": "/spec/servers"}]' 2>/dev/null || true
 	@echo "DNS configuration restored."
 
-# Clean up ClusterIssuers
-clean-issuers:
-	@echo "Cleaning up ClusterIssuers..."
+clean-issuers: ## Clean up ClusterIssuers
+	@echo "$(BOLD)$(YELLOW)Cleaning up ClusterIssuers...$(RESET)"
 	@oc delete clusterissuer pebble-issuer pebble-dns01-issuer --ignore-not-found=true
 	@oc delete secret rfc2136-credentials -n default --ignore-not-found=true
-	@echo "ClusterIssuers cleaned."
+	@echo "$(GREEN)ClusterIssuers cleaned.$(RESET)"
 
-# Clean everything except cert-manager-operator
-clean: clean-certs clean-issuers clean-pebble clean-fake-dns clean-dns-config
-	@echo ""
-	@echo "========================================"
-	@echo "  Cleanup Complete!"
-	@echo "========================================"
-	@echo ""
-	@echo "cert-manager-operator is still installed."
-	@echo "To test again, run: make test-dns01"
-
-# Clean temporary files
-clean-temp:
+clean-temp: ## Clean up temporary files
 	@echo "Cleaning temporary files..."
 	@find . -name "*.tmp" -delete
 	@find . -name ".*.swp" -delete
 	@echo "Temp files cleaned."
 
-# Uninstall cert-manager-operator (use with caution)
-uninstall-cert-manager-operator:
-	@echo "WARNING: This will uninstall cert-manager-operator!"
+clean: clean-certs clean-issuers clean-pebble clean-fake-dns clean-dns-config ## Clean everything except cert-manager-operator
+	@echo ""
+	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
+	@echo "  ╔═════════════════════════════════════════════════════════════╗"
+	@echo "  ║                  Cleanup Complete!                          ║"
+	@echo "  ╚═════════════════════════════════════════════════════════════╝"
+	@echo "$(RESET)"
+	@echo ""
+	@echo "cert-manager-operator is still installed."
+	@echo "To test again, run: make test-dns01"
+
+uninstall-cert-manager-operator: ## Uninstall cert-manager Operator (WARNING!)
+	@echo "$(RED)$(BOLD)WARNING: This will uninstall cert-manager-operator!$(RESET)"
 	@echo "Press Ctrl+C to cancel, or Enter to continue..."
 	@read confirm
 	@echo "Uninstalling cert-manager-operator..."
 	@oc delete subscription cert-manager-operator -n openshift-cert-manager-operator --ignore-not-found=true
 	@oc delete csv -n openshift-cert-manager-operator -l operators.coreos.com/cert-manager-operator.openshift-cert-manager-operator --ignore-not-found=true
 	@oc delete namespace openshift-cert-manager-operator --ignore-not-found=true
-	@echo "cert-manager-operator uninstalled."
+	@echo "$(GREEN)cert-manager-operator uninstalled.$(RESET)"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+# common.sh - Shared functions for cert-manager-scripts
+#
+# Usage: Source this file at the top of your scripts:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+#   source "$SCRIPT_DIR/lib/common.sh"
+#
+# Features:
+#   - Colorized logging with log levels (LOG_LEVEL=quiet|error|warn|info|debug)
+#   - Dependency checking (require_cmd)
+#   - Cluster connectivity validation (require_cluster)
+#   - .env file loading (load_env)
+#   - Cleanup trap setup (setup_cleanup)
+#   - Retry logic with exponential backoff (retry)
+#   - Summary output (print_summary)
+
+set -euo pipefail
+
+# ============================================================================
+# COLOR DEFINITIONS
+# ============================================================================
+# Only use colors if terminal supports it
+if [[ -t 1 ]]; then
+	RED='\033[0;31m'
+	GREEN='\033[0;32m'
+	YELLOW='\033[1;33m'
+	BLUE='\033[0;34m'
+	BOLD='\033[1m'
+	NC='\033[0m' # No Color
+else
+	RED=''
+	GREEN=''
+	YELLOW=''
+	BLUE=''
+	BOLD=''
+	NC=''
+fi
+
+# ============================================================================
+# LOG LEVELS
+# ============================================================================
+# Log levels: 0=quiet, 1=error, 2=warn, 3=info (default), 4=debug
+# Set via environment variable: LOG_LEVEL=quiet|error|warn|info|debug
+_LOG_LEVEL="${LOG_LEVEL:-3}"
+
+# Normalize string log levels to numeric (portable for bash 3.x on macOS)
+_LOG_LEVEL_LOWER=$(echo "$_LOG_LEVEL" | tr '[:upper:]' '[:lower:]')
+case "$_LOG_LEVEL_LOWER" in
+quiet | q) _LOG_LEVEL=0 ;;
+error | e) _LOG_LEVEL=1 ;;
+warn | w) _LOG_LEVEL=2 ;;
+info | i) _LOG_LEVEL=3 ;;
+debug | d) _LOG_LEVEL=4 ;;
+[0-4]) ;; # Already numeric
+*)
+	echo "[WARN] Invalid LOG_LEVEL '$_LOG_LEVEL', using 'info'" >&2
+	_LOG_LEVEL=3
+	;;
+esac
+readonly LOG_LEVEL=$_LOG_LEVEL
+
+# ============================================================================
+# LOGGING FUNCTIONS
+# ============================================================================
+log_error() {
+	[[ $LOG_LEVEL -ge 1 ]] && echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+log_warn() {
+	[[ $LOG_LEVEL -ge 2 ]] && echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+log_info() {
+	[[ $LOG_LEVEL -ge 3 ]] && echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+log_success() {
+	[[ $LOG_LEVEL -ge 3 ]] && echo -e "${GREEN}[SUCCESS]${NC} $*"
+}
+
+log_debug() {
+	[[ $LOG_LEVEL -ge 4 ]] && echo -e "${BOLD}[DEBUG]${NC} $*"
+}
+
+# ============================================================================
+# DEPENDENCY CHECKING
+# ============================================================================
+# Check if required commands are available
+# Usage: require_cmd oc yq jq
+require_cmd() {
+	for cmd in "$@"; do
+		if ! command -v "$cmd" &>/dev/null; then
+			log_error "Required command not found: '$cmd'"
+			case "$cmd" in
+			oc) log_info "  Install OpenShift CLI: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html" ;;
+			yq) log_info "  Install yq: brew install yq (macOS) or https://github.com/mikefarah/yq" ;;
+			jq) log_info "  Install jq: brew install jq (macOS) or apt install jq (Linux)" ;;
+			envsubst) log_info "  Install gettext: brew install gettext (macOS) or dnf install gettext (Fedora)" ;;
+			esac
+			exit 1
+		fi
+	done
+}
+
+# ============================================================================
+# CLUSTER CONNECTIVITY
+# ============================================================================
+# Verify cluster connectivity
+# Usage: require_cluster
+require_cluster() {
+	if ! command -v oc &>/dev/null; then
+		log_error "OpenShift CLI (oc) not found."
+		exit 1
+	fi
+
+	if ! oc whoami &>/dev/null 2>&1; then
+		log_error "Not connected to OpenShift cluster. Run 'oc login' first."
+		exit 1
+	fi
+
+	log_debug "Connected to cluster as: $(oc whoami)"
+	log_debug "Cluster: $(oc whoami --show-server 2>/dev/null || echo 'unknown')"
+}
+
+# ============================================================================
+# ENVIRONMENT LOADING
+# ============================================================================
+# Load .env file if present
+# Usage: load_env [optional_path]
+load_env() {
+	local env_file="${1:-.env}"
+
+	# Look for .env in script directory or parent
+	if [[ ! -f "$env_file" && -n "${SCRIPT_DIR:-}" ]]; then
+		if [[ -f "$SCRIPT_DIR/.env" ]]; then
+			env_file="$SCRIPT_DIR/.env"
+		elif [[ -f "$SCRIPT_DIR/../.env" ]]; then
+			env_file="$SCRIPT_DIR/../.env"
+		fi
+	fi
+
+	if [[ -f "$env_file" ]]; then
+		log_debug "Loading environment from: $env_file"
+		set -a
+		# shellcheck source=/dev/null
+		source "$env_file"
+		set +a
+	fi
+}
+
+# ============================================================================
+# CLEANUP HANDLING
+# ============================================================================
+# Track start time and set up cleanup trap
+# Usage: setup_cleanup
+_START_TIME=""
+_TEMP_FILES=()
+
+setup_cleanup() {
+	_START_TIME=$(date +%s)
+
+	cleanup() {
+		local exit_code=$?
+		local duration=$(($(date +%s) - _START_TIME))
+
+		# Clean up temp files
+		for f in "${_TEMP_FILES[@]:-}"; do
+			[[ -f "$f" ]] && rm -f "$f"
+		done
+
+		if [[ $LOG_LEVEL -ge 3 ]]; then
+			log_info "Duration: ${duration}s"
+		fi
+		exit $exit_code
+	}
+	trap cleanup EXIT
+}
+
+# Register a temp file for cleanup
+# Usage: register_temp_file /path/to/file
+register_temp_file() {
+	_TEMP_FILES+=("$1")
+}
+
+# ============================================================================
+# RETRY LOGIC
+# ============================================================================
+# Retry a command with exponential backoff
+# Usage: retry <max_attempts> <initial_delay_seconds> <command...>
+# Example: retry 3 5 oc get pods
+retry() {
+	local max_attempts="$1"
+	local delay="$2"
+	shift 2
+
+	local attempt=1
+	while true; do
+		if "$@"; then
+			return 0
+		fi
+
+		if [[ $attempt -ge $max_attempts ]]; then
+			log_error "Command failed after $max_attempts attempts: $*"
+			return 1
+		fi
+
+		log_warn "Attempt $attempt/$max_attempts failed, retrying in ${delay}s..."
+		sleep "$delay"
+		delay=$((delay * 2)) # Exponential backoff
+		attempt=$((attempt + 1))
+	done
+}
+
+# ============================================================================
+# SUMMARY OUTPUT
+# ============================================================================
+# Print a formatted summary table
+# Usage: print_summary "Key1" "Value1" "Key2" "Value2" ...
+print_summary() {
+	echo ""
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	echo "  SUMMARY"
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	while [[ $# -ge 2 ]]; do
+		printf "  %-25s %s\n" "$1:" "$2"
+		shift 2
+	done
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	echo ""
+}
+
+# ============================================================================
+# UTILITY FUNCTIONS
+# ============================================================================
+# Check if running with cluster-admin privileges
+require_cluster_admin() {
+	require_cluster
+	if ! oc auth can-i '*' '*' --all-namespaces &>/dev/null; then
+		log_error "Cluster-admin privileges required."
+		exit 1
+	fi
+	log_debug "Cluster-admin privileges confirmed"
+}
+
+# Wait for a resource to be ready
+# Usage: wait_for_resource <type/name> <namespace> <timeout>
+wait_for_resource() {
+	local resource="$1"
+	local namespace="${2:-default}"
+	local timeout="${3:-300s}"
+
+	log_info "Waiting for $resource to be ready..."
+	if oc wait --for=condition=available --timeout="$timeout" "$resource" -n "$namespace"; then
+		log_success "$resource is ready"
+		return 0
+	else
+		log_error "$resource failed to become ready within $timeout"
+		return 1
+	fi
+}

--- a/scripts/install-cert-manager-operator.sh
+++ b/scripts/install-cert-manager-operator.sh
@@ -8,34 +8,33 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# Get script directory and source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+	# shellcheck source=../lib/common.sh
+	source "$SCRIPT_DIR/lib/common.sh"
+	load_env
+	setup_cleanup
+else
+	# Fallback if common.sh doesn't exist
+	RED='\033[0;31m'
+	GREEN='\033[0;32m'
+	YELLOW='\033[1;33m'
+	BLUE='\033[0;34m'
+	NC='\033[0m'
+	log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
+	log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+	log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+	log_success() { echo -e "${GREEN}[SUCCESS]${NC} $*"; }
+fi
 
-# Get script directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-YAML_DIR="${SCRIPT_DIR}/../yaml/cert-manager-operator"
+YAML_DIR="${SCRIPT_DIR}/yaml/cert-manager-operator"
 
-# Configuration (exported for envsubst)
-export OPERATOR_NAMESPACE="cert-manager-operator"
-export CERT_MANAGER_NAMESPACE="cert-manager"
-export OPERATOR_NAME="openshift-cert-manager-operator"
-export CHANNEL="stable-v1"
-
-# Function to print colored messages
-log_info() {
-	echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-log_warn() {
-	echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-	echo -e "${RED}[ERROR]${NC} $1"
-}
+# Configuration (exported for envsubst, can be overridden via .env)
+export OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-cert-manager-operator}"
+export CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
+export OPERATOR_NAME="${OPERATOR_NAME:-openshift-cert-manager-operator}"
+export CHANNEL="${CHANNEL:-stable-v1}"
 
 # Function to check if oc is installed and user is logged in
 check_prerequisites() {

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+# preflight-check.sh - Validate all dependencies before running workflows
+#
+# Usage: ./scripts/preflight-check.sh
+#        make preflight
+
+set -euo pipefail
+
+# Source common library if available
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+	# shellcheck source=../lib/common.sh
+	source "$SCRIPT_DIR/lib/common.sh"
+else
+	# Fallback if common.sh doesn't exist
+	RED='\033[0;31m'
+	GREEN='\033[0;32m'
+	YELLOW='\033[1;33m'
+	BLUE='\033[0;34m'
+	NC='\033[0m'
+	log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
+	log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+	log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+	log_success() { echo -e "${GREEN}[SUCCESS]${NC} $*"; }
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  CERT-MANAGER SCRIPTS - PREFLIGHT CHECK"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+FAILED=0
+WARNINGS=0
+
+# ============================================================================
+# Required CLI Tools
+# ============================================================================
+log_info "Checking required CLI tools..."
+
+check_cmd() {
+	local cmd="$1"
+	local install_hint="${2:-}"
+
+	if command -v "$cmd" &>/dev/null; then
+		local version
+		case "$cmd" in
+		oc) version=$(oc version --client 2>/dev/null | head -1 || echo "unknown") ;;
+		envsubst) version=$(envsubst --version 2>/dev/null | head -1 || echo "installed") ;;
+		shfmt) version=$(shfmt --version 2>/dev/null || echo "installed") ;;
+		shellcheck) version=$(shellcheck --version 2>/dev/null | grep version: || echo "installed") ;;
+		*) version="installed" ;;
+		esac
+		log_success "$cmd: $version"
+		return 0
+	else
+		log_error "$cmd: NOT FOUND"
+		[[ -n "$install_hint" ]] && echo "       $install_hint"
+		FAILED=1
+		return 1
+	fi
+}
+
+# Required tools
+check_cmd oc "Install: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html"
+check_cmd envsubst "Install: brew install gettext (macOS) or dnf install gettext (Fedora)"
+
+# Optional tools (for development)
+echo ""
+log_info "Checking optional development tools..."
+
+if ! check_cmd shfmt "Install: brew install shfmt (macOS) or go install mvdan.cc/sh/v3/cmd/shfmt@latest"; then
+	FAILED=$((FAILED - 1)) # Don't count as failure
+	WARNINGS=$((WARNINGS + 1))
+fi
+
+if ! check_cmd shellcheck "Install: brew install shellcheck (macOS) or dnf install ShellCheck (Fedora)"; then
+	FAILED=$((FAILED - 1)) # Don't count as failure
+	WARNINGS=$((WARNINGS + 1))
+fi
+
+# ============================================================================
+# Cluster Connectivity
+# ============================================================================
+echo ""
+log_info "Checking cluster connectivity..."
+
+if command -v oc &>/dev/null; then
+	if oc whoami &>/dev/null 2>&1; then
+		user=$(oc whoami)
+		server=$(oc whoami --show-server 2>/dev/null || echo "unknown")
+		log_success "Logged in as: $user"
+		log_success "Cluster: $server"
+
+		# Check cluster-admin privileges
+		if oc auth can-i '*' '*' --all-namespaces &>/dev/null 2>&1; then
+			log_success "Cluster-admin privileges: yes"
+		else
+			log_warn "Cluster-admin privileges: no (some operations may fail)"
+			WARNINGS=$((WARNINGS + 1))
+		fi
+	else
+		log_warn "Not connected to cluster (optional for preflight)"
+		log_info "Run 'oc login' before running scripts that require cluster access"
+		WARNINGS=$((WARNINGS + 1))
+	fi
+else
+	log_error "Cannot check cluster: oc not installed"
+fi
+
+# ============================================================================
+# YAML Directory Check
+# ============================================================================
+echo ""
+log_info "Checking project structure..."
+
+YAML_DIR="$SCRIPT_DIR/yaml/cert-manager-operator"
+if [[ -d "$YAML_DIR" ]]; then
+	yaml_count=$(find "$YAML_DIR" -name "*.yaml" 2>/dev/null | wc -l | tr -d ' ')
+	log_success "YAML templates directory: $YAML_DIR ($yaml_count files)"
+else
+	log_error "YAML templates directory not found: $YAML_DIR"
+	FAILED=$((FAILED + 1))
+fi
+
+# Check lib/common.sh exists
+if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
+	log_success "Shared library: lib/common.sh"
+else
+	log_warn "Shared library not found: lib/common.sh"
+	WARNINGS=$((WARNINGS + 1))
+fi
+
+# Check .env file
+if [[ -f "$SCRIPT_DIR/.env" ]]; then
+	log_success "Environment config: .env (loaded)"
+elif [[ -f "$SCRIPT_DIR/.env.example" ]]; then
+	log_info "Environment config: .env.example exists (copy to .env to customize)"
+else
+	log_info "Environment config: not configured (using defaults)"
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  SUMMARY"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ $FAILED -eq 0 && $WARNINGS -eq 0 ]]; then
+	log_success "All checks passed!"
+	echo ""
+	echo "You're ready to run cert-manager-scripts."
+	echo "Start with: make install-cert-manager-operator"
+	exit 0
+elif [[ $FAILED -eq 0 ]]; then
+	log_warn "Passed with $WARNINGS warning(s)"
+	echo ""
+	echo "You can proceed, but some features may be limited."
+	exit 0
+else
+	log_error "Failed with $FAILED error(s) and $WARNINGS warning(s)"
+	echo ""
+	echo "Please install missing dependencies before proceeding."
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `lib/common.sh` with reusable functions (logging, dependency checking, .env support, retry logic)
- Add `.env.example` configuration template
- Add `scripts/preflight-check.sh` for dependency validation
- Update Makefile with colorized, categorized help output
- Update `install-cert-manager-operator.sh` to use common library

This aligns cert-manager-scripts with the compliance-scripts repo structure for consistency.

## Test plan
- [x] `make preflight` runs successfully
- [x] `make lint` passes (shellcheck + shfmt)
- [x] `make help` shows colorized categorized output
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)