### PR TITLE
Add comment headers to YAML manifests

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,3 +1,7 @@
+# Dependabot: Configuration
+#
+# Configures Dependabot to check for GitHub Actions updates daily. Keeps CI
+# workflows current with the latest action versions for security and features.
 ---
 version: 2
 updates:

--- a/yaml/acme-dns/configmap.yaml
+++ b/yaml/acme-dns/configmap.yaml
@@ -1,3 +1,7 @@
+# ACME-DNS: Configuration
+#
+# Configuration for the ACME-DNS server including DNS listener settings (:53),
+# API endpoint (:8080), and sqlite3 database for storing challenge records.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/yaml/acme-dns/deployment.yaml
+++ b/yaml/acme-dns/deployment.yaml
@@ -1,3 +1,8 @@
+# ACME-DNS: Deployment
+#
+# Deploys the joohoi/acme-dns container which provides a specialized DNS server
+# for ACME DNS-01 challenges. Stores TXT records in sqlite3 and exposes both
+# DNS and API interfaces for automated certificate issuance.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/yaml/acme-dns/namespace.yaml
+++ b/yaml/acme-dns/namespace.yaml
@@ -1,3 +1,7 @@
+# ACME-DNS: Namespace
+#
+# Creates the namespace for the ACME-DNS server, which provides a specialized
+# DNS server for ACME DNS-01 challenges with automatic TXT record management.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/yaml/acme-dns/service.yaml
+++ b/yaml/acme-dns/service.yaml
@@ -1,3 +1,7 @@
+# ACME-DNS: Service
+#
+# Exposes the ACME-DNS server with DNS ports (UDP/TCP 53) for challenge
+# resolution and HTTP API port (8080) for TXT record registration.
 apiVersion: v1
 kind: Service
 metadata:

--- a/yaml/cert-manager-operator/operatorgroup.yaml
+++ b/yaml/cert-manager-operator/operatorgroup.yaml
@@ -1,3 +1,7 @@
+# Cert-Manager Operator: OperatorGroup
+#
+# Creates the OperatorGroup required for installing the cert-manager-operator
+# from OperatorHub. Scopes the operator to its own namespace.
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/yaml/cert-manager-operator/subscription.yaml
+++ b/yaml/cert-manager-operator/subscription.yaml
@@ -1,3 +1,7 @@
+# Cert-Manager Operator: Subscription
+#
+# Subscribes to the openshift-cert-manager-operator from Red Hat's operator
+# catalog. Uses automatic install approval to keep the operator updated.
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/yaml/certificates/test-certificate.yaml
+++ b/yaml/certificates/test-certificate.yaml
@@ -1,3 +1,8 @@
+# Test Certificate: Template
+#
+# Template for requesting a test certificate via cert-manager. Configures 90-day
+# duration with 15-day renewal window. Uses environment variables for flexibility
+# in specifying issuer, secret name, and DNS names.
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/yaml/fake-dns-api/deployment.yaml
+++ b/yaml/fake-dns-api/deployment.yaml
@@ -1,3 +1,8 @@
+# Fake DNS API: Deployment
+#
+# Runs the fake DNS API server on UBI9 Python. Accepts RFC2136 DNS updates and
+# responds to SOA/TXT queries for air-gapped cert-manager DNS-01 testing.
+# Requires root privileges for binding to privileged port 53.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/yaml/fake-dns-api/namespace.yaml
+++ b/yaml/fake-dns-api/namespace.yaml
@@ -1,3 +1,7 @@
+# Fake DNS API: Namespace
+#
+# Creates the namespace for the fake DNS API server used in air-gapped testing
+# environments where real DNS updates are not possible or desired.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/yaml/fake-dns-api/service.yaml
+++ b/yaml/fake-dns-api/service.yaml
@@ -1,3 +1,7 @@
+# Fake DNS API: Service
+#
+# Exposes the fake DNS API with UDP port 53 for DNS queries and TCP port 8080
+# for health checks. Used with Pebble ALWAYS_VALID mode for testing.
 apiVersion: v1
 kind: Service
 metadata:

--- a/yaml/fake-dns-api/serviceaccount.yaml
+++ b/yaml/fake-dns-api/serviceaccount.yaml
@@ -1,3 +1,7 @@
+# Fake DNS API: ServiceAccount
+#
+# ServiceAccount for the fake DNS API pod. Required for OpenShift security
+# context constraints when running with elevated privileges for port 53.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/yaml/ibu/minio/deployment.yaml
+++ b/yaml/ibu/minio/deployment.yaml
@@ -1,3 +1,8 @@
+# MinIO: Deployment
+#
+# Deploys MinIO object storage server with health checks and persistent storage.
+# Credentials are sourced from the minio-credentials secret. Uses Recreate
+# strategy to ensure clean storage handoff during updates.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/yaml/ibu/minio/namespace.yaml
+++ b/yaml/ibu/minio/namespace.yaml
@@ -1,3 +1,7 @@
+# MinIO: Namespace
+#
+# Creates the namespace for MinIO, an S3-compatible object storage server.
+# Used as the backup target for OADP/Velero during IBU testing.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/yaml/ibu/minio/pvc.yaml
+++ b/yaml/ibu/minio/pvc.yaml
@@ -1,3 +1,7 @@
+# MinIO: Persistent Volume Claim
+#
+# Requests 10Gi of persistent storage for MinIO's data directory. Stores
+# Velero backups including Kubernetes resources and certificate secrets.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/yaml/ibu/minio/route.yaml
+++ b/yaml/ibu/minio/route.yaml
@@ -1,3 +1,7 @@
+# MinIO: Console Route
+#
+# Creates an OpenShift Route for the MinIO web console with edge TLS termination.
+# Provides external access for browsing backups and managing buckets.
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/yaml/ibu/minio/secret.yaml
+++ b/yaml/ibu/minio/secret.yaml
@@ -1,3 +1,7 @@
+# MinIO: Credentials Secret
+#
+# Contains MinIO access credentials (accessKeyID/secretAccessKey) used by both
+# MinIO itself and OADP for S3-compatible backup storage authentication.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/yaml/ibu/minio/service.yaml
+++ b/yaml/ibu/minio/service.yaml
@@ -1,3 +1,7 @@
+# MinIO: Service
+#
+# Exposes MinIO's S3-compatible API (port 9000) and web console (port 9001).
+# OADP/Velero connects to port 9000 for backup storage operations.
 apiVersion: v1
 kind: Service
 metadata:

--- a/yaml/ibu/oadp/cloud-credentials-secret.yaml
+++ b/yaml/ibu/oadp/cloud-credentials-secret.yaml
@@ -1,3 +1,7 @@
+# OADP: Cloud Credentials Secret
+#
+# AWS-style credentials for OADP to authenticate with MinIO's S3-compatible API.
+# Uses the same credentials as MinIO but in AWS credentials file format.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/yaml/ibu/oadp/dataprotectionapplication.yaml
+++ b/yaml/ibu/oadp/dataprotectionapplication.yaml
@@ -1,3 +1,8 @@
+# OADP: DataProtectionApplication
+#
+# Configures Velero with AWS, OpenShift, and CSI plugins pointing to MinIO for
+# S3-compatible backup storage. Enables Kopia-based node agent for file-level
+# backups and sets a 10-minute resource timeout for operations.
 apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:

--- a/yaml/ibu/oadp/namespace.yaml
+++ b/yaml/ibu/oadp/namespace.yaml
@@ -1,3 +1,7 @@
+# OADP: Namespace
+#
+# Creates the openshift-adp namespace for the OpenShift API for Data Protection
+# operator. Enables cluster monitoring for OADP metrics collection.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/yaml/ibu/oadp/operatorgroup.yaml
+++ b/yaml/ibu/oadp/operatorgroup.yaml
@@ -1,3 +1,7 @@
+# OADP: OperatorGroup
+#
+# Creates the OperatorGroup required for OADP operator installation.
+# Scopes the operator to the openshift-adp namespace.
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/yaml/ibu/oadp/subscription.yaml
+++ b/yaml/ibu/oadp/subscription.yaml
@@ -1,3 +1,7 @@
+# OADP: Subscription
+#
+# Subscribes to Red Hat's OADP operator from the stable channel. OADP provides
+# Velero-based backup and restore capabilities for Kubernetes resources.
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/yaml/issuers/pebble-clusterissuer.yaml
+++ b/yaml/issuers/pebble-clusterissuer.yaml
@@ -1,3 +1,8 @@
+# Pebble ClusterIssuer: HTTP-01
+#
+# ClusterIssuer configured for HTTP-01 ACME challenges using Pebble as the CA.
+# Skips TLS verification for Pebble's self-signed certificates and uses
+# ingress-based challenge solving.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/yaml/issuers/pebble-dns01-clusterissuer.yaml
+++ b/yaml/issuers/pebble-dns01-clusterissuer.yaml
@@ -1,3 +1,8 @@
+# Pebble ClusterIssuer: DNS-01 Webhook
+#
+# ClusterIssuer for DNS-01 challenges using a webhook solver placeholder.
+# Designed for use with Pebble's ALWAYS_VALID mode where actual DNS updates
+# are not required and challenges auto-succeed.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/yaml/issuers/pebble-dns01-simple-clusterissuer.yaml
+++ b/yaml/issuers/pebble-dns01-simple-clusterissuer.yaml
@@ -1,3 +1,8 @@
+# Pebble ClusterIssuer: DNS-01 RFC2136
+#
+# ClusterIssuer for DNS-01 challenges using RFC2136 dynamic DNS updates.
+# Works with the fake DNS API server for air-gapped testing where Pebble's
+# ALWAYS_VALID mode auto-validates challenges regardless of actual DNS state.
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:

--- a/yaml/pebble-challtestsrv/deployment.yaml
+++ b/yaml/pebble-challtestsrv/deployment.yaml
@@ -1,3 +1,8 @@
+# Pebble Challenge Test Server: Deployment
+#
+# Deploys pebble-challtestsrv which provides a mock DNS/HTTP server for ACME
+# challenge testing. Supports HTTP-01, TLS-ALPN-01, and DNS-01 challenges
+# with a management API to configure responses.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/yaml/pebble-challtestsrv/service.yaml
+++ b/yaml/pebble-challtestsrv/service.yaml
@@ -1,3 +1,7 @@
+# Pebble Challenge Test Server: Service
+#
+# Exposes the challenge test server with DNS (port 8053) and management (port 8055)
+# interfaces. Provides mock DNS responses for Pebble's ACME challenge validation.
 apiVersion: v1
 kind: Service
 metadata:

--- a/yaml/pebble/configmap.yaml
+++ b/yaml/pebble/configmap.yaml
@@ -1,3 +1,7 @@
+# Pebble: Configuration
+#
+# Pebble server configuration specifying ACME endpoint (port 14000) and
+# management interface (port 15000). Uses built-in test certificates.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/yaml/pebble/deployment.yaml
+++ b/yaml/pebble/deployment.yaml
@@ -1,3 +1,8 @@
+# Pebble: Deployment
+#
+# Deploys Let's Encrypt's Pebble ACME test server. Configurable DNS server for
+# challenge validation and PEBBLE_VA_ALWAYS_VALID mode for air-gapped testing
+# where challenges auto-succeed without actual validation.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/yaml/pebble/namespace.yaml
+++ b/yaml/pebble/namespace.yaml
@@ -1,3 +1,7 @@
+# Pebble: Namespace
+#
+# Creates the namespace for Pebble, Let's Encrypt's small ACME test server.
+# Used for local certificate testing without rate limits or internet access.
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/yaml/pebble/route.yaml
+++ b/yaml/pebble/route.yaml
@@ -1,3 +1,7 @@
+# Pebble: OpenShift Route
+#
+# Creates an external route to Pebble's ACME endpoint using TLS passthrough.
+# Allows external access to the local ACME server for testing purposes.
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/yaml/pebble/service.yaml
+++ b/yaml/pebble/service.yaml
@@ -1,3 +1,7 @@
+# Pebble: Service
+#
+# Exposes Pebble's ACME server (port 14000) and management interface (port 15000)
+# within the cluster for cert-manager to use as a local ACME CA.
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
## Summary
- Add descriptive comment headers to 33 YAML files that were missing them
- Each header includes a component name, brief title, and explanation of what the resource does
- Improves codebase documentation and makes manifests more self-documenting

### Files updated:
- **acme-dns/** (4 files): namespace, configmap, service, deployment
- **cert-manager-operator/** (2 files): operatorgroup, subscription
- **certificates/** (1 file): test-certificate template
- **fake-dns-api/** (4 files): namespace, service, serviceaccount, deployment
- **pebble/** (5 files): namespace, configmap, service, route, deployment
- **pebble-challtestsrv/** (2 files): service, deployment
- **issuers/** (3 files): HTTP-01, DNS-01 webhook, DNS-01 RFC2136 ClusterIssuers
- **ibu/minio/** (6 files): namespace, secret, pvc, service, deployment, route
- **ibu/oadp/** (5 files): namespace, operatorgroup, subscription, credentials, dataprotectionapplication
- **.github/** (1 file): dependabot config

## Test plan
- [x] Verified YAML syntax is preserved
- [x] Comments follow existing format from `yaml/ibu/backup/` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)