### PR TITLE
Add README documentation to YAML subdirectories and standardize script headers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# Documentation
+
+Technical documentation for cert-manager-scripts beyond the main guides.
+
+## Contents
+
+| Document | Description |
+|----------|-------------|
+| [IBU-FAQ.md](IBU-FAQ.md) | Frequently asked questions about IBU certificate testing |
+| [CRC-CLUSTER-HEALTH-IMPROVEMENTS.md](CRC-CLUSTER-HEALTH-IMPROVEMENTS.md) | CI workflow health check enhancements |
+
+## IBU-FAQ.md
+
+Answers common questions about cert-manager certificate behavior during OpenShift Image-Based Upgrade (IBU) operations:
+
+- Does this testing address IBU certificate concerns?
+- Is the cert immediately reissued or does it wait until expiration?
+- What is the workflow for labeling certs?
+- How does the simulation differ from real LCA behavior?
+
+## CRC-CLUSTER-HEALTH-IMPROVEMENTS.md
+
+Documents CI workflow improvements for CRC cluster testing:
+
+- Enhanced cluster verification scripts
+- Cluster recovery mechanisms
+- Health check integration in GitHub Actions
+- Troubleshooting transient failures
+
+## Related Documentation
+
+Main documentation files are in the repository root:
+
+| File | Description |
+|------|-------------|
+| `INSTALLATION.md` | Cert-manager installation guide |
+| `DNS01-SETUP.md` | DNS-01 challenge configuration |
+| `PEBBLE-USAGE.md` | Using Pebble for local ACME testing |
+| `NETWORK-SUPPORT.md` | Network configuration details |
+| `IBU-TESTING.md` | IBU certificate loss validation |
+| `TROUBLESHOOTING.md` | Common issues and solutions |
+| `CONTRIBUTING.md` | Contribution guidelines |

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,96 @@
+# Library
+
+Shared shell library functions for cert-manager-scripts.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `common.sh` | Core library with logging, validation, and utility functions |
+
+## Usage
+
+Source `common.sh` at the top of your scripts:
+
+```bash
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
+```
+
+## Available Functions
+
+### Logging
+
+| Function | Description |
+|----------|-------------|
+| `log_error "msg"` | Red error message (stderr) |
+| `log_warn "msg"` | Yellow warning message |
+| `log_info "msg"` | Blue informational message |
+| `log_success "msg"` | Green success message |
+| `log_debug "msg"` | Bold debug message (when LOG_LEVEL=debug) |
+
+### Dependency Checking
+
+| Function | Description |
+|----------|-------------|
+| `require_cmd oc yq jq` | Verify required commands exist |
+| `require_cluster` | Verify OpenShift cluster connectivity |
+| `require_cluster_admin` | Verify cluster-admin privileges |
+
+### Environment
+
+| Function | Description |
+|----------|-------------|
+| `load_env [path]` | Load .env file (searches script dir) |
+
+### Cleanup
+
+| Function | Description |
+|----------|-------------|
+| `setup_cleanup` | Set up EXIT trap with timing |
+| `register_temp_file /path` | Register file for cleanup on exit |
+
+### Utilities
+
+| Function | Description |
+|----------|-------------|
+| `retry 3 5 cmd args...` | Retry command with exponential backoff |
+| `wait_for_resource type/name ns timeout` | Wait for resource readiness |
+| `print_summary "Key" "Val" ...` | Print formatted summary table |
+
+## Log Levels
+
+Set via `LOG_LEVEL` environment variable:
+
+| Level | Value | Output |
+|-------|-------|--------|
+| quiet | 0 | Nothing |
+| error | 1 | Errors only |
+| warn | 2 | Errors + warnings |
+| info | 3 | Errors + warnings + info (default) |
+| debug | 4 | Everything |
+
+Example:
+```bash
+LOG_LEVEL=debug ./scripts/install-pebble.sh
+```
+
+## Example Script
+
+```bash
+#!/bin/bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
+
+setup_cleanup
+load_env
+require_cmd oc envsubst
+require_cluster
+
+log_info "Starting deployment..."
+# ... your code ...
+log_success "Deployment complete"
+
+print_summary "Namespace" "$NAMESPACE" "Status" "Ready"
+```

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# preflight-check.sh - Validate all dependencies before running workflows
+################################################################################
+# Script: preflight-check.sh
+# Description: Validate all dependencies and prerequisites before running workflows
+################################################################################
 #
 # Usage: ./scripts/preflight-check.sh
 #        make preflight

--- a/scripts/workflows/run-workload-partitioning-check.sh
+++ b/scripts/workflows/run-workload-partitioning-check.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+################################################################################
+# Script: run-workload-partitioning-check.sh
+# Description: Execute the workload partitioning check via Makefile target
+################################################################################
 
 set -euo pipefail
 

--- a/scripts/workflows/verify-directory-structure.sh
+++ b/scripts/workflows/verify-directory-structure.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+################################################################################
+# Script: verify-directory-structure.sh
+# Description: Verify that required repository directories exist
+################################################################################
 
 set -euo pipefail
 

--- a/scripts/workflows/verify-documentation.sh
+++ b/scripts/workflows/verify-documentation.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+################################################################################
+# Script: verify-documentation.sh
+# Description: Verify that workload partitioning is documented in markdown files
+################################################################################
 
 set -euo pipefail
 

--- a/scripts/workflows/verify-key-files.sh
+++ b/scripts/workflows/verify-key-files.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+################################################################################
+# Script: verify-key-files.sh
+# Description: Verify that required repository files exist (README, Makefile, etc.)
+################################################################################
 
 set -euo pipefail
 

--- a/scripts/workflows/verify-makefile-target.sh
+++ b/scripts/workflows/verify-makefile-target.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+################################################################################
+# Script: verify-makefile-target.sh
+# Description: Verify that check-workload-partitioning target exists in Makefile
+################################################################################
 
 set -euo pipefail
 

--- a/scripts/workflows/verify-script-executable.sh
+++ b/scripts/workflows/verify-script-executable.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+################################################################################
+# Script: verify-script-executable.sh
+# Description: Verify that workload partitioning check script is executable
+################################################################################
 
 set -euo pipefail
 

--- a/scripts/workflows/verify-workload-partitioning-script-exists.sh
+++ b/scripts/workflows/verify-workload-partitioning-script-exists.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+################################################################################
+# Script: verify-workload-partitioning-script-exists.sh
+# Description: Verify that workload partitioning check script exists
+################################################################################
 
 set -euo pipefail
 

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -6,8 +6,18 @@ This directory contains Kubernetes/OpenShift YAML manifests organized by purpose
 
 Each subdirectory represents a specific component or feature:
 
-- `cert-manager-operator/` - Manifests for installing the cert-manager Operator
-- `pebble/` - Manifests for deploying the Pebble ACME test server
+| Directory | Description | Files |
+|-----------|-------------|-------|
+| [`acme-dns/`](acme-dns/) | ACME-DNS server for DNS-01 challenge automation | 4 |
+| [`cert-manager-operator/`](cert-manager-operator/) | OpenShift cert-manager operator installation | 2 |
+| [`certificates/`](certificates/) | Test certificate templates | 1 |
+| [`fake-dns-api/`](fake-dns-api/) | Air-gapped DNS testing server | 5 |
+| [`issuers/`](issuers/) | ClusterIssuer configurations (HTTP-01, DNS-01) | 3 |
+| [`pebble/`](pebble/) | Let's Encrypt Pebble ACME test server | 5 |
+| [`pebble-challtestsrv/`](pebble-challtestsrv/) | Pebble challenge test server | 2 |
+| [`ibu/`](ibu/) | IBU testing resources (MinIO, OADP, backups) | 3 subdirs |
+
+See individual subdirectory READMEs for detailed documentation.
 
 ## Variable Substitution
 

--- a/yaml/acme-dns/README.md
+++ b/yaml/acme-dns/README.md
@@ -1,0 +1,37 @@
+# ACME-DNS
+
+ACME-DNS server for DNS-01 challenge automation. Provides a specialized DNS server that handles TXT record management for ACME certificate issuance.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `namespace.yaml` | Namespace for ACME-DNS deployment |
+| `configmap.yaml` | ACME-DNS configuration (domain, API settings) |
+| `deployment.yaml` | Deploys joohoi/acme-dns container |
+| `service.yaml` | Exposes DNS (53) and API (8080) ports |
+
+## Usage
+
+```bash
+# Deploy ACME-DNS
+export ACMEDNS_NAMESPACE="acme-dns"
+envsubst < yaml/acme-dns/namespace.yaml | oc apply -f -
+envsubst < yaml/acme-dns/configmap.yaml | oc apply -f -
+envsubst < yaml/acme-dns/deployment.yaml | oc apply -f -
+envsubst < yaml/acme-dns/service.yaml | oc apply -f -
+```
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ACMEDNS_NAMESPACE` | Namespace for ACME-DNS deployment |
+
+## How It Works
+
+ACME-DNS stores TXT records in sqlite3 and exposes both DNS (port 53) and HTTP API (port 8080) interfaces. cert-manager can use the ACME-DNS webhook solver to automate DNS-01 challenges.
+
+## Related Documentation
+
+- [DNS01-SETUP.md](../../DNS01-SETUP.md) - DNS-01 challenge configuration

--- a/yaml/cert-manager-operator/README.md
+++ b/yaml/cert-manager-operator/README.md
@@ -1,0 +1,37 @@
+# cert-manager-operator
+
+OpenShift cert-manager operator installation manifests. Installs the Red Hat-supported cert-manager operator from the OperatorHub catalog.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `operatorgroup.yaml` | OperatorGroup for the cert-manager-operator namespace |
+| `subscription.yaml` | Subscription to install the operator from Red Hat catalog |
+
+## Usage
+
+```bash
+# Install cert-manager-operator
+make install-cert-manager-operator
+
+# Or manually:
+export OPERATOR_NAMESPACE="cert-manager-operator"
+export OPERATOR_NAME="openshift-cert-manager-operator"
+export CHANNEL="stable-v1"
+
+envsubst < yaml/cert-manager-operator/operatorgroup.yaml | oc apply -f -
+envsubst < yaml/cert-manager-operator/subscription.yaml | oc apply -f -
+```
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPERATOR_NAMESPACE` | `cert-manager-operator` | Namespace for the operator |
+| `OPERATOR_NAME` | `openshift-cert-manager-operator` | Operator subscription name |
+| `CHANNEL` | `stable-v1` | Update channel |
+
+## Related Documentation
+
+- [INSTALLATION.md](../../INSTALLATION.md) - Full installation guide

--- a/yaml/certificates/README.md
+++ b/yaml/certificates/README.md
@@ -1,0 +1,57 @@
+# Certificates
+
+Test certificate templates for cert-manager. Used to request certificates from ClusterIssuers during testing.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `test-certificate.yaml` | Template for requesting a test certificate with 90-day validity |
+
+## Usage
+
+```bash
+# Request a test certificate
+make test-cert
+
+# Or manually:
+export CERT_NAME="test-cert"
+export CERT_NAMESPACE="default"
+export CERT_SECRET_NAME="test-cert-tls"
+export CERT_COMMON_NAME="test.example.com"
+export CERT_DNS_NAME="test.example.com"
+export ISSUER_NAME="pebble-issuer"
+
+envsubst < yaml/certificates/test-certificate.yaml | oc apply -f -
+```
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CERT_NAME` | Name of the Certificate resource |
+| `CERT_NAMESPACE` | Namespace for the certificate |
+| `CERT_SECRET_NAME` | Name of the TLS secret to create |
+| `CERT_COMMON_NAME` | Certificate common name |
+| `CERT_DNS_NAME` | DNS name(s) for the certificate |
+| `ISSUER_NAME` | ClusterIssuer to use |
+
+## Certificate Lifecycle
+
+- **Duration**: 90 days (2160h)
+- **Renewal**: Begins 15 days before expiry (360h)
+- **Challenge**: HTTP-01 (for non-wildcard certs)
+
+## Verification
+
+```bash
+# Check certificate status
+make verify-cert
+
+# View certificate details
+oc get certificate -n $CERT_NAMESPACE $CERT_NAME -o yaml
+```
+
+## Related Documentation
+
+- [PEBBLE-USAGE.md](../../PEBBLE-USAGE.md) - Using Pebble for testing

--- a/yaml/fake-dns-api/README.md
+++ b/yaml/fake-dns-api/README.md
@@ -1,0 +1,53 @@
+# Fake DNS API
+
+Air-gapped DNS testing server for cert-manager DNS-01 challenges. Accepts RFC2136 DNS updates and responds to SOA/TXT queries without requiring external DNS infrastructure.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `namespace.yaml` | Namespace for the fake DNS server |
+| `configmap.yaml` | Python DNS API server script |
+| `deployment.yaml` | Deploys the DNS server on UBI9 Python |
+| `service.yaml` | Exposes DNS (53) and health check (8080) ports |
+| `serviceaccount.yaml` | ServiceAccount for the deployment |
+
+## Usage
+
+```bash
+# Deploy fake DNS API
+make install-fake-dns
+
+# Or manually:
+export FAKEDNS_NAMESPACE="fake-dns"
+envsubst < yaml/fake-dns-api/namespace.yaml | oc apply -f -
+envsubst < yaml/fake-dns-api/configmap.yaml | oc apply -f -
+envsubst < yaml/fake-dns-api/serviceaccount.yaml | oc apply -f -
+envsubst < yaml/fake-dns-api/deployment.yaml | oc apply -f -
+envsubst < yaml/fake-dns-api/service.yaml | oc apply -f -
+```
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `FAKEDNS_NAMESPACE` | Namespace for fake DNS deployment |
+
+## How It Works
+
+The fake DNS API server:
+1. Listens on port 53 for DNS queries (SOA, TXT)
+2. Accepts RFC2136 dynamic DNS UPDATE requests
+3. Stores TXT records in memory
+4. Returns stored records when queried
+
+This enables testing DNS-01 challenges without public DNS or internet connectivity.
+
+## Use Case
+
+Combined with Pebble's `ALWAYS_VALID=1` mode, the fake DNS server allows complete air-gapped testing of cert-manager DNS-01 workflows.
+
+## Related Documentation
+
+- [DNS01-SETUP.md](../../DNS01-SETUP.md) - DNS-01 challenge configuration
+- [NETWORK-SUPPORT.md](../../NETWORK-SUPPORT.md) - Air-gapped setup

--- a/yaml/ibu/README.md
+++ b/yaml/ibu/README.md
@@ -1,0 +1,62 @@
+# IBU (Image-Based Upgrade) Testing
+
+Resources for testing cert-manager certificate behavior during OpenShift Image-Based Upgrade (IBU) operations. Includes MinIO object storage, OADP operator configuration, and Velero backup/restore manifests.
+
+## Subdirectories
+
+| Directory | Description |
+|-----------|-------------|
+| `minio/` | MinIO S3-compatible object storage for backup destination |
+| `oadp/` | OADP (OpenShift API for Data Protection) operator installation |
+| `backup/` | Velero Backup and Restore manifests for IBU simulation |
+
+## Quick Start
+
+```bash
+# Install all IBU prerequisites (MinIO + OADP)
+make install-ibu-prereqs
+
+# Run the full IBU certificate loss simulation
+make test-ibu-certs
+
+# Or run the end-to-end test
+make quick-ibu-test
+
+# Clean up
+make clean-ibu
+```
+
+## Components
+
+### MinIO (`minio/`)
+S3-compatible object storage used as the backup destination for Velero. Includes deployment, service, route, PVC, and credentials.
+
+### OADP (`oadp/`)
+OpenShift API for Data Protection operator. Configures Velero with AWS, OpenShift, and CSI plugins pointing to the MinIO instance.
+
+### Backup (`backup/`)
+Velero Backup and Restore CRs that simulate IBU behavior:
+- `backup.yaml` / `restore.yaml` - Default behavior (certificates regenerated)
+- `backup-preserved.yaml` / `restore-preserved.yaml` - LCA label preservation
+
+## Test Scenarios
+
+| Scenario | Backup CR | Result |
+|----------|-----------|--------|
+| **Scenario 1 (Default)** | `backup.yaml` | Certificates regenerated with new keys |
+| **Scenario 2 (Preserved)** | `backup-preserved.yaml` | Certificates preserved via LCA labels |
+
+## How It Works
+
+1. **MinIO** provides S3-compatible storage within the cluster
+2. **OADP/Velero** handles backup and restore operations
+3. **Backup CRs** capture certificate resources (with or without TLS secrets)
+4. **Restore CRs** restore resources, triggering cert-manager reconciliation
+
+The key difference between scenarios is whether the `lca.openshift.io/backup` label is applied to TLS secrets, which determines if private key material is preserved.
+
+## Related Documentation
+
+- [IBU-TESTING.md](../../IBU-TESTING.md) - Full IBU testing guide
+- [docs/IBU-FAQ.md](../../docs/IBU-FAQ.md) - Frequently asked questions
+- [Validation Report](https://gist.github.com/sebrandon1/71f33b35aea2aa4cf9edda855201c8fc)

--- a/yaml/issuers/README.md
+++ b/yaml/issuers/README.md
@@ -1,0 +1,65 @@
+# Issuers
+
+ClusterIssuer configurations for cert-manager. These define how certificates are requested from ACME servers (Pebble for testing).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `pebble-clusterissuer.yaml` | HTTP-01 challenge issuer using ingress |
+| `pebble-dns01-clusterissuer.yaml` | DNS-01 issuer with webhook solver placeholder |
+| `pebble-dns01-simple-clusterissuer.yaml` | DNS-01 issuer using RFC2136 dynamic DNS |
+
+## Usage
+
+```bash
+# Create an issuer
+make create-issuer
+
+# Or manually (HTTP-01):
+export ISSUER_NAME="pebble-issuer"
+export ACME_SERVER_URL="https://pebble.pebble.svc.cluster.local:14000/dir"
+export ACME_EMAIL="test@example.com"
+export INGRESS_CLASS="openshift-default"
+
+envsubst < yaml/issuers/pebble-clusterissuer.yaml | oc apply -f -
+```
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `ISSUER_NAME` | Name of the ClusterIssuer |
+| `ACME_SERVER_URL` | ACME directory URL (Pebble endpoint) |
+| `ACME_EMAIL` | Email for ACME account registration |
+| `INGRESS_CLASS` | Ingress class for HTTP-01 challenges |
+| `DNS_SERVER` | DNS server for RFC2136 (DNS-01 only) |
+
+## Issuer Types
+
+### HTTP-01 (`pebble-clusterissuer.yaml`)
+- Uses ingress-based challenge solving
+- Works for non-wildcard certificates
+- Requires accessible ingress routes
+
+### DNS-01 Webhook (`pebble-dns01-clusterissuer.yaml`)
+- Placeholder for webhook-based DNS solvers
+- Use with Pebble's `ALWAYS_VALID=1` mode
+
+### DNS-01 RFC2136 (`pebble-dns01-simple-clusterissuer.yaml`)
+- Uses RFC2136 dynamic DNS updates
+- Works with fake-dns-api for air-gapped testing
+- Required for wildcard certificates
+
+## Choosing an Issuer
+
+| Certificate Type | Recommended Issuer |
+|-----------------|-------------------|
+| Non-wildcard | HTTP-01 (`pebble-clusterissuer.yaml`) |
+| Wildcard (`*.example.com`) | DNS-01 (`pebble-dns01-simple-clusterissuer.yaml`) |
+| Air-gapped testing | DNS-01 with `PEBBLE_ALWAYS_VALID=1` |
+
+## Related Documentation
+
+- [DNS01-SETUP.md](../../DNS01-SETUP.md) - DNS-01 configuration
+- [PEBBLE-USAGE.md](../../PEBBLE-USAGE.md) - Pebble usage guide

--- a/yaml/pebble-challtestsrv/README.md
+++ b/yaml/pebble-challtestsrv/README.md
@@ -1,0 +1,49 @@
+# Pebble Challenge Test Server
+
+Mock DNS/HTTP server for ACME challenge testing. Companion service to Pebble that provides configurable responses for HTTP-01, TLS-ALPN-01, and DNS-01 challenges.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `deployment.yaml` | Deploys letsencrypt/pebble-challtestsrv container |
+| `service.yaml` | Exposes DNS (8053), HTTP (5002), and management (8055) |
+
+## Usage
+
+```bash
+# Deploy alongside Pebble
+export PEBBLE_NAMESPACE="pebble"
+envsubst < yaml/pebble-challtestsrv/deployment.yaml | oc apply -f -
+envsubst < yaml/pebble-challtestsrv/service.yaml | oc apply -f -
+```
+
+## Variables
+
+| Variable | Description |
+|----------|-------------|
+| `PEBBLE_NAMESPACE` | Namespace (typically same as Pebble) |
+
+## Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 8053 | UDP/TCP | DNS queries |
+| 5002 | TCP | HTTP-01 challenge responses |
+| 5001 | TCP | TLS-ALPN-01/HTTPS challenges |
+| 8055 | TCP | Management API |
+
+## Management API
+
+The challenge test server provides an API (port 8055) to:
+- Add/remove mock DNS records
+- Configure HTTP-01 challenge responses
+- Set default IP addresses for challenge validation
+
+## When to Use
+
+Use pebble-challtestsrv when you need fine-grained control over challenge responses. For simple testing, Pebble's `ALWAYS_VALID=1` mode is often sufficient.
+
+## Related Documentation
+
+- [PEBBLE-USAGE.md](../../PEBBLE-USAGE.md) - Pebble usage guide

--- a/yaml/pebble/README.md
+++ b/yaml/pebble/README.md
@@ -1,0 +1,67 @@
+# Pebble
+
+Let's Encrypt Pebble ACME test server. A lightweight ACME server that runs in your cluster for testing cert-manager without rate limits or public DNS requirements.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `namespace.yaml` | Namespace for Pebble deployment |
+| `configmap.yaml` | Pebble configuration (ports, validation settings) |
+| `deployment.yaml` | Deploys letsencrypt/pebble container |
+| `service.yaml` | Exposes ACME API (14000) and management (15000) |
+| `route.yaml` | Optional route for external access |
+
+## Usage
+
+```bash
+# Deploy Pebble
+make install-pebble
+
+# Or manually:
+export PEBBLE_NAMESPACE="pebble"
+export DNS_SERVER="8.8.8.8:53"
+export PEBBLE_ALWAYS_VALID="0"
+
+envsubst < yaml/pebble/namespace.yaml | oc apply -f -
+envsubst < yaml/pebble/configmap.yaml | oc apply -f -
+envsubst < yaml/pebble/deployment.yaml | oc apply -f -
+envsubst < yaml/pebble/service.yaml | oc apply -f -
+envsubst < yaml/pebble/route.yaml | oc apply -f -
+```
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PEBBLE_NAMESPACE` | `pebble` | Namespace for Pebble |
+| `DNS_SERVER` | `8.8.8.8:53` | DNS server for challenge validation |
+| `PEBBLE_ALWAYS_VALID` | `0` | Auto-validate challenges (1=yes, 0=no) |
+
+## What is Pebble?
+
+Pebble is a small ACME test server from Let's Encrypt that:
+- Has no rate limits (unlike production Let's Encrypt)
+- Runs entirely in your OpenShift cluster
+- Can auto-validate challenges for easier testing
+- Issues real X.509 certificates (self-signed CA)
+
+## Accessing Pebble
+
+| Access | URL |
+|--------|-----|
+| Internal | `https://pebble.pebble.svc.cluster.local:14000/dir` |
+| External | Through OpenShift route (if created) |
+
+Use the internal URL when configuring cert-manager ClusterIssuers.
+
+## Configuration
+
+Key `configmap.yaml` settings:
+- **listenAddress**: ACME API endpoint (port 14000)
+- **managementListenAddress**: Management API (port 15000)
+- **httpPort/tlsPort**: Ports for HTTP-01 challenge validation
+
+## Related Documentation
+
+- [PEBBLE-USAGE.md](../../PEBBLE-USAGE.md) - Detailed Pebble usage guide


### PR DESCRIPTION
## Summary

- Add README.md to each yaml/ subdirectory documenting their purpose, files, usage, and variables
- Update yaml/README.md with a comprehensive directory listing table
- Add docs/README.md as an index for technical documentation
- Add lib/README.md documenting shared library functions and usage
- Standardize script headers in scripts/workflows/ verification scripts
- Add proper header to scripts/preflight-check.sh

## New Files (10)

| File | Description |
|------|-------------|
| `yaml/acme-dns/README.md` | ACME-DNS server documentation |
| `yaml/cert-manager-operator/README.md` | Operator installation docs |
| `yaml/certificates/README.md` | Test certificate templates docs |
| `yaml/fake-dns-api/README.md` | Air-gapped DNS testing docs |
| `yaml/pebble/README.md` | Pebble ACME server docs |
| `yaml/pebble-challtestsrv/README.md` | Challenge test server docs |
| `yaml/issuers/README.md` | ClusterIssuer configurations docs |
| `yaml/ibu/README.md` | IBU testing resources docs |
| `docs/README.md` | Index for technical documentation |
| `lib/README.md` | Library overview and function reference |

## Modified Files (9)

- `yaml/README.md` - Updated with full directory listing table
- `scripts/preflight-check.sh` - Added standard header
- `scripts/workflows/*.sh` (7 files) - Added standard headers

## Test plan

- [ ] Verify all README links work correctly
- [ ] Check formatting renders properly on GitHub
- [ ] Run `make lint` to ensure no script issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)