### PR TITLE
Skip integration tests for Dependabot PRs

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -88,7 +88,9 @@ jobs:
     name: Integration Test (OCP 4.19)
     runs-on: ubuntu-latest
     needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure]
+    # Skip integration tests for Dependabot PRs (no access to secrets)
     if: |
+      github.actor != 'dependabot[bot]' &&
       needs.shell-format-check.result == 'success' &&
       needs.shellcheck.result == 'success' &&
       needs.workload-partitioning-check.result == 'success' &&


### PR DESCRIPTION
## Summary
- Skip integration tests when the PR author is `dependabot[bot]`
- Dependabot PRs don't have access to repository secrets by design, causing the `CRC_PULL_SECRET` check to fail
- Dependabot PRs only update action versions and don't require full cluster testing

## Related
Fixes the failing CI on #12

## Test plan
- [ ] Merge this PR
- [ ] Comment `@dependabot rebase` on #12 to trigger a new CI run
- [ ] Verify the integration test is skipped for the Dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)