### PR TITLE
Consolidate duplicated code into shared library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,20 @@ Organized by component: `cert-manager-operator/`, `pebble/`, `fake-dns-api/`, `i
 
 ### lib/common.sh API
 
-Scripts source this library for shared functionality:
+All scripts source this library. The sourcing pattern depends on directory depth:
+
 ```bash
+# scripts/*.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# scripts/ibu/*.sh
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-source "$SCRIPT_DIR/lib/common.sh"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# scripts/troubleshooting/*.sh and scripts/workflows/*.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 ```
 
 Key functions:
@@ -109,9 +119,17 @@ Key functions:
 - **Cluster**: `require_cluster` / `require_cluster_admin` — validates connectivity and privileges
 - **Environment**: `load_env` — loads `.env` from script or parent directory
 - **Retry**: `retry <max_attempts> <delay> <command...>` — exponential backoff
-- **Wait**: `wait_for_resource <type/name> <namespace> <timeout>` — polls resource readiness
+- **Wait**: `wait_for_resource <type/name> <namespace> <timeout>` — uses `oc wait --for=condition=available`
 - **Cleanup**: `setup_cleanup` + `register_temp_file` — trap-based cleanup with duration tracking
 - **Output**: `print_summary "Key1" "Val1" "Key2" "Val2"` — formatted summary table
+- **Headers**: `print_header "Title"` — formatted section header box
+- **YAML**: `apply_yaml_template <yaml_file> <resource_type>` — envsubst + oc apply with file validation
+- **Namespace**: `ensure_namespace <namespace>` — idempotent namespace creation
+- **Deployment**: `check_deployment_exists <deployment> <namespace>` — returns 0 if deployment is healthy
+- **OLM**: `wait_for_csv <namespace> <grep_pattern> <max_attempts>` — waits for CSV to reach Succeeded phase
+- **OADP**: `wait_for_backup_restore <type> <name> <namespace> <max_attempts>` — waits for backup/restore completion
+- **IBU**: `build_lca_annotations <namespace>` — builds lca.openshift.io/apply-label annotation value
+- **IBU**: `capture_secret_checksums <namespace> <output_file>` — captures TLS secret checksums in a single API call
 
 ## IBU Certificate Validation
 
@@ -129,11 +147,12 @@ The LCA (Lifecycle Agent) apply-label format is `<apiGroup>/<version>/<resourceT
 ## Code Style
 
 - All scripts use `set -euo pipefail`
-- Scripts resolve their own location with `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"`
+- All scripts source `lib/common.sh` — do not redefine color constants, logging functions, or utility helpers inline
+- Scripts resolve their own location with `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` (varies by depth — see sourcing patterns above)
+- Use shared functions: `require_cmd`/`require_cluster` instead of inline prerequisite checks, `apply_yaml_template` instead of inline envsubst, `print_header` instead of inline echo headers, `wait_for_resource` instead of custom polling loops
 - `shfmt` formatting: 2-space indentation (tabs in Makefile), binary operators at line start, switch cases indented
 - `shellcheck` with severity=error; excluded codes: SC1091, SC2034, SC2086, SC2155, SC2046, SC2181, SC2126, SC2329
 - Cleanup operations use `--ignore-not-found=true` for idempotency
-- New scripts should source `lib/common.sh` and use its logging/dependency/retry functions
 - New Makefile targets need a `## Description` comment suffix for `make help` integration
 
 ## CI Pipeline
@@ -143,7 +162,7 @@ CI runs on PRs to main (`.github/workflows/pre-main.yml`):
 2. **shellcheck** — severity=error on `scripts/`
 3. **workload-partitioning-check** — validates script existence, executability, syntax
 4. **verify-structure** — directory layout and key files
-5. **integration-test** — deploys OCP 4.20 CRC cluster, runs `make quick-http-test`, API server cert creation/verification, workload partitioning check, network stack detection
+5. **integration-test** — deploys OCP 4.20/4.21 CRC cluster (matrix), runs `make quick-http-test`, API server cert creation/verification, workload partitioning check, network stack detection
 
 ## Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,8 +136,8 @@ The CI pipeline runs on every push and pull request with two jobs:
 - Ensures consistent formatting across the codebase
 - **Must pass** before integration tests run
 
-#### 2. Integration Test (OCP 4.19 + cert-manager)
-- Deploys a real OpenShift 4.19 cluster using [quick-ocp](https://github.com/palmsoftware/quick-ocp)
+#### 2. Integration Test (OCP 4.20/4.21 + cert-manager)
+- Deploys a real OpenShift cluster using [quick-ocp](https://github.com/palmsoftware/quick-ocp)
 - Installs cert-manager-operator
 - Runs the complete `make quick-test` workflow:
   - Installs fake DNS for air-gapped testing
@@ -195,6 +195,7 @@ Update documentation when you:
 - **PEBBLE-USAGE.md** - Pebble-specific usage and examples
 - **NETWORK-SUPPORT.md** - IPv4/IPv6/dual-stack testing
 - **DNS01-SETUP.md** - DNS-01 challenge configuration
+- **IBU-TESTING.md** - Image-Based Upgrade certificate loss validation
 - **CONTRIBUTING.md** - This file
 
 ### Documentation Style
@@ -209,33 +210,38 @@ Update documentation when you:
 
 When adding a new script:
 
-1. **Place the script in the `scripts/` directory:**
+1. **Place the script in the appropriate directory and make it executable:**
    ```bash
-   # Create your new script
    touch scripts/new-script.sh
    chmod +x scripts/new-script.sh
    ```
 
-2. **Follow the existing pattern:**
-   - Check prerequisites at the start
-   - Use colored output functions (log_info, log_warn, log_error)
-   - Make scripts idempotent
-   - Display helpful next steps
+2. **Source `lib/common.sh` — do not redefine colors or logging inline:**
+   ```bash
+   #!/bin/bash
+   set -euo pipefail
 
-3. **Add configuration via environment variables:**
+   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+   source "$SCRIPT_DIR/../lib/common.sh"
+   ```
+
+3. **Use shared functions from common.sh:**
+   - `require_cmd oc envsubst` and `require_cluster` instead of inline prerequisite checks
+   - `print_header "Title"` instead of inline echo header blocks
+   - `apply_yaml_template "$YAML_DIR/file.yaml" "ResourceType"` instead of inline envsubst
+   - `wait_for_resource "deployment/name" "namespace" "300s"` instead of custom polling loops
+   - `ensure_namespace "name"` instead of inline namespace creation
+   - `check_deployment_exists "name" "namespace"` for idempotency checks
+
+4. **Add configuration via environment variables:**
    ```bash
    export VARIABLE_NAME="${VARIABLE_NAME:-default-value}"
    ```
 
-4. **Add error handling:**
-   ```bash
-   set -euo pipefail
-   ```
-
-5. **Add a Makefile target:**
+5. **Add a Makefile target with a help comment:**
    ```makefile
-   new-target:
-       @./scripts/new-script.sh
+   new-target: ## Description for make help
+   	@./scripts/new-script.sh
    ```
 
 6. **Document the script:**
@@ -245,8 +251,7 @@ When adding a new script:
 
 7. **Add YAML manifests:**
    - Place in appropriate `yaml/` subdirectory
-   - Use `envsubst` for variable substitution
-   - Document variables in script comments
+   - Use `envsubst` for variable substitution via `apply_yaml_template`
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Scripts for testing and managing cert-manager-operator on OpenShift clusters wit
 
 ## Quick Start
 
-Test DNS-01 certificate issuance in 3 commands:
+Test certificate issuance in 3 commands:
 
 ```bash
 make install-cert-manager-operator  # Install cert-manager-operator
-make quick-test                     # Setup Pebble, fake DNS, and test wildcard cert
+make quick-http-test                # Setup Pebble (ALWAYS_VALID=1) + HTTP-01 cert
 make clean                          # Clean up when done
 ```
 
-The `quick-test` target installs Pebble ACME server (air-gapped), fake DNS server, configures DNS forwarding, creates a DNS-01 ClusterIssuer, and requests a wildcard certificate (`*.example.com`).
+The `quick-http-test` target installs Pebble ACME server with auto-validation, creates an HTTP-01 ClusterIssuer, and requests a test certificate. For DNS-01 with air-gapped fake DNS, use `make quick-dns-test` instead.
 
 **Note:** Check certificate progress with `make verify-cert` if needed.
 
@@ -68,6 +68,17 @@ Run `make help` to see all available targets. Key targets include:
 - `make test-cert` / `make verify-cert` - Test and verify certificates
 - `make clean` - Clean up all resources (keeps operator)
 
+### IBU Testing
+
+Test certificate behavior during Image-Based Upgrade (IBU) simulation:
+
+```bash
+make quick-ibu-test    # End-to-end IBU certificate loss validation
+make clean-ibu         # Clean up IBU test resources
+```
+
+See [IBU-TESTING.md](./IBU-TESTING.md) for details on validating cert-manager behavior during IBU.
+
 ## Documentation
 
 - [INSTALLATION.md](./INSTALLATION.md) - Detailed installation instructions
@@ -75,6 +86,7 @@ Run `make help` to see all available targets. Key targets include:
 - [PEBBLE-USAGE.md](./PEBBLE-USAGE.md) - Pebble usage guide
 - [NETWORK-SUPPORT.md](./NETWORK-SUPPORT.md) - IPv4/IPv6/dual-stack testing
 - [DNS01-SETUP.md](./DNS01-SETUP.md) - DNS-01 challenge setup
+- [IBU-TESTING.md](./IBU-TESTING.md) - Image-Based Upgrade certificate loss validation
 - [CONTRIBUTING.md](./CONTRIBUTING.md) - CI/CD and contributing guidelines
 
 ## Troubleshooting

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -258,3 +258,213 @@ wait_for_resource() {
 		return 1
 	fi
 }
+
+# Print a formatted section header
+# Usage: print_header "Title"
+print_header() {
+	local title="${1:-Script Execution}"
+	echo
+	echo "========================================"
+	echo "  $title"
+	echo "========================================"
+	echo
+}
+
+# Apply a YAML template with envsubst variable substitution
+# Usage: apply_yaml_template <yaml_file> <resource_type>
+apply_yaml_template() {
+	local yaml_file="$1"
+	local resource_type="${2:-Resource}"
+
+	if [[ ! -f "$yaml_file" ]]; then
+		log_error "YAML file not found: $yaml_file"
+		return 1
+	fi
+
+	log_info "Applying $resource_type from $(basename "$yaml_file")..."
+	envsubst <"$yaml_file" | oc apply -f -
+}
+
+# Create a namespace if it doesn't exist
+# Usage: ensure_namespace <namespace>
+ensure_namespace() {
+	local namespace="$1"
+
+	if oc get namespace "$namespace" &>/dev/null; then
+		log_info "Namespace '$namespace' already exists."
+	else
+		log_info "Creating namespace '$namespace'..."
+		oc create namespace "$namespace"
+		log_info "Namespace '$namespace' created successfully."
+	fi
+}
+
+# Check if a deployment exists and is healthy
+# Usage: check_deployment_exists <deployment> <namespace>
+# Returns 0 if deployment exists and has ready replicas
+check_deployment_exists() {
+	local deployment="$1"
+	local namespace="$2"
+
+	if ! oc get namespace "$namespace" &>/dev/null; then
+		return 1
+	fi
+
+	if ! oc get deployment "$deployment" -n "$namespace" &>/dev/null; then
+		return 1
+	fi
+
+	local ready_replicas
+	ready_replicas=$(oc get deployment "$deployment" -n "$namespace" \
+		-o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+	local desired_replicas
+	desired_replicas=$(oc get deployment "$deployment" -n "$namespace" \
+		-o jsonpath='{.spec.replicas}' 2>/dev/null || echo "1")
+
+	if [[ "$ready_replicas" = "$desired_replicas" ]] && [[ "$ready_replicas" != "0" ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+# Wait for a CSV (ClusterServiceVersion) to reach Succeeded phase
+# Usage: wait_for_csv <namespace> <label_or_grep_pattern> <timeout_attempts>
+wait_for_csv() {
+	local namespace="$1"
+	local pattern="$2"
+	local max_attempts="${3:-60}"
+
+	log_info "Waiting for CSV to reach Succeeded phase..."
+	local attempt=0
+
+	while [[ $attempt -lt $max_attempts ]]; do
+		if oc get csv -n "$namespace" 2>/dev/null | grep -q "${pattern}.*Succeeded"; then
+			log_success "CSV is in Succeeded phase."
+			return 0
+		fi
+
+		attempt=$((attempt + 1))
+		if [[ $((attempt % 6)) -eq 0 ]]; then
+			echo -n " [${attempt}/${max_attempts}]"
+		else
+			echo -n "."
+		fi
+		sleep 5
+	done
+	echo
+
+	log_error "Timeout waiting for CSV to reach Succeeded phase."
+	return 1
+}
+
+# Wait for OADP Backup or Restore to complete
+# Usage: wait_for_backup_restore <type> <name> <namespace> <max_attempts>
+# type: "backup" or "restore"
+wait_for_backup_restore() {
+	local resource_type="$1"
+	local name="$2"
+	local namespace="$3"
+	local max_attempts="${4:-60}"
+
+	log_info "Waiting for $resource_type to complete..."
+	local attempt=0
+
+	while [[ $attempt -lt $max_attempts ]]; do
+		local phase
+		phase=$(oc get "$resource_type" "$name" -n "$namespace" \
+			-o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+
+		case "$phase" in
+		Completed)
+			log_success "${resource_type^} completed successfully!"
+			return 0
+			;;
+		Failed | PartiallyFailed)
+			log_error "${resource_type^} failed with phase: $phase"
+			oc describe "$resource_type" "$name" -n "$namespace"
+			return 1
+			;;
+		esac
+
+		attempt=$((attempt + 1))
+		if [[ $((attempt % 6)) -eq 0 ]]; then
+			log_info "${resource_type^} phase: $phase ($attempt/$max_attempts)"
+		fi
+		sleep 5
+	done
+
+	log_error "Timeout waiting for $resource_type to complete"
+	return 1
+}
+
+# Build lca.openshift.io/apply-label annotation value for cert resources
+# Usage: build_lca_annotations <namespace>
+build_lca_annotations() {
+	local namespace="$1"
+	local annotation_parts=()
+
+	local cert_names
+	cert_names=$(oc get certificates -n "$namespace" \
+		-o jsonpath='{.items[*].metadata.name}')
+
+	for cert_name in $cert_names; do
+		annotation_parts+=("cert-manager.io/v1/certificates/$namespace/$cert_name")
+
+		local secret_name
+		secret_name=$(oc get certificate "$cert_name" -n "$namespace" \
+			-o jsonpath='{.spec.secretName}' 2>/dev/null || echo "")
+
+		if [[ -n "$secret_name" ]]; then
+			if oc get secret "$secret_name" -n "$namespace" &>/dev/null; then
+				annotation_parts+=("v1/secrets/$namespace/$secret_name")
+			fi
+		fi
+	done
+
+	local annotation_value
+	annotation_value=$(
+		IFS=','
+		echo "${annotation_parts[*]}"
+	)
+
+	echo "$annotation_value"
+}
+
+# Capture TLS secret checksums for a namespace in a single API call
+# Usage: capture_secret_checksums <namespace> <output_file>
+capture_secret_checksums() {
+	local namespace="$1"
+	local checksums_file="$2"
+
+	local secrets_json
+	secrets_json=$(oc get secrets -n "$namespace" -o json 2>/dev/null || echo '{"items":[]}')
+
+	echo "[]" >"$checksums_file"
+
+	local secret_entries
+	secret_entries=$(echo "$secrets_json" | jq -r '
+		[.items[] | select(.type == "kubernetes.io/tls" or .data["tls.crt"] != null)]
+		| .[] | [.metadata.name, (.data["tls.crt"] // ""), (.data["tls.key"] // "")] | @tsv
+	')
+
+	while IFS=$'\t' read -r name cert_data key_data; do
+		[[ -z "$name" ]] && continue
+
+		local cert_checksum=""
+		if [[ -n "$cert_data" ]]; then
+			cert_checksum=$(echo "$cert_data" | shasum -a 256 | cut -d' ' -f1)
+		fi
+
+		local key_checksum=""
+		if [[ -n "$key_data" ]]; then
+			key_checksum=$(echo "$key_data" | shasum -a 256 | cut -d' ' -f1)
+		fi
+
+		jq --arg name "$name" \
+			--arg cert_checksum "$cert_checksum" \
+			--arg key_checksum "$key_checksum" \
+			'. += [{name: $name, cert_checksum: $cert_checksum, key_checksum: $key_checksum}]' \
+			"$checksums_file" >"$checksums_file.tmp" && mv "$checksums_file.tmp" "$checksums_file"
+	done <<<"$secret_entries"
+}

--- a/scripts/check-cluster-network.sh
+++ b/scripts/check-cluster-network.sh
@@ -7,51 +7,16 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# CYAN color not defined in common.sh, add locally
 CYAN='\033[0;36m'
-NC='\033[0m' # No Color
 
-# Function to print colored messages
-log_info() {
-	echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-log_warn() {
-	echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-	echo -e "${RED}[ERROR]${NC} $1"
-}
-
+# Function to print detail messages with cyan color
 log_detail() {
 	echo -e "${CYAN}[DETAIL]${NC} $1"
-}
-
-# Function to print header
-print_header() {
-	echo
-	echo "========================================"
-	echo "  OpenShift Network Configuration Check"
-	echo "========================================"
-	echo
-}
-
-# Function to check prerequisites
-check_prerequisites() {
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
 }
 
 # Function to get cluster version
@@ -85,10 +50,8 @@ check_network_type() {
 
 # Function to check IP families
 check_ip_families() {
+	local cluster_networks="$1"
 	log_info "Checking cluster IP address families..."
-
-	# Get cluster networks from network config
-	local cluster_networks=$(oc get network.config.openshift.io cluster -o json 2>/dev/null)
 
 	if [ -z "$cluster_networks" ]; then
 		log_error "Unable to retrieve network configuration"
@@ -253,16 +216,17 @@ check_cert_manager_compatibility() {
 
 # Function to provide recommendations
 provide_recommendations() {
+	local cluster_networks="$1"
 	log_info "========================================"
 	log_info "  Recommendations"
 	log_info "========================================"
 	echo
 
-	local cluster_networks=$(oc get network.config.openshift.io cluster -o json 2>/dev/null)
 	local has_ipv4=false
 	local has_ipv6=false
 
-	local cluster_cidrs=$(echo "$cluster_networks" | jq -r '.spec.clusterNetwork[]?.cidr' 2>/dev/null)
+	local cluster_cidrs
+	cluster_cidrs=$(echo "$cluster_networks" | jq -r '.spec.clusterNetwork[]?.cidr' 2>/dev/null)
 	for cidr in $cluster_cidrs; do
 		if [[ "$cidr" =~ : ]]; then
 			has_ipv6=true
@@ -313,15 +277,21 @@ export_network_info() {
 
 # Main execution
 main() {
-	print_header
-	check_prerequisites
+	print_header "OpenShift Network Configuration Check"
+	require_cmd oc
+	require_cluster
+
+	# Fetch network config once and cache it
+	local cluster_networks
+	cluster_networks=$(oc get network.config.openshift.io cluster -o json 2>/dev/null)
+
 	get_cluster_version
 	check_network_type
-	check_ip_families
+	check_ip_families "$cluster_networks"
 	check_api_server
 	check_node_addresses
 	check_cert_manager_compatibility
-	provide_recommendations
+	provide_recommendations "$cluster_networks"
 
 	# Export if requested
 	if [ "${EXPORT_FORMAT:-}" = "json" ]; then

--- a/scripts/create-apiserver-certificate.sh
+++ b/scripts/create-apiserver-certificate.sh
@@ -10,17 +10,9 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_detail() { echo -e "${BLUE}[DETAIL]${NC} $1"; }
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
 
 # Configuration
 ISSUER_NAME="${ISSUER_NAME:-pebble-issuer}"
@@ -28,26 +20,11 @@ CERT_NAMESPACE="${CERT_NAMESPACE:-openshift-config}"
 CERT_NAME="apiserver-cert"
 SECRET_NAME="apiserver-cert-tls"
 
-print_header() {
-	echo
-	echo "========================================"
-	echo "  Create API Server Certificate"
-	echo "========================================"
-	echo
-}
-
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
+	require_cmd oc
+	require_cluster
 
 	# Check if cert-manager is installed
 	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
@@ -70,34 +47,25 @@ get_api_server_info() {
 
 	# Get the API server URL
 	API_URL=$(oc whoami --show-server)
-	log_detail "API Server URL: $API_URL"
+	log_debug "API Server URL: $API_URL"
 
 	# Extract hostname from URL
 	API_HOST=$(echo "$API_URL" | sed -E 's|https?://([^:/]+).*|\1|')
-	log_detail "API Server Hostname: $API_HOST"
+	log_debug "API Server Hostname: $API_HOST"
 
 	# Get cluster base domain
 	CLUSTER_DOMAIN=$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "")
 	if [ -n "$CLUSTER_DOMAIN" ]; then
-		log_detail "Cluster Domain: $CLUSTER_DOMAIN"
+		log_debug "Cluster Domain: $CLUSTER_DOMAIN"
 		# Extract base domain (remove apps. prefix if present)
-		BASE_DOMAIN=$(echo "$CLUSTER_DOMAIN" | sed 's/^apps\.//')
-		log_detail "Base Domain: $BASE_DOMAIN"
+		BASE_DOMAIN="${CLUSTER_DOMAIN#apps.}"
+		log_debug "Base Domain: $BASE_DOMAIN"
 	else
 		log_warn "Could not determine cluster domain"
 		BASE_DOMAIN=""
 	fi
 
 	echo
-}
-
-create_namespace_if_needed() {
-	if ! oc get namespace "$CERT_NAMESPACE" &>/dev/null; then
-		log_info "Creating namespace: $CERT_NAMESPACE"
-		oc create namespace "$CERT_NAMESPACE"
-	else
-		log_info "Namespace '$CERT_NAMESPACE' already exists"
-	fi
 }
 
 create_certificate() {
@@ -248,10 +216,10 @@ EOF
 }
 
 main() {
-	print_header
+	print_header "Create API Server Certificate"
 	check_prerequisites
 	get_api_server_info
-	create_namespace_if_needed
+	ensure_namespace "$CERT_NAMESPACE"
 	create_certificate
 	wait_for_certificate || true
 	display_certificate_info

--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -7,48 +7,26 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
-
-# Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
 YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"
 
-# Configuration
 export ISSUER_NAME="${ISSUER_NAME:-pebble-dns01-issuer}"
 export ACME_SERVER_URL="${ACME_SERVER_URL:-https://pebble.pebble.svc.cluster.local:14000/dir}"
 export ACME_EMAIL="${ACME_EMAIL:-test@example.com}"
 export DNS_SERVER="${DNS_SERVER:-8.8.8.8:53}"
 
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+print_header "Create DNS-01 ClusterIssuer"
 
-echo
-echo "========================================"
-echo "  Create DNS-01 ClusterIssuer"
-echo "========================================"
-echo
+require_cluster
 
-# Check prerequisites
-if ! oc whoami &>/dev/null; then
-	log_error "Not logged into OpenShift"
-	exit 1
-fi
-
-# Create dummy secret for RFC2136 (not actually used with ALWAYS_VALID)
-# Secret must be in cert-manager namespace for ClusterIssuer
-# Value must be valid base64
 log_info "Creating dummy RFC2136 secret in cert-manager namespace..."
 oc create secret generic rfc2136-credentials \
 	--from-literal=tsig-secret=$(echo -n "dummy-secret-key" | base64) \
 	--namespace cert-manager \
 	--dry-run=client -o yaml | oc apply -f -
 
-# Create ClusterIssuer
 log_info "Creating DNS-01 ClusterIssuer..."
 envsubst <"$YAML_DIR/pebble-dns01-simple-clusterissuer.yaml" | oc apply -f -
 

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -7,94 +7,16 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
 YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"
 
-# Configuration (exported for envsubst)
 export ISSUER_NAME="${ISSUER_NAME:-pebble-issuer}"
 export ACME_SERVER_URL="${ACME_SERVER_URL:-https://pebble.pebble.svc.cluster.local:14000/dir}"
 export ACME_EMAIL="${ACME_EMAIL:-test@example.com}"
 export INGRESS_CLASS="${INGRESS_CLASS:-openshift-default}"
 
-# Function to print colored messages
-log_info() {
-	echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-log_warn() {
-	echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-	echo -e "${RED}[ERROR]${NC} $1"
-}
-
-log_detail() {
-	echo -e "${BLUE}[DETAIL]${NC} $1"
-}
-
-# Function to print header
-print_header() {
-	echo
-	echo "========================================"
-	echo "  Create cert-manager ClusterIssuer"
-	echo "========================================"
-	echo
-}
-
-# Function to check prerequisites
-check_prerequisites() {
-	log_info "Checking prerequisites..."
-
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! command -v envsubst &>/dev/null; then
-		log_error "envsubst command not found. Please install gettext package."
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
-
-	# Check if cert-manager is installed
-	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
-		log_error "cert-manager not found. Please install cert-manager-operator first."
-		log_info "  Run: make install-cert-manager-operator"
-		exit 1
-	fi
-
-	# Wait for cert-manager webhook to be ready before creating CRDs
-	log_info "Waiting for cert-manager webhook to be ready..."
-	if ! oc wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager; then
-		log_error "Timeout waiting for cert-manager webhook to be ready."
-		log_info "  Check webhook status: oc get deployment cert-manager-webhook -n cert-manager"
-		exit 1
-	fi
-	log_info "cert-manager webhook is ready."
-
-	# Check if YAML directory exists
-	if [ ! -d "$YAML_DIR" ]; then
-		log_error "YAML directory not found: $YAML_DIR"
-		exit 1
-	fi
-
-	log_info "Prerequisites check passed."
-}
-
-# Function to check if Pebble is available (optional but recommended)
 check_pebble() {
 	log_info "Checking if Pebble is available..."
 
@@ -112,7 +34,6 @@ check_pebble() {
 	else
 		log_info "Pebble ACME server is available."
 
-		# Check if Pebble is ready
 		local ready_replicas=$(oc get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 		if [ "$ready_replicas" = "0" ]; then
 			log_warn "Pebble deployment exists but no replicas are ready."
@@ -122,16 +43,14 @@ check_pebble() {
 	fi
 }
 
-# Function to check if issuer already exists
 check_existing_issuer() {
 	log_info "Checking for existing ClusterIssuer '$ISSUER_NAME'..."
 
 	if oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
 		log_warn "ClusterIssuer '$ISSUER_NAME' already exists."
 
-		# Show current configuration
 		local current_server=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.server}' 2>/dev/null || echo "unknown")
-		log_detail "Current ACME server: $current_server"
+		log_debug "Current ACME server: $current_server"
 
 		echo
 		read -p "Overwrite existing issuer? (y/N): " -n 1 -r
@@ -143,7 +62,6 @@ check_existing_issuer() {
 	fi
 }
 
-# Function to display configuration
 display_configuration() {
 	log_info "========================================"
 	log_info "  ClusterIssuer Configuration"
@@ -157,7 +75,6 @@ display_configuration() {
 	echo
 }
 
-# Function to create issuer
 create_issuer() {
 	log_info "Creating ClusterIssuer '$ISSUER_NAME'..."
 
@@ -171,7 +88,6 @@ create_issuer() {
 	fi
 }
 
-# Function to verify issuer
 verify_issuer() {
 	log_info "Waiting for ClusterIssuer to be ready..."
 
@@ -253,10 +169,31 @@ display_next_steps() {
 	echo
 }
 
-# Main execution
 main() {
-	print_header
-	check_prerequisites
+	print_header "Create cert-manager ClusterIssuer"
+
+	require_cmd oc envsubst
+	require_cluster
+
+	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
+		log_error "cert-manager not found. Please install cert-manager-operator first."
+		log_info "  Run: make install-cert-manager-operator"
+		exit 1
+	fi
+
+	log_info "Waiting for cert-manager webhook to be ready..."
+	if ! oc wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager; then
+		log_error "Timeout waiting for cert-manager webhook to be ready."
+		log_info "  Check webhook status: oc get deployment cert-manager-webhook -n cert-manager"
+		exit 1
+	fi
+	log_info "cert-manager webhook is ready."
+
+	if [ ! -d "$YAML_DIR" ]; then
+		log_error "YAML directory not found: $YAML_DIR"
+		exit 1
+	fi
+
 	display_configuration
 	check_pebble
 	check_existing_issuer
@@ -265,5 +202,4 @@ main() {
 	display_next_steps
 }
 
-# Run main function
 main

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -7,65 +7,22 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Get script directory
+# Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
 YAML_DIR="${SCRIPT_DIR}/../yaml/certificates"
 
 # Configuration (exported for envsubst)
 export ISSUER_NAME="${ISSUER_NAME:-pebble-issuer}"
 export CERT_NAMESPACE="${CERT_NAMESPACE:-default}"
 
-# Function to print colored messages
-log_info() {
-	echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-log_warn() {
-	echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-	echo -e "${RED}[ERROR]${NC} $1"
-}
-
-log_detail() {
-	echo -e "${BLUE}[DETAIL]${NC} $1"
-}
-
-# Function to print header
-print_header() {
-	echo
-	echo "========================================"
-	echo "  Create Test Certificates"
-	echo "========================================"
-	echo
-}
-
 # Function to check prerequisites
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! command -v envsubst &>/dev/null; then
-		log_error "envsubst command not found. Please install gettext package."
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
+	require_cmd oc envsubst
+	require_cluster
 
 	# Check if cert-manager is installed
 	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
@@ -183,7 +140,8 @@ wait_for_certificates() {
 		# Check each certificate
 		for cert in test-cert-simple test-cert-app test-cert-api; do
 			if oc get certificate "$cert" -n "$CERT_NAMESPACE" &>/dev/null; then
-				local ready=$(oc get certificate "$cert" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
+				local ready
+				ready=$(oc get certificate "$cert" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
 
 				if [ "$ready" != "True" ]; then
 					all_ready=false
@@ -200,7 +158,7 @@ wait_for_certificates() {
 		done
 
 		if [ "$all_ready" = true ]; then
-			log_info "All certificates are ready!"
+			log_success "All certificates are ready!"
 			break
 		fi
 
@@ -289,7 +247,7 @@ display_next_steps() {
 
 # Main execution
 main() {
-	print_header
+	print_header "Create Test Certificates"
 	check_prerequisites
 	create_test_certificates
 	wait_for_certificates

--- a/scripts/ibu/capture-cert-state.sh
+++ b/scripts/ibu/capture-cert-state.sh
@@ -17,15 +17,6 @@ STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"
 STATE_LABEL="${STATE_LABEL:-before}"
 TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 
-print_header() {
-	echo
-	echo "========================================"
-	echo "  Certificate State Capture"
-	echo "  Label: $STATE_LABEL"
-	echo "========================================"
-	echo
-}
-
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 	require_cmd oc jq
@@ -82,40 +73,8 @@ capture_secrets() {
 		})
 	' >"$secrets_file"
 
-	# Compute SHA256 checksums for each TLS secret's certificate data
-	echo "[]" >"$checksums_file"
-
-	# shellcheck disable=SC2016
-	local secret_names
-	secret_names=$(oc get secrets -n "$TARGET_NAMESPACE" -o json 2>/dev/null | jq -r '
-		.items | map(select(.type == "kubernetes.io/tls" or (.data["tls.crt"] != null))) | .[].metadata.name
-	')
-
-	for secret_name in $secret_names; do
-		# Get the certificate data and compute checksum
-		local cert_data
-		cert_data=$(oc get secret "$secret_name" -n "$TARGET_NAMESPACE" -o jsonpath='{.data.tls\.crt}' 2>/dev/null || echo "")
-
-		if [ -n "$cert_data" ]; then
-			local checksum
-			checksum=$(echo "$cert_data" | shasum -a 256 | cut -d' ' -f1)
-
-			# Also capture key checksum
-			local key_data
-			key_data=$(oc get secret "$secret_name" -n "$TARGET_NAMESPACE" -o jsonpath='{.data.tls\.key}' 2>/dev/null || echo "")
-			local key_checksum=""
-			if [ -n "$key_data" ]; then
-				key_checksum=$(echo "$key_data" | shasum -a 256 | cut -d' ' -f1)
-			fi
-
-			# Add to checksums file
-			jq --arg name "$secret_name" \
-				--arg cert_checksum "$checksum" \
-				--arg key_checksum "$key_checksum" \
-				'. += [{name: $name, cert_checksum: $cert_checksum, key_checksum: $key_checksum}]' \
-				"$checksums_file" >"$checksums_file.tmp" && mv "$checksums_file.tmp" "$checksums_file"
-		fi
-	done
+	# Capture checksums using shared library function
+	capture_secret_checksums "$TARGET_NAMESPACE" "$checksums_file"
 
 	local count
 	count=$(jq 'length' "$checksums_file")
@@ -168,33 +127,26 @@ capture_metadata() {
 EOF
 }
 
-print_summary() {
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo "  State Capture Summary ($STATE_LABEL)"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
-
+print_capture_summary() {
 	local cert_count
 	cert_count=$(jq 'length' "$STATE_DIR/certificates-${STATE_LABEL}.json" 2>/dev/null || echo "0")
-	echo "  Certificates:     $cert_count"
 
 	local secret_count
 	secret_count=$(jq 'length' "$STATE_DIR/checksums-${STATE_LABEL}.json" 2>/dev/null || echo "0")
-	echo "  TLS Secrets:      $secret_count"
 
 	local issuer_count
 	issuer_count=$(jq 'length' "$STATE_DIR/issuers-${STATE_LABEL}.json" 2>/dev/null || echo "0")
-	echo "  ClusterIssuers:   $issuer_count"
 
-	echo
-	echo "  State saved to:   $STATE_DIR"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
+	print_summary \
+		"State Label" "$STATE_LABEL" \
+		"Certificates" "$cert_count" \
+		"TLS Secrets" "$secret_count" \
+		"ClusterIssuers" "$issuer_count" \
+		"State saved to" "$STATE_DIR"
 }
 
 main() {
-	print_header
+	print_header "Certificate State Capture - Label: $STATE_LABEL"
 	check_prerequisites
 	setup_state_directory
 
@@ -203,7 +155,7 @@ main() {
 	capture_issuers
 	capture_metadata
 
-	print_summary
+	print_capture_summary
 	log_success "State capture complete!"
 }
 

--- a/scripts/ibu/install-minio.sh
+++ b/scripts/ibu/install-minio.sh
@@ -14,14 +14,6 @@ source "$SCRIPT_DIR/../lib/common.sh"
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/minio"
 MINIO_NAMESPACE="${MINIO_NAMESPACE:-minio}"
 
-print_header() {
-	echo
-	echo "========================================"
-	echo "  MinIO Object Storage Installation"
-	echo "========================================"
-	echo
-}
-
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 	require_cmd oc
@@ -32,15 +24,9 @@ check_prerequisites() {
 check_existing_installation() {
 	log_info "Checking for existing MinIO installation..."
 
-	if oc get namespace "$MINIO_NAMESPACE" &>/dev/null; then
-		if oc get deployment minio -n "$MINIO_NAMESPACE" &>/dev/null; then
-			local ready_replicas
-			ready_replicas=$(oc get deployment minio -n "$MINIO_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-			if [ "$ready_replicas" != "0" ]; then
-				log_info "MinIO is already installed and running."
-				return 0
-			fi
-		fi
+	if check_deployment_exists minio "$MINIO_NAMESPACE"; then
+		log_info "MinIO is already installed and running."
+		return 0
 	fi
 
 	log_info "No existing MinIO installation found."
@@ -68,33 +54,6 @@ install_minio() {
 
 	log_info "Creating console route..."
 	oc apply -f "$YAML_DIR/route.yaml"
-}
-
-wait_for_minio() {
-	log_info "Waiting for MinIO to be ready..."
-
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		if oc get deployment minio -n "$MINIO_NAMESPACE" &>/dev/null; then
-			local ready_replicas
-			ready_replicas=$(oc get deployment minio -n "$MINIO_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-			if [ "$ready_replicas" = "1" ]; then
-				log_success "MinIO is ready!"
-				return 0
-			fi
-		fi
-
-		attempt=$((attempt + 1))
-		echo -n "."
-		sleep 5
-	done
-	echo
-
-	log_error "Timeout waiting for MinIO to be ready."
-	log_info "Check status with: oc get pods -n $MINIO_NAMESPACE"
-	return 1
 }
 
 create_velero_bucket() {
@@ -138,14 +97,14 @@ verify_installation() {
 }
 
 main() {
-	print_header
+	print_header "MinIO Object Storage Installation"
 	check_prerequisites
 
 	if check_existing_installation; then
 		log_info "Verifying existing installation..."
 	else
 		install_minio
-		wait_for_minio
+		wait_for_resource "deployment/minio" "$MINIO_NAMESPACE" "300s"
 		create_velero_bucket
 	fi
 

--- a/scripts/ibu/install-oadp.sh
+++ b/scripts/ibu/install-oadp.sh
@@ -14,14 +14,6 @@ source "$SCRIPT_DIR/../lib/common.sh"
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/oadp"
 OADP_NAMESPACE="${OADP_NAMESPACE:-openshift-adp}"
 
-print_header() {
-	echo
-	echo "========================================"
-	echo "  OADP Operator Installation"
-	echo "========================================"
-	echo
-}
-
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 	require_cmd oc
@@ -72,35 +64,7 @@ install_oadp() {
 	oc apply -f "$YAML_DIR/subscription.yaml"
 
 	# Wait for operator to be ready
-	wait_for_operator
-}
-
-wait_for_operator() {
-	log_info "Waiting for OADP operator to be ready..."
-
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		# Check if CSV is succeeded
-		local csv_phase
-		csv_phase=$(oc get csv -n "$OADP_NAMESPACE" -l operators.coreos.com/redhat-oadp-operator.openshift-adp -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "")
-
-		if [ "$csv_phase" = "Succeeded" ]; then
-			log_success "OADP operator is ready!"
-			return 0
-		fi
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			log_info "Waiting for operator... ($attempt/$max_attempts)"
-		fi
-		sleep 5
-	done
-
-	log_error "Timeout waiting for OADP operator."
-	log_info "Check status with: oc get csv -n $OADP_NAMESPACE"
-	return 1
+	wait_for_csv "$OADP_NAMESPACE" "redhat-oadp-operator"
 }
 
 configure_dpa() {
@@ -167,7 +131,7 @@ verify_installation() {
 }
 
 main() {
-	print_header
+	print_header "OADP Operator Installation"
 	check_prerequisites
 
 	if check_existing_installation; then

--- a/scripts/ibu/label-cert-resources.sh
+++ b/scripts/ibu/label-cert-resources.sh
@@ -17,17 +17,6 @@ source "$SCRIPT_DIR/../lib/common.sh"
 TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 BACKUP_NAME="${BACKUP_NAME:-ibu-preserved-backup}"
 
-print_header() {
-	echo
-	echo "========================================"
-	echo "  LCA Resource Labeling"
-	echo "========================================"
-	echo
-	echo "  Target Namespace: $TARGET_NAMESPACE"
-	echo "  Backup Name:      $BACKUP_NAME"
-	echo
-}
-
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 	require_cmd oc jq
@@ -82,42 +71,6 @@ label_secrets() {
 	log_success "Labeled $labeled TLS secrets"
 }
 
-build_annotation_list() {
-	log_info "Building lca.openshift.io/apply-label annotation value..."
-
-	local annotation_parts=()
-
-	# Get all certificates
-	local cert_names
-	cert_names=$(oc get certificates -n "$TARGET_NAMESPACE" -o jsonpath='{.items[*].metadata.name}')
-
-	for cert_name in $cert_names; do
-		# Add certificate
-		annotation_parts+=("cert-manager.io/v1/certificates/$TARGET_NAMESPACE/$cert_name")
-
-		# Get the associated secret name
-		local secret_name
-		secret_name=$(oc get certificate "$cert_name" -n "$TARGET_NAMESPACE" \
-			-o jsonpath='{.spec.secretName}' 2>/dev/null || echo "")
-
-		if [ -n "$secret_name" ]; then
-			# Check if secret exists
-			if oc get secret "$secret_name" -n "$TARGET_NAMESPACE" &>/dev/null; then
-				annotation_parts+=("v1/secrets/$TARGET_NAMESPACE/$secret_name")
-			fi
-		fi
-	done
-
-	# Join with commas
-	local annotation_value
-	annotation_value=$(
-		IFS=','
-		echo "${annotation_parts[*]}"
-	)
-
-	echo "$annotation_value"
-}
-
 print_summary() {
 	echo
 	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -137,7 +90,11 @@ print_summary() {
 }
 
 main() {
-	print_header
+	print_header "LCA Resource Labeling"
+	log_info "Target Namespace: $TARGET_NAMESPACE"
+	log_info "Backup Name: $BACKUP_NAME"
+	echo
+
 	check_prerequisites
 
 	label_certificates
@@ -145,7 +102,7 @@ main() {
 
 	# Output the annotation value for use in backup CRs
 	local annotation_value
-	annotation_value=$(build_annotation_list)
+	annotation_value=$(build_lca_annotations "$TARGET_NAMESPACE")
 
 	echo
 	log_info "Annotation value for Backup CR:"

--- a/scripts/ibu/simulate-ibu-backup-restore.sh
+++ b/scripts/ibu/simulate-ibu-backup-restore.sh
@@ -23,17 +23,6 @@ export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 export BACKUP_NAME="${BACKUP_NAME:-ibu-cert-test-$(date +%s)}"
 export RESTORE_NAME="${RESTORE_NAME:-${BACKUP_NAME}-restore}"
 
-print_header() {
-	echo
-	echo "========================================"
-	echo "  IBU Simulation via OADP"
-	echo "========================================"
-	echo
-	echo "  Target Namespace: $TARGET_NAMESPACE"
-	echo "  Backup Name:      $BACKUP_NAME"
-	echo
-}
-
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 	require_cmd oc envsubst
@@ -73,35 +62,7 @@ create_backup() {
 	envsubst <"$YAML_DIR/backup.yaml" | oc apply -f -
 
 	# Wait for backup to complete
-	log_info "Waiting for backup to complete..."
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local phase
-		phase=$(oc get backup "$BACKUP_NAME" -n "$OADP_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-
-		case "$phase" in
-		Completed)
-			log_success "Backup completed successfully!"
-			return 0
-			;;
-		Failed | PartiallyFailed)
-			log_error "Backup failed with phase: $phase"
-			oc describe backup "$BACKUP_NAME" -n "$OADP_NAMESPACE"
-			return 1
-			;;
-		esac
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			log_info "Backup phase: $phase ($attempt/$max_attempts)"
-		fi
-		sleep 5
-	done
-
-	log_error "Timeout waiting for backup to complete"
-	return 1
+	wait_for_backup_restore "backup" "$BACKUP_NAME" "$OADP_NAMESPACE"
 }
 
 delete_namespace_resources() {
@@ -135,35 +96,7 @@ restore_from_backup() {
 	envsubst <"$YAML_DIR/restore.yaml" | oc apply -f -
 
 	# Wait for restore to complete
-	log_info "Waiting for restore to complete..."
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local phase
-		phase=$(oc get restore "$RESTORE_NAME" -n "$OADP_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-
-		case "$phase" in
-		Completed)
-			log_success "Restore completed successfully!"
-			return 0
-			;;
-		Failed | PartiallyFailed)
-			log_error "Restore failed with phase: $phase"
-			oc describe restore "$RESTORE_NAME" -n "$OADP_NAMESPACE"
-			return 1
-			;;
-		esac
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			log_info "Restore phase: $phase ($attempt/$max_attempts)"
-		fi
-		sleep 5
-	done
-
-	log_error "Timeout waiting for restore to complete"
-	return 1
+	wait_for_backup_restore "restore" "$RESTORE_NAME" "$OADP_NAMESPACE"
 }
 
 wait_for_cert_manager_reconcile() {
@@ -202,7 +135,11 @@ print_summary() {
 }
 
 main() {
-	print_header
+	print_header "IBU Simulation via OADP"
+	log_info "Target Namespace: $TARGET_NAMESPACE"
+	log_info "Backup Name: $BACKUP_NAME"
+	echo
+
 	check_prerequisites
 
 	create_backup

--- a/scripts/ibu/simulate-ibu-preserved.sh
+++ b/scripts/ibu/simulate-ibu-preserved.sh
@@ -21,18 +21,6 @@ export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 export BACKUP_NAME="${BACKUP_NAME:-ibu-preserved-$(date +%s)}"
 export RESTORE_NAME="${RESTORE_NAME:-${BACKUP_NAME}-restore}"
 
-print_header() {
-	echo
-	echo "========================================"
-	echo "  IBU Simulation (Preserved Mode)"
-	echo "========================================"
-	echo
-	echo "  Target Namespace: $TARGET_NAMESPACE"
-	echo "  Backup Name:      $BACKUP_NAME"
-	echo "  Mode:             Certificate Preservation"
-	echo
-}
-
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 	require_cmd oc jq envsubst
@@ -64,47 +52,12 @@ check_prerequisites() {
 	log_info "Prerequisites check passed."
 }
 
-build_apply_label_annotation() {
-	# Build the lca.openshift.io/apply-label annotation value
-	local annotation_parts=()
-
-	# Get all certificates
-	local cert_names
-	cert_names=$(oc get certificates -n "$TARGET_NAMESPACE" -o jsonpath='{.items[*].metadata.name}')
-
-	for cert_name in $cert_names; do
-		# Add certificate
-		annotation_parts+=("cert-manager.io/v1/certificates/$TARGET_NAMESPACE/$cert_name")
-
-		# Get the associated secret name
-		local secret_name
-		secret_name=$(oc get certificate "$cert_name" -n "$TARGET_NAMESPACE" \
-			-o jsonpath='{.spec.secretName}' 2>/dev/null || echo "")
-
-		if [ -n "$secret_name" ]; then
-			# Check if secret exists
-			if oc get secret "$secret_name" -n "$TARGET_NAMESPACE" &>/dev/null; then
-				annotation_parts+=("v1/secrets/$TARGET_NAMESPACE/$secret_name")
-			fi
-		fi
-	done
-
-	# Join with commas
-	local annotation_value
-	annotation_value=$(
-		IFS=','
-		echo "${annotation_parts[*]}"
-	)
-
-	echo "$annotation_value"
-}
-
 create_preserved_backup() {
 	log_info "Creating preserved backup: $BACKUP_NAME"
 
 	# Build the apply-label annotation
 	local apply_label_annotation
-	apply_label_annotation=$(build_apply_label_annotation)
+	apply_label_annotation=$(build_lca_annotations "$TARGET_NAMESPACE")
 
 	log_info "Using apply-label annotation: $apply_label_annotation"
 
@@ -112,35 +65,7 @@ create_preserved_backup() {
 	envsubst <"$YAML_DIR/backup-preserved.yaml" | oc apply -f -
 
 	# Wait for backup to complete
-	log_info "Waiting for backup to complete..."
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local phase
-		phase=$(oc get backup "$BACKUP_NAME" -n "$OADP_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-
-		case "$phase" in
-		Completed)
-			log_success "Backup completed successfully!"
-			return 0
-			;;
-		Failed | PartiallyFailed)
-			log_error "Backup failed with phase: $phase"
-			oc describe backup "$BACKUP_NAME" -n "$OADP_NAMESPACE"
-			return 1
-			;;
-		esac
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			log_info "Backup phase: $phase ($attempt/$max_attempts)"
-		fi
-		sleep 5
-	done
-
-	log_error "Timeout waiting for backup to complete"
-	return 1
+	wait_for_backup_restore "backup" "$BACKUP_NAME" "$OADP_NAMESPACE"
 }
 
 delete_namespace_resources() {
@@ -174,35 +99,7 @@ restore_from_backup() {
 	envsubst <"$YAML_DIR/restore-preserved.yaml" | oc apply -f -
 
 	# Wait for restore to complete
-	log_info "Waiting for restore to complete..."
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local phase
-		phase=$(oc get restore "$RESTORE_NAME" -n "$OADP_NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-
-		case "$phase" in
-		Completed)
-			log_success "Restore completed successfully!"
-			return 0
-			;;
-		Failed | PartiallyFailed)
-			log_error "Restore failed with phase: $phase"
-			oc describe restore "$RESTORE_NAME" -n "$OADP_NAMESPACE"
-			return 1
-			;;
-		esac
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			log_info "Restore phase: $phase ($attempt/$max_attempts)"
-		fi
-		sleep 5
-	done
-
-	log_error "Timeout waiting for restore to complete"
-	return 1
+	wait_for_backup_restore "restore" "$RESTORE_NAME" "$OADP_NAMESPACE"
 }
 
 verify_restored_resources() {
@@ -245,7 +142,12 @@ print_summary() {
 }
 
 main() {
-	print_header
+	print_header "IBU Simulation (Preserved Mode)"
+	log_info "Target Namespace: $TARGET_NAMESPACE"
+	log_info "Backup Name: $BACKUP_NAME"
+	log_info "Mode: Certificate Preservation"
+	echo
+
 	check_prerequisites
 
 	create_preserved_backup

--- a/scripts/ibu/validate-cert-loss.sh
+++ b/scripts/ibu/validate-cert-loss.sh
@@ -34,7 +34,7 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-print_header() {
+print_validation_header() {
 	echo
 	echo "========================================"
 	if [ "$EXPECT_PRESERVED" = true ]; then
@@ -263,7 +263,7 @@ compare_metadata() {
 }
 
 main() {
-	print_header
+	print_validation_header
 	check_prerequisites
 
 	compare_metadata

--- a/scripts/import-acmedns-image.sh
+++ b/scripts/import-acmedns-image.sh
@@ -7,20 +7,11 @@
 
 set -euo pipefail
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+# Source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
 
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-
-echo
-echo "========================================"
-echo "  Import acme-dns Image"
-echo "========================================"
-echo
+print_header "Import acme-dns Image"
 
 ACMEDNS_IMAGE="joohoi/acme-dns:latest"
 ACMEDNS_NAMESPACE="${ACMEDNS_NAMESPACE:-acme-dns}"

--- a/scripts/install-cert-manager-operator.sh
+++ b/scripts/install-cert-manager-operator.sh
@@ -10,23 +10,10 @@ set -euo pipefail
 
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
-	# shellcheck source=../lib/common.sh
-	source "$SCRIPT_DIR/lib/common.sh"
-	load_env
-	setup_cleanup
-else
-	# Fallback if common.sh doesn't exist
-	RED='\033[0;31m'
-	GREEN='\033[0;32m'
-	YELLOW='\033[1;33m'
-	BLUE='\033[0;34m'
-	NC='\033[0m'
-	log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
-	log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-	log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
-	log_success() { echo -e "${GREEN}[SUCCESS]${NC} $*"; }
-fi
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+load_env
+setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/yaml/cert-manager-operator"
 
@@ -36,32 +23,12 @@ export CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
 export OPERATOR_NAME="${OPERATOR_NAME:-openshift-cert-manager-operator}"
 export CHANNEL="${CHANNEL:-stable-v1}"
 
-# Function to check if oc is installed and user is logged in
+# Function to check prerequisites
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! command -v envsubst &>/dev/null; then
-		log_error "envsubst command not found. Please install gettext package."
-		log_info "  macOS: brew install gettext"
-		log_info "  RHEL/Fedora: dnf install gettext"
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
-
-	# Check if user has cluster-admin privileges
-	if ! oc auth can-i '*' '*' --all-namespaces &>/dev/null; then
-		log_error "Cluster-admin privileges required. Please ensure you have the necessary permissions."
-		exit 1
-	fi
+	require_cmd oc envsubst
+	require_cluster_admin
 
 	# Check if YAML directory exists
 	if [ ! -d "$YAML_DIR" ]; then
@@ -70,19 +37,6 @@ check_prerequisites() {
 	fi
 
 	log_info "Prerequisites check passed."
-}
-
-# Function to create namespace if it doesn't exist
-create_namespace() {
-	local namespace=$1
-
-	if oc get namespace "$namespace" &>/dev/null; then
-		log_info "Namespace '$namespace' already exists."
-	else
-		log_info "Creating namespace '$namespace'..."
-		oc create namespace "$namespace"
-		log_info "Namespace '$namespace' created successfully."
-	fi
 }
 
 # Function to check if operator is already installed
@@ -110,78 +64,33 @@ check_existing_installation() {
 	log_info "No existing installation found. Will proceed with fresh installation."
 }
 
-# Function to apply YAML with variable substitution
-apply_yaml() {
-	local yaml_file=$1
-	local resource_type=$2
-
-	if [ ! -f "$yaml_file" ]; then
-		log_error "YAML file not found: $yaml_file"
-		exit 1
-	fi
-
-	log_info "Applying $resource_type from $(basename "$yaml_file")..."
-	envsubst <"$yaml_file" | oc apply -f -
-}
-
 # Function to install the operator
 install_operator() {
 	log_info "Installing cert-manager Operator for Red Hat OpenShift..."
 
 	# Create OperatorGroup
-	apply_yaml "$YAML_DIR/operatorgroup.yaml" "OperatorGroup"
+	apply_yaml_template "$YAML_DIR/operatorgroup.yaml" "OperatorGroup"
 
 	# Create Subscription
-	apply_yaml "$YAML_DIR/subscription.yaml" "Subscription"
+	apply_yaml_template "$YAML_DIR/subscription.yaml" "Subscription"
 
 	log_info "Resources applied. Waiting for operator installation to complete..."
 }
 
 # Function to wait for operator to be ready
 wait_for_operator() {
-	log_info "Waiting for cert-manager-operator to be ready..."
-
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		# Check if CSV is present and successful
-		if oc get csv -n "$OPERATOR_NAMESPACE" 2>/dev/null | grep -q "cert-manager.*Succeeded"; then
-			log_info "Operator CSV is in Succeeded phase."
-			break
-		fi
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			echo -n " [${attempt}/${max_attempts}]"
-		else
-			echo -n "."
-		fi
-		sleep 5
-	done
-	echo
-
-	if [ $attempt -eq $max_attempts ]; then
-		log_error "Timeout waiting for operator CSV to be ready."
-		log_info "Check the status with: oc get csv -n $OPERATOR_NAMESPACE"
-		log_info "Check operator logs with: oc logs -n $OPERATOR_NAMESPACE deployment/cert-manager-operator-controller-manager"
-		exit 1
-	fi
+	# Wait for CSV to reach Succeeded phase
+	wait_for_csv "$OPERATOR_NAMESPACE" "cert-manager" 60
 
 	# Wait for operator deployment to be ready
 	log_info "Waiting for operator deployment to be ready..."
 	if oc get deployment cert-manager-operator-controller-manager -n "$OPERATOR_NAMESPACE" &>/dev/null; then
-		oc wait --for=condition=available --timeout=300s \
-			deployment/cert-manager-operator-controller-manager \
-			-n "$OPERATOR_NAMESPACE" || {
-			log_error "Operator deployment failed to become ready."
-			exit 1
-		}
+		wait_for_resource "deployment/cert-manager-operator-controller-manager" "$OPERATOR_NAMESPACE" 300s
 	else
 		log_warn "Operator deployment not found yet, but CSV is ready."
 	fi
 
-	log_info "Operator is ready!"
+	log_success "Operator is ready!"
 }
 
 # Function to verify installation
@@ -239,7 +148,7 @@ main() {
 
 	check_prerequisites
 	check_existing_installation
-	create_namespace "$OPERATOR_NAMESPACE"
+	ensure_namespace "$OPERATOR_NAMESPACE"
 	install_operator
 	wait_for_operator
 	verify_installation

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -7,120 +7,27 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-# Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
 YAML_DIR="${SCRIPT_DIR}/../yaml/fake-dns-api"
 
-# Configuration
 export FAKEDNS_NAMESPACE="${FAKEDNS_NAMESPACE:-fake-dns}"
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_note() { echo -e "${BLUE}[NOTE]${NC} $1"; }
-
-print_header() {
-	echo
-	echo "========================================"
-	echo "  Install Fake DNS API (Air-gapped)"
-	echo "========================================"
-	echo
-}
-
-check_prerequisites() {
-	log_info "Checking prerequisites..."
-
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found"
-		exit 1
-	fi
-
-	if ! command -v envsubst &>/dev/null; then
-		log_error "envsubst command not found"
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged into OpenShift"
-		exit 1
-	fi
-
-	log_info "Prerequisites check passed"
-}
-
-apply_yaml() {
-	local yaml_file=$1
-	local resource_type=$2
-
-	if [ ! -f "$yaml_file" ]; then
-		log_error "YAML file not found: $yaml_file"
-		exit 1
-	fi
-
-	log_info "Applying $resource_type from $(basename "$yaml_file")..."
-	envsubst <"$yaml_file" | oc apply -f -
-}
 
 install_fake_dns() {
 	log_info "Installing fake DNS API server..."
 
-	apply_yaml "$YAML_DIR/namespace.yaml" "Namespace"
-	apply_yaml "$YAML_DIR/serviceaccount.yaml" "ServiceAccount"
+	apply_yaml_template "$YAML_DIR/namespace.yaml" "Namespace"
+	apply_yaml_template "$YAML_DIR/serviceaccount.yaml" "ServiceAccount"
 
-	# Grant anyuid SCC to allow binding to port 53
 	log_info "Granting anyuid SCC to fake-dns-api ServiceAccount..."
 	oc adm policy add-scc-to-user anyuid -z fake-dns-api -n "$FAKEDNS_NAMESPACE"
 
-	apply_yaml "$YAML_DIR/configmap.yaml" "ConfigMap"
-	apply_yaml "$YAML_DIR/deployment.yaml" "Deployment"
-	apply_yaml "$YAML_DIR/service.yaml" "Service"
+	apply_yaml_template "$YAML_DIR/configmap.yaml" "ConfigMap"
+	apply_yaml_template "$YAML_DIR/deployment.yaml" "Deployment"
+	apply_yaml_template "$YAML_DIR/service.yaml" "Service"
 
 	log_info "Resources applied. Waiting for fake-dns-api to be ready..."
-}
-
-wait_for_fake_dns() {
-	log_info "Waiting for fake-dns-api deployment..."
-
-	local max_attempts=120 # 10 minutes total
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		if oc get deployment fake-dns-api -n "$FAKEDNS_NAMESPACE" &>/dev/null; then
-			local ready=$(oc get deployment fake-dns-api -n "$FAKEDNS_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-			if [ "$ready" != "0" ]; then
-				log_info "fake-dns-api is ready!"
-				break
-			fi
-
-			# Show pod status periodically for better feedback
-			if [ $((attempt % 12)) -eq 0 ] && [ $attempt -gt 0 ]; then
-				echo
-				log_info "Still waiting... Current pod status:"
-				oc get pods -n "$FAKEDNS_NAMESPACE" --no-headers 2>/dev/null || true
-			fi
-		fi
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			echo -n " [${attempt}/${max_attempts}]"
-		else
-			echo -n "."
-		fi
-		sleep 5
-	done
-	echo
-
-	if [ $attempt -eq $max_attempts ]; then
-		log_error "Timeout waiting for fake-dns-api"
-		exit 1
-	fi
 }
 
 verify_installation() {
@@ -135,7 +42,6 @@ verify_installation() {
 configure_coredns() {
 	log_info "Configuring CoreDNS to delegate example.com to fake DNS server..."
 
-	# Get the fake-dns ClusterIP
 	local fake_dns_ip=$(oc get service fake-dns-api -n "$FAKEDNS_NAMESPACE" -o jsonpath='{.spec.clusterIP}')
 
 	if [ -z "$fake_dns_ip" ]; then
@@ -145,14 +51,12 @@ configure_coredns() {
 
 	log_info "Fake DNS server IP: $fake_dns_ip"
 
-	# Check if CoreDNS configmap exists
 	if ! oc get configmap dns-default -n openshift-dns &>/dev/null; then
 		log_warn "CoreDNS configmap not found, skipping CoreDNS configuration"
 		log_warn "You may need to manually configure DNS forwarding for example.com"
 		return
 	fi
 
-	# Update CoreDNS to forward example.com to our fake DNS
 	local corefile=$(oc get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}')
 
 	if echo "$corefile" | grep -q "example.com:53"; then
@@ -160,7 +64,6 @@ configure_coredns() {
 	else
 		log_info "Adding example.com zone to CoreDNS..."
 
-		# Add example.com zone configuration
 		cat <<EOF | oc apply -f -
 apiVersion: v1
 kind: ConfigMap
@@ -202,10 +105,10 @@ display_next_steps() {
 	log_info "  Fake DNS API Installation Complete!"
 	log_info "========================================"
 	echo
-	log_note "This fake DNS server accepts RFC2136 update requests and returns success"
-	log_note "without actually updating DNS. Perfect for air-gapped DNS-01 testing!"
+	log_info "This fake DNS server accepts RFC2136 update requests and returns success"
+	log_info "without actually updating DNS. Perfect for air-gapped DNS-01 testing!"
 	echo
-	log_note "CoreDNS has been configured to forward example.com queries to fake DNS."
+	log_info "CoreDNS has been configured to forward example.com queries to fake DNS."
 	echo
 	echo "Next steps:"
 	echo
@@ -241,10 +144,13 @@ display_next_steps() {
 }
 
 main() {
-	print_header
-	check_prerequisites
+	print_header "Install Fake DNS API (Air-gapped)"
+
+	require_cmd oc envsubst
+	require_cluster
+
 	install_fake_dns
-	wait_for_fake_dns
+	wait_for_resource "deployment/fake-dns-api" "$FAKEDNS_NAMESPACE" "600s"
 	verify_installation
 	configure_coredns
 	display_next_steps

--- a/scripts/install-local-dns.sh
+++ b/scripts/install-local-dns.sh
@@ -7,161 +7,24 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
 YAML_DIR="${SCRIPT_DIR}/../yaml/acme-dns"
 
-# Configuration (exported for envsubst)
 export ACMEDNS_NAMESPACE="${ACMEDNS_NAMESPACE:-acme-dns}"
 
-# Function to print colored messages
-log_info() {
-	echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-log_warn() {
-	echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-	echo -e "${RED}[ERROR]${NC} $1"
-}
-
-log_note() {
-	echo -e "${BLUE}[NOTE]${NC} $1"
-}
-
-# Function to print header
-print_header() {
-	echo
-	echo "========================================"
-	echo "  Install Local DNS Server (acme-dns)"
-	echo "========================================"
-	echo
-}
-
-# Function to check prerequisites
-check_prerequisites() {
-	log_info "Checking prerequisites..."
-
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! command -v envsubst &>/dev/null; then
-		log_error "envsubst command not found. Please install gettext package."
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
-
-	if [ ! -d "$YAML_DIR" ]; then
-		log_error "YAML directory not found: $YAML_DIR"
-		exit 1
-	fi
-
-	log_info "Prerequisites check passed."
-}
-
-# Function to check existing installation
-check_existing_installation() {
-	log_info "Checking for existing acme-dns installation..."
-
-	if oc get namespace "$ACMEDNS_NAMESPACE" &>/dev/null; then
-		log_info "acme-dns namespace already exists."
-
-		if oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" &>/dev/null; then
-			local ready_replicas=$(oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-			if [ "$ready_replicas" != "0" ]; then
-				log_info "acme-dns is already installed and running."
-				log_info "Installation is idempotent - will verify components."
-				return 0
-			fi
-		fi
-	fi
-
-	log_info "No existing installation found. Will proceed with fresh installation."
-}
-
-# Function to apply YAML with variable substitution
-apply_yaml() {
-	local yaml_file=$1
-	local resource_type=$2
-
-	if [ ! -f "$yaml_file" ]; then
-		log_error "YAML file not found: $yaml_file"
-		exit 1
-	fi
-
-	log_info "Applying $resource_type from $(basename "$yaml_file")..."
-	envsubst <"$yaml_file" | oc apply -f -
-}
-
-# Function to install acme-dns
 install_acme_dns() {
 	log_info "Installing acme-dns..."
 
-	apply_yaml "$YAML_DIR/namespace.yaml" "Namespace"
-	apply_yaml "$YAML_DIR/configmap.yaml" "ConfigMap"
-	apply_yaml "$YAML_DIR/deployment.yaml" "Deployment"
-	apply_yaml "$YAML_DIR/service.yaml" "Service"
+	apply_yaml_template "$YAML_DIR/namespace.yaml" "Namespace"
+	apply_yaml_template "$YAML_DIR/configmap.yaml" "ConfigMap"
+	apply_yaml_template "$YAML_DIR/deployment.yaml" "Deployment"
+	apply_yaml_template "$YAML_DIR/service.yaml" "Service"
 
 	log_info "Resources applied. Waiting for acme-dns to be ready..."
 }
 
-# Function to wait for acme-dns
-wait_for_acme_dns() {
-	log_info "Waiting for acme-dns deployment to be ready..."
-
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		if oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" &>/dev/null; then
-			local ready_replicas=$(oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-			if [ "$ready_replicas" != "0" ]; then
-				log_info "acme-dns is ready!"
-				break
-			fi
-		fi
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			echo -n " [${attempt}/${max_attempts}]"
-		else
-			echo -n "."
-		fi
-		sleep 5
-	done
-	echo
-
-	if [ $attempt -eq $max_attempts ]; then
-		log_error "Timeout waiting for acme-dns to be ready."
-		log_info "Check status: oc get pods -n $ACMEDNS_NAMESPACE"
-		exit 1
-	fi
-
-	if oc get deployment acme-dns -n "$ACMEDNS_NAMESPACE" &>/dev/null; then
-		oc wait --for=condition=available --timeout=60s \
-			deployment/acme-dns \
-			-n "$ACMEDNS_NAMESPACE" || {
-			log_warn "Deployment condition not met, but pods may be working."
-		}
-	fi
-}
-
-# Function to verify installation
 verify_installation() {
 	log_info "Verifying acme-dns installation..."
 
@@ -176,7 +39,6 @@ verify_installation() {
 	log_info "Installation verification complete!"
 }
 
-# Function to display next steps
 display_next_steps() {
 	local acmedns_api="http://acme-dns.${ACMEDNS_NAMESPACE}.svc.cluster.local:8080"
 	local acmedns_dns="acme-dns.${ACMEDNS_NAMESPACE}.svc.cluster.local"
@@ -207,21 +69,33 @@ display_next_steps() {
 	echo "  - API: ${acmedns_api}"
 	echo "  - DNS: ${acmedns_dns}:53"
 	echo
-	log_note "acme-dns provides a REST API for creating/updating DNS TXT records"
-	log_note "cert-manager will use this API for DNS-01 challenges"
+	log_info "acme-dns provides a REST API for creating/updating DNS TXT records"
+	log_info "cert-manager will use this API for DNS-01 challenges"
 	echo
 }
 
-# Main execution
 main() {
-	print_header
-	check_prerequisites
-	check_existing_installation
+	print_header "Install Local DNS Server (acme-dns)"
+
+	require_cmd oc envsubst
+	require_cluster
+
+	if [ ! -d "$YAML_DIR" ]; then
+		log_error "YAML directory not found: $YAML_DIR"
+		exit 1
+	fi
+
+	if check_deployment_exists acme-dns "$ACMEDNS_NAMESPACE"; then
+		log_info "acme-dns is already installed and running."
+		log_info "Installation is idempotent - will verify components."
+	else
+		log_info "No existing installation found. Will proceed with fresh installation."
+	fi
+
 	install_acme_dns
-	wait_for_acme_dns
+	wait_for_resource "deployment/acme-dns" "$ACMEDNS_NAMESPACE" "300s"
 	verify_installation
 	display_next_steps
 }
 
-# Run main function
 main

--- a/scripts/install-pebble-challtestsrv.sh
+++ b/scripts/install-pebble-challtestsrv.sh
@@ -7,40 +7,18 @@
 
 set -euo pipefail
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
 YAML_DIR="${SCRIPT_DIR}/../yaml/pebble-challtestsrv"
 
 export PEBBLE_NAMESPACE="${PEBBLE_NAMESPACE:-pebble}"
 
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_note() { echo -e "${BLUE}[NOTE]${NC} $1"; }
+print_header "Install Pebble Challenge Test Server"
 
-echo
-echo "========================================"
-echo "  Install Pebble Challenge Test Server"
-echo "========================================"
-echo
+require_cmd oc
+require_cluster
 
-# Check prerequisites
-if ! command -v oc &>/dev/null; then
-	log_error "oc command not found"
-	exit 1
-fi
-
-if ! oc whoami &>/dev/null; then
-	log_error "Not logged into OpenShift"
-	exit 1
-fi
-
-# Check if Pebble namespace exists
 if ! oc get namespace "$PEBBLE_NAMESPACE" &>/dev/null; then
 	log_error "Pebble namespace '$PEBBLE_NAMESPACE' not found. Install Pebble first."
 	exit 1
@@ -48,7 +26,6 @@ fi
 
 log_info "Installing Challenge Test Server..."
 
-# Apply manifests
 log_info "Applying deployment..."
 envsubst <"$YAML_DIR/deployment.yaml" | oc apply -f -
 
@@ -76,4 +53,4 @@ echo "2. Use management API to set DNS records:"
 echo "   curl -X POST http://pebble-challtestsrv.pebble.svc:8055/set-txt \\"
 echo "     -d '{\"host\":\"_acme-challenge.example.com.\",\"value\":\"test\"}'"
 echo
-log_note "This DNS server works with Pebble's ALWAYS_VALID mode!"
+log_info "This DNS server works with Pebble's ALWAYS_VALID mode!"

--- a/scripts/install-pebble.sh
+++ b/scripts/install-pebble.sh
@@ -8,218 +8,54 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Get script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
 YAML_DIR="${SCRIPT_DIR}/../yaml/pebble"
 
-# Configuration (exported for envsubst)
 export PEBBLE_NAMESPACE="${PEBBLE_NAMESPACE:-pebble}"
 export DNS_SERVER="${DNS_SERVER:-8.8.8.8:53}"
 export PEBBLE_ALWAYS_VALID="${PEBBLE_ALWAYS_VALID:-0}"
 
-# Function to print colored messages
-log_info() {
-	echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-log_warn() {
-	echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-	echo -e "${RED}[ERROR]${NC} $1"
-}
-
-log_note() {
-	echo -e "${BLUE}[NOTE]${NC} $1"
-}
-
-# Function to print header
-print_header() {
-	echo
-	echo "========================================"
-	echo "  Pebble ACME Test Server Installation"
-	echo "========================================"
-	echo
-}
-
-# Function to check prerequisites
-check_prerequisites() {
-	log_info "Checking prerequisites..."
-
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! command -v envsubst &>/dev/null; then
-		log_error "envsubst command not found. Please install gettext package."
-		log_info "  macOS: brew install gettext"
-		log_info "  RHEL/Fedora: dnf install gettext"
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
-
-	# Check if YAML directory exists
-	if [ ! -d "$YAML_DIR" ]; then
-		log_error "YAML directory not found: $YAML_DIR"
-		exit 1
-	fi
-
-	log_info "Prerequisites check passed."
-}
-
-# Function to check if Pebble is already installed
-check_existing_installation() {
-	log_info "Checking for existing Pebble installation..."
-
-	if oc get namespace "$PEBBLE_NAMESPACE" &>/dev/null; then
-		log_info "Pebble namespace '$PEBBLE_NAMESPACE' already exists."
-
-		# Check if deployment exists and is healthy
-		if oc get deployment pebble -n "$PEBBLE_NAMESPACE" &>/dev/null; then
-			local ready_replicas=$(oc get deployment pebble -n "$PEBBLE_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-			local desired_replicas=$(oc get deployment pebble -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "1")
-
-			if [ "$ready_replicas" = "$desired_replicas" ] && [ "$ready_replicas" != "0" ]; then
-				log_info "Pebble is already installed and healthy."
-				log_info "Installation is idempotent - will verify and ensure components are ready."
-				return 0
-			else
-				log_warn "Pebble exists but may not be healthy. Will attempt to reconcile."
-				return 0
-			fi
-		fi
-	fi
-
-	log_info "No existing installation found. Will proceed with fresh installation."
-}
-
-# Function to apply YAML with variable substitution
-apply_yaml() {
-	local yaml_file=$1
-	local resource_type=$2
-
-	if [ ! -f "$yaml_file" ]; then
-		log_error "YAML file not found: $yaml_file"
-		exit 1
-	fi
-
-	log_info "Applying $resource_type from $(basename "$yaml_file")..."
-	envsubst <"$yaml_file" | oc apply -f -
-}
-
-# Function to install Pebble
 install_pebble() {
 	log_info "Installing Pebble ACME test server..."
 
-	# Apply resources in order
-	apply_yaml "$YAML_DIR/namespace.yaml" "Namespace"
-	apply_yaml "$YAML_DIR/configmap.yaml" "ConfigMap"
-	apply_yaml "$YAML_DIR/deployment.yaml" "Deployment"
-	apply_yaml "$YAML_DIR/service.yaml" "Service"
-	apply_yaml "$YAML_DIR/route.yaml" "Route"
+	apply_yaml_template "$YAML_DIR/namespace.yaml" "Namespace"
+	apply_yaml_template "$YAML_DIR/configmap.yaml" "ConfigMap"
+	apply_yaml_template "$YAML_DIR/deployment.yaml" "Deployment"
+	apply_yaml_template "$YAML_DIR/service.yaml" "Service"
+	apply_yaml_template "$YAML_DIR/route.yaml" "Route"
 
 	log_info "Resources applied. Waiting for Pebble to be ready..."
 }
 
-# Function to wait for Pebble to be ready
-wait_for_pebble() {
-	log_info "Waiting for Pebble deployment to be ready..."
-
-	local max_attempts=120 # 10 minutes total
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		if oc get deployment pebble -n "$PEBBLE_NAMESPACE" &>/dev/null; then
-			local ready_replicas=$(oc get deployment pebble -n "$PEBBLE_NAMESPACE" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-			local desired_replicas=$(oc get deployment pebble -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "1")
-
-			if [ "$ready_replicas" = "$desired_replicas" ] && [ "$ready_replicas" != "0" ]; then
-				log_info "Pebble deployment is ready!"
-				break
-			fi
-
-			# Show pod status periodically for better feedback
-			if [ $((attempt % 12)) -eq 0 ] && [ $attempt -gt 0 ]; then
-				echo
-				log_info "Still waiting... Current pod status:"
-				oc get pods -n "$PEBBLE_NAMESPACE" --no-headers 2>/dev/null || true
-			fi
-		fi
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			echo -n " [${attempt}/${max_attempts}]"
-		else
-			echo -n "."
-		fi
-		sleep 5
-	done
-	echo
-
-	if [ $attempt -eq $max_attempts ]; then
-		log_error "Timeout waiting for Pebble to be ready."
-		log_info "Check the status with: oc get pods -n $PEBBLE_NAMESPACE"
-		log_info "Check logs with: oc logs -n $PEBBLE_NAMESPACE deployment/pebble"
-		exit 1
-	fi
-
-	# Additional wait for pod to be fully ready
-	if oc get deployment pebble -n "$PEBBLE_NAMESPACE" &>/dev/null; then
-		oc wait --for=condition=available --timeout=60s \
-			deployment/pebble \
-			-n "$PEBBLE_NAMESPACE" || {
-			log_warn "Deployment ready condition not met, but pods may still be working."
-		}
-	fi
-}
-
-# Function to verify installation
 verify_installation() {
 	log_info "Verifying Pebble installation..."
 
-	# Check pod status
 	log_info "Checking pod status..."
 	oc get pods -n "$PEBBLE_NAMESPACE"
 	echo
 
-	# Check service
 	log_info "Checking service..."
 	oc get service pebble -n "$PEBBLE_NAMESPACE"
 	echo
 
-	# Check route
 	log_info "Checking route..."
 	oc get route pebble-acme -n "$PEBBLE_NAMESPACE"
 	echo
 
-	# Get the route URL
 	local route_host=$(oc get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 
 	if [ -n "$route_host" ]; then
 		log_info "Pebble ACME directory URL: https://${route_host}/dir"
 	fi
 
-	# Get internal service URL
 	local service_url="https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:14000/dir"
 	log_info "Pebble internal URL: ${service_url}"
 
 	log_info "Installation verification complete!"
 }
 
-# Function to display configuration summary
 display_configuration() {
 	echo
 	log_info "========================================"
@@ -232,16 +68,15 @@ display_configuration() {
 	echo
 
 	if [ "$PEBBLE_ALWAYS_VALID" = "1" ]; then
-		log_note "PEBBLE_ALWAYS_VALID=1: All challenges will automatically succeed."
-		log_note "This is useful for testing without proper DNS/HTTP challenge setup."
+		log_info "PEBBLE_ALWAYS_VALID=1: All challenges will automatically succeed."
+		log_info "This is useful for testing without proper DNS/HTTP challenge setup."
 	else
-		log_note "PEBBLE_ALWAYS_VALID=0: Challenges must be properly configured."
-		log_note "You'll need proper DNS records or HTTP-01 challenge routes."
+		log_info "PEBBLE_ALWAYS_VALID=0: Challenges must be properly configured."
+		log_info "You'll need proper DNS records or HTTP-01 challenge routes."
 	fi
 	echo
 }
 
-# Function to display next steps
 display_next_steps() {
 	local route_host=$(oc get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 	local service_url="https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:14000/dir"
@@ -285,8 +120,8 @@ display_next_steps() {
 	echo
 
 	if [ "$PEBBLE_ALWAYS_VALID" = "1" ]; then
-		log_note "Remember: PEBBLE_ALWAYS_VALID=1 means all challenges auto-succeed."
-		log_note "Great for initial testing, but doesn't validate actual DNS/HTTP setup."
+		log_info "Remember: PEBBLE_ALWAYS_VALID=1 means all challenges auto-succeed."
+		log_info "Great for initial testing, but doesn't validate actual DNS/HTTP setup."
 	fi
 
 	echo
@@ -295,18 +130,30 @@ display_next_steps() {
 	echo
 }
 
-# Main execution
 main() {
-	print_header
+	print_header "Pebble ACME Test Server Installation"
 
-	check_prerequisites
+	require_cmd oc envsubst
+	require_cluster
+
+	if [ ! -d "$YAML_DIR" ]; then
+		log_error "YAML directory not found: $YAML_DIR"
+		exit 1
+	fi
+
 	display_configuration
-	check_existing_installation
+
+	if check_deployment_exists pebble "$PEBBLE_NAMESPACE"; then
+		log_info "Pebble is already installed and healthy."
+		log_info "Installation is idempotent - will verify and ensure components are ready."
+	else
+		log_info "No existing installation found. Will proceed with fresh installation."
+	fi
+
 	install_pebble
-	wait_for_pebble
+	wait_for_resource "deployment/pebble" "$PEBBLE_NAMESPACE" "600s"
 	verify_installation
 	display_next_steps
 }
 
-# Run main function
 main

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -9,23 +9,10 @@
 
 set -euo pipefail
 
-# Source common library if available
+# Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [[ -f "$SCRIPT_DIR/lib/common.sh" ]]; then
-	# shellcheck source=../lib/common.sh
-	source "$SCRIPT_DIR/lib/common.sh"
-else
-	# Fallback if common.sh doesn't exist
-	RED='\033[0;31m'
-	GREEN='\033[0;32m'
-	YELLOW='\033[1;33m'
-	BLUE='\033[0;34m'
-	NC='\033[0m'
-	log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
-	log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-	log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
-	log_success() { echo -e "${GREEN}[SUCCESS]${NC} $*"; }
-fi
+# shellcheck source=../lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/troubleshooting/check-all.sh
+++ b/scripts/troubleshooting/check-all.sh
@@ -7,30 +7,13 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
-echo
-echo "========================================"
-echo "  Complete System Diagnostics"
-echo "========================================"
-echo
+print_header "Complete System Diagnostics"
 
-# Check if we're logged in
-if ! oc whoami &>/dev/null; then
-	log_error "Not logged into OpenShift cluster"
-	exit 1
-fi
+require_cmd oc
+require_cluster
 
 log_info "Cluster: $(oc whoami --show-server)"
 log_info "User: $(oc whoami)"

--- a/scripts/troubleshooting/check-certificate.sh
+++ b/scripts/troubleshooting/check-certificate.sh
@@ -7,28 +7,15 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_detail() { echo -e "${BLUE}[DETAIL]${NC} $1"; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
 # Function to check a single certificate
 check_single_certificate() {
 	local CERT_NAME=$1
 	local NAMESPACE=$2
 
-	echo
-	echo "========================================"
-	echo "  Certificate Diagnostics"
-	echo "========================================"
-	echo
+	print_header "Certificate Diagnostics"
 	log_info "Certificate: $CERT_NAME"
 	log_info "Namespace: $NAMESPACE"
 	echo
@@ -57,7 +44,7 @@ check_single_certificate() {
 		oc get secret "$SECRET_NAME" -n "$NAMESPACE" 2>/dev/null || log_warn "Secret not found"
 
 		echo
-		log_info "Certificate Details:"
+		log_debug "Certificate Details:"
 		echo "To view certificate:"
 		echo "  oc get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout"
 
@@ -152,11 +139,7 @@ check_single_certificate() {
 # Main logic
 if [ $# -eq 0 ]; then
 	# No arguments - check all certificates
-	echo
-	echo "========================================"
-	echo "  Checking All Certificates"
-	echo "========================================"
-	echo
+	print_header "Checking All Certificates"
 
 	# Get all certificates across all namespaces
 	CERTS=$(oc get certificate -A -o json 2>/dev/null | jq -r '.items[] | "\(.metadata.namespace) \(.metadata.name)"' 2>/dev/null || echo "")

--- a/scripts/troubleshooting/check-issuer.sh
+++ b/scripts/troubleshooting/check-issuer.sh
@@ -7,27 +7,14 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_detail() { echo -e "${BLUE}[DETAIL]${NC} $1"; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
 # Function to check a single ClusterIssuer
 check_single_issuer() {
 	local ISSUER_NAME=$1
 
-	echo
-	echo "========================================"
-	echo "  ClusterIssuer Diagnostics"
-	echo "========================================"
-	echo
+	print_header "ClusterIssuer Diagnostics"
 	log_info "ClusterIssuer: $ISSUER_NAME"
 	echo
 
@@ -51,24 +38,24 @@ check_single_issuer() {
 
 	# Get ACME server URL
 	ACME_SERVER=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.server}' 2>/dev/null || echo "N/A")
-	log_detail "ACME Server: $ACME_SERVER"
+	log_debug "ACME Server: $ACME_SERVER"
 
 	# Get email
 	EMAIL=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.email}' 2>/dev/null || echo "N/A")
-	log_detail "Email: $EMAIL"
+	log_debug "Email: $EMAIL"
 
 	# Check solver type
 	SOLVER_TYPE=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].http01}' 2>/dev/null)
 	if [ -n "$SOLVER_TYPE" ]; then
-		log_detail "Solver Type: HTTP-01"
+		log_debug "Solver Type: HTTP-01"
 		INGRESS_CLASS=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].http01.ingress.class}' 2>/dev/null || echo "N/A")
-		log_detail "Ingress Class: $INGRESS_CLASS"
+		log_debug "Ingress Class: $INGRESS_CLASS"
 	else
 		SOLVER_TYPE=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].dns01}' 2>/dev/null)
 		if [ -n "$SOLVER_TYPE" ]; then
-			log_detail "Solver Type: DNS-01"
+			log_debug "Solver Type: DNS-01"
 		else
-			log_detail "Solver Type: Unknown"
+			log_debug "Solver Type: Unknown"
 		fi
 	fi
 
@@ -128,11 +115,7 @@ check_single_issuer() {
 # Main logic
 if [ $# -eq 0 ]; then
 	# No arguments - check all ClusterIssuers
-	echo
-	echo "========================================"
-	echo "  Checking All ClusterIssuers"
-	echo "========================================"
-	echo
+	print_header "Checking All ClusterIssuers"
 
 	# Get all ClusterIssuers
 	ISSUERS=$(oc get clusterissuer -o json 2>/dev/null | jq -r '.items[].metadata.name' 2>/dev/null || echo "")

--- a/scripts/troubleshooting/check-network-stack.sh
+++ b/scripts/troubleshooting/check-network-stack.sh
@@ -8,42 +8,8 @@
 
 set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
-
-# Function to print colored messages
-log_info() {
-	echo -e "${GREEN}[INFO]${NC} $1"
-}
-
-log_warn() {
-	echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-	echo -e "${RED}[ERROR]${NC} $1"
-}
-
-log_detail() {
-	echo -e "${BLUE}[DETAIL]${NC} $1"
-}
-
-# Function to check prerequisites
-check_prerequisites() {
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
 # Function to detect cluster network configuration
 detect_cluster_network() {
@@ -54,8 +20,8 @@ detect_cluster_network() {
 	local cluster_network=$(oc get network.config.openshift.io cluster -o jsonpath='{.spec.clusterNetwork[*].cidr}' 2>/dev/null || echo "")
 	local service_network=$(oc get network.config.openshift.io cluster -o jsonpath='{.spec.serviceNetwork[*]}' 2>/dev/null || echo "")
 
-	log_detail "Cluster Networks: ${cluster_network:-Not found}"
-	log_detail "Service Networks: ${service_network:-Not found}"
+	log_debug "Cluster Networks: ${cluster_network:-Not found}"
+	log_debug "Service Networks: ${service_network:-Not found}"
 
 	# Detect stack type
 	local has_ipv4=false
@@ -100,8 +66,8 @@ check_node_addresses() {
 	local has_ipv6_nodes=false
 
 	while IFS=$'\t' read -r node_name node_ip; do
-		log_detail "Node: $node_name"
-		log_detail "  IP: $node_ip"
+		log_debug "Node: $node_name"
+		log_debug "  IP: $node_ip"
 
 		if echo "$node_ip" | grep -q "\."; then
 			has_ipv4_nodes=true
@@ -144,8 +110,8 @@ check_certmanager_pods() {
 
 	while IFS=$'\t' read -r pod_name pod_ip; do
 		if [ -n "$pod_ip" ]; then
-			log_detail "Pod: $pod_name"
-			log_detail "  IP: $pod_ip"
+			log_debug "Pod: $pod_name"
+			log_debug "  IP: $pod_ip"
 
 			if echo "$pod_ip" | grep -q "\."; then
 				has_ipv4_pods=true
@@ -181,11 +147,11 @@ check_webhook_connectivity() {
 	local webhook_cluster_ips=$(oc get service cert-manager-webhook -n cert-manager -o jsonpath='{.spec.clusterIPs[*]}' 2>/dev/null || echo "")
 
 	if [ -n "$webhook_cluster_ip" ]; then
-		log_detail "Webhook ClusterIP: $webhook_cluster_ip"
+		log_debug "Webhook ClusterIP: $webhook_cluster_ip"
 	fi
 
 	if [ -n "$webhook_cluster_ips" ]; then
-		log_detail "Webhook ClusterIPs: $webhook_cluster_ips"
+		log_debug "Webhook ClusterIPs: $webhook_cluster_ips"
 
 		if echo "$webhook_cluster_ips" | grep -q " "; then
 			log_info "✅ Webhook service has multiple ClusterIPs (dual-stack capable)"
@@ -200,13 +166,10 @@ check_webhook_connectivity() {
 
 # Main execution
 main() {
-	echo
-	echo "========================================"
-	echo "  Network Stack Detection"
-	echo "========================================"
-	echo
+	print_header "Network Stack Detection"
 
-	check_prerequisites
+	require_cmd oc
+	require_cluster
 
 	# Detect stack type
 	local stack_type=$(detect_cluster_network)

--- a/scripts/troubleshooting/check-workload-partitioning.sh
+++ b/scripts/troubleshooting/check-workload-partitioning.sh
@@ -11,44 +11,8 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_detail() { echo -e "${BLUE}[DETAIL]${NC} $1"; }
-
-# Print header
-print_header() {
-	echo
-	echo "========================================"
-	echo "  Workload Partitioning Check"
-	echo "========================================"
-	echo
-}
-
-# Check prerequisites
-check_prerequisites() {
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
-
-	if ! oc whoami &>/dev/null; then
-		log_error "Not logged in to OpenShift cluster. Please run 'oc login' first."
-		exit 1
-	fi
-
-	# Check if jq is available (optional but helpful)
-	if ! command -v jq &>/dev/null; then
-		log_warn "jq not found - output will be less detailed"
-	fi
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
 # Check if cert-manager is installed
 check_cert_manager_exists() {
@@ -84,7 +48,7 @@ check_workload_partitioning() {
 		local pod_name=$(echo "$pods" | jq -r ".items[$i].metadata.name")
 		local annotations=$(echo "$pods" | jq -r ".items[$i].metadata.annotations // {}")
 
-		log_detail "Checking pod: $pod_name"
+		log_debug "Checking pod: $pod_name"
 
 		# Check for the workload partitioning annotation
 		local wp_annotation=$(echo "$annotations" | jq -r '."target.workload.openshift.io/management" // empty')
@@ -133,7 +97,7 @@ check_deployment_configs() {
 			local deploy_name=$(echo "$deployments" | jq -r ".items[$i].metadata.name")
 			local pod_annotations=$(echo "$deployments" | jq -r ".items[$i].spec.template.metadata.annotations // {}")
 
-			log_detail "Checking deployment: $deploy_name"
+			log_debug "Checking deployment: $deploy_name"
 
 			local wp_annotation=$(echo "$pod_annotations" | jq -r '."target.workload.openshift.io/management" // empty')
 
@@ -193,8 +157,9 @@ provide_recommendations() {
 
 # Main execution
 main() {
-	print_header
-	check_prerequisites
+	print_header "Workload Partitioning Check"
+	require_cmd oc jq
+	require_cluster
 	check_cert_manager_exists
 
 	local namespace="cert-manager"

--- a/scripts/troubleshooting/diagnose-dns01.sh
+++ b/scripts/troubleshooting/diagnose-dns01.sh
@@ -7,23 +7,10 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_detail() { echo -e "${BLUE}[DETAIL]${NC} $1"; }
-
-echo
-echo "========================================"
-echo "  DNS-01 Challenge Diagnostics"
-echo "========================================"
-echo
+print_header "DNS-01 Challenge Diagnostics"
 
 # Check cert-manager
 log_info "Checking cert-manager..."
@@ -50,9 +37,9 @@ if oc get deployment pebble -n pebble &>/dev/null; then
 		# Check if using ALWAYS_VALID
 		ALWAYS_VALID=$(oc get deployment pebble -n pebble -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="PEBBLE_VA_ALWAYS_VALID")].value}' 2>/dev/null || echo "0")
 		if [ "$ALWAYS_VALID" = "1" ]; then
-			log_detail "Pebble ALWAYS_VALID: enabled (all challenges auto-succeed)"
+			log_debug "Pebble ALWAYS_VALID: enabled (all challenges auto-succeed)"
 		else
-			log_detail "Pebble ALWAYS_VALID: disabled (real DNS validation required)"
+			log_debug "Pebble ALWAYS_VALID: disabled (real DNS validation required)"
 		fi
 	else
 		log_error "Pebble has no ready replicas"
@@ -124,21 +111,21 @@ if [ -n "$CHALLENGES" ]; then
 		NAMESPACE=$(echo "$challenge" | cut -d'/' -f1)
 		NAME=$(echo "$challenge" | cut -d'/' -f2)
 
-		log_detail "Challenge: $NAME (namespace: $NAMESPACE)"
+		log_debug "Challenge: $NAME (namespace: $NAMESPACE)"
 
 		STATE=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.status.state}' 2>/dev/null || echo "unknown")
-		log_detail "  State: $STATE"
+		log_debug "  State: $STATE"
 
 		# Get challenge details
 		DOMAIN=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.dnsName}' 2>/dev/null || echo "unknown")
 		KEY=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.key}' 2>/dev/null || echo "unknown")
 
-		log_detail "  Domain: $DOMAIN"
-		log_detail "  DNS Record: _acme-challenge.$DOMAIN"
+		log_debug "  Domain: $DOMAIN"
+		log_debug "  DNS Record: _acme-challenge.$DOMAIN"
 
 		# Check if TXT record should exist
 		if [ "$STATE" = "pending" ] || [ "$STATE" = "processing" ]; then
-			log_detail "  Expected TXT record key: ${KEY:0:20}..."
+			log_debug "  Expected TXT record key: ${KEY:0:20}..."
 		fi
 
 		echo

--- a/scripts/troubleshooting/diagnose-http01.sh
+++ b/scripts/troubleshooting/diagnose-http01.sh
@@ -7,23 +7,10 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_detail() { echo -e "${BLUE}[DETAIL]${NC} $1"; }
-
-echo
-echo "========================================"
-echo "  HTTP-01 Challenge Diagnostics"
-echo "========================================"
-echo
+print_header "HTTP-01 Challenge Diagnostics"
 
 # Check cert-manager
 log_info "Checking cert-manager..."
@@ -50,7 +37,7 @@ if oc get deployment pebble -n pebble &>/dev/null; then
 		# Get Pebble route
 		ROUTE=$(oc get route pebble-acme -n pebble -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 		if [ -n "$ROUTE" ]; then
-			log_detail "Pebble route: https://$ROUTE"
+			log_debug "Pebble route: https://$ROUTE"
 		fi
 	else
 		log_error "Pebble has no ready replicas"
@@ -92,18 +79,18 @@ if [ -n "$CHALLENGES" ]; then
 		NAMESPACE=$(echo "$challenge" | cut -d'/' -f1)
 		NAME=$(echo "$challenge" | cut -d'/' -f2)
 
-		log_detail "Challenge: $NAME (namespace: $NAMESPACE)"
+		log_debug "Challenge: $NAME (namespace: $NAMESPACE)"
 
 		STATE=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.status.state}' 2>/dev/null || echo "unknown")
-		log_detail "  State: $STATE"
+		log_debug "  State: $STATE"
 
 		# Get challenge details
 		DOMAIN=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.dnsName}' 2>/dev/null || echo "unknown")
 		TOKEN=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.token}' 2>/dev/null || echo "unknown")
 		KEY=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.key}' 2>/dev/null || echo "unknown")
 
-		log_detail "  Domain: $DOMAIN"
-		log_detail "  Token: ${TOKEN:0:20}..."
+		log_debug "  Domain: $DOMAIN"
+		log_debug "  Token: ${TOKEN:0:20}..."
 
 		# Check if challenge service exists
 		if oc get service -n "$NAMESPACE" -l "acme.cert-manager.io/http01-solver=true" &>/dev/null; then

--- a/scripts/troubleshooting/verify-apiserver-certificate.sh
+++ b/scripts/troubleshooting/verify-apiserver-certificate.sh
@@ -14,36 +14,16 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-log_detail() { echo -e "${BLUE}[DETAIL]${NC} $1"; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
 # Configuration
 CERT_NAMESPACE="${CERT_NAMESPACE:-openshift-config}"
 CERT_NAME="apiserver-cert"
 SECRET_NAME="apiserver-cert-tls"
 
-print_header() {
-	echo
-	echo "========================================"
-	echo "  API Server Certificate Verification"
-	echo "========================================"
-	echo
-}
-
 check_prerequisites() {
-	if ! command -v oc &>/dev/null; then
-		log_error "oc command not found. Please install OpenShift CLI."
-		exit 1
-	fi
+	require_cmd oc
 
 	# Try multiple times to connect - cluster may be temporarily unstable
 	local max_attempts=3
@@ -80,7 +60,7 @@ verify_api_server_access() {
 	if oc whoami &>/dev/null; then
 		log_info "  ✅ API server is accessible (authenticated)"
 		local username=$(oc whoami 2>/dev/null || echo "unknown")
-		log_detail "     Logged in as: $username"
+		log_debug "     Logged in as: $username"
 	else
 		log_error "  ❌ Cannot authenticate with API server"
 		has_issues=1
@@ -195,19 +175,19 @@ verify_certificate_details() {
 		# Check subject
 		local subject=$(echo "$cert_pem" | openssl x509 -noout -subject 2>/dev/null)
 		if [ -n "$subject" ]; then
-			log_detail "  Subject: $subject"
+			log_debug "  Subject: $subject"
 		fi
 
 		# Check SANs
 		local sans=$(echo "$cert_pem" | openssl x509 -noout -text 2>/dev/null | grep -A1 "Subject Alternative Name" | tail -1 | sed 's/^[[:space:]]*//')
 		if [ -n "$sans" ]; then
-			log_detail "  SANs: $sans"
+			log_debug "  SANs: $sans"
 		fi
 
 		# Check issuer
 		local issuer=$(echo "$cert_pem" | openssl x509 -noout -issuer 2>/dev/null)
 		if [ -n "$issuer" ]; then
-			log_detail "  Issuer: $issuer"
+			log_debug "  Issuer: $issuer"
 		fi
 	else
 		log_error "  ❌ Could not extract certificate from secret"
@@ -231,11 +211,11 @@ check_apiserver_configuration() {
 			log_info "  Named certificates configured:"
 			echo "$serving_certs" | while read -r cert_name; do
 				if [ -n "$cert_name" ]; then
-					log_detail "    - $cert_name"
+					log_debug "    - $cert_name"
 				fi
 			done
 		else
-			log_detail "  No named certificates configured (using default)"
+			log_debug "  No named certificates configured (using default)"
 		fi
 	else
 		log_warn "  ⚠️  Could not retrieve API server configuration"
@@ -283,7 +263,7 @@ provide_recommendations() {
 }
 
 main() {
-	print_header
+	print_header "API Server Certificate Verification"
 	check_prerequisites
 
 	local total_issues=0

--- a/scripts/workflows/display-component-status.sh
+++ b/scripts/workflows/display-component-status.sh
@@ -8,15 +8,9 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+# Get script directory and source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
 echo
 echo "========================================"

--- a/scripts/workflows/recover-cluster.sh
+++ b/scripts/workflows/recover-cluster.sh
@@ -8,15 +8,9 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+# Get script directory and source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
 echo
 echo "========================================"

--- a/scripts/workflows/verify-cluster-access.sh
+++ b/scripts/workflows/verify-cluster-access.sh
@@ -8,15 +8,9 @@
 
 set -euo pipefail
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
-
-log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+# Get script directory and source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
 
 echo
 echo "========================================"
@@ -68,8 +62,8 @@ echo
 
 # Test 4: Check authentication
 log_info "Checking cluster authentication..."
-if oc whoami &>/dev/null; then
-	USERNAME=$(oc whoami 2>/dev/null)
+USERNAME=$(oc whoami 2>/dev/null || echo "")
+if [ -n "$USERNAME" ]; then
 	log_info "✅ Authenticated as: $USERNAME"
 else
 	log_error "❌ Cannot authenticate with cluster"


### PR DESCRIPTION
## Summary

- Refactor all 32 bash scripts to source `lib/common.sh` instead of redefining their own color constants, logging functions, prerequisite checks, and utility helpers
- Add 8 new shared functions to `lib/common.sh`: `print_header`, `apply_yaml_template`, `ensure_namespace`, `check_deployment_exists`, `wait_for_csv`, `wait_for_backup_restore`, `build_lca_annotations`, `capture_secret_checksums`
- Eliminate ~1,000 lines of duplicated code (net -1,005 lines across 31 files)
- Fix N+1 API call pattern in `capture-cert-state.sh` (21 API calls reduced to 1)
- Replace custom deployment polling loops with `oc wait` via `wait_for_resource`
- Cache duplicate network config fetches in `check-cluster-network.sh`

## Test plan

- [x] `make lint` passes (shellcheck + shfmt)
- [ ] `make preflight` runs successfully
- [ ] `make quick-http-test` completes end-to-end
- [ ] `make quick-dns-test` completes end-to-end
- [ ] IBU tests (`make test-ibu-certs`, `make test-ibu-preserved`) complete
- [ ] Troubleshooting scripts (`make troubleshoot`) produce expected output
- [ ] CI integration test passes