### PR TITLE
Add self-signed CA issuer support for disconnected environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,13 @@ BG_BLUE := \033[44m
 # ────────────────────────────────────────────────────────────────────────────────
 .PHONY: all help banner preflight lint install-cert-manager-operator install-pebble \
         install-fake-dns install-all install-monitoring create-issuer create-dns01-issuer \
-        create-certs create-apiserver-cert verify-apiserver-cert \
-        test-all test-dns01 quick-http-test quick-dns-test test-cert verify-cert \
+        create-selfsigned-issuer create-certs create-apiserver-cert verify-apiserver-cert \
+        test-all test-dns01 quick-http-test quick-dns-test quick-selfsigned-test \
+        test-cert verify-cert \
         troubleshoot check-cert check-issuer check-network check-network-stack check-workload-partitioning \
         diagnose-http01 diagnose-dns01 clean clean-certs clean-pebble clean-fake-dns \
-        clean-dns-config clean-issuers clean-monitoring clean-temp uninstall-cert-manager-operator \
+        clean-dns-config clean-issuers clean-selfsigned clean-monitoring clean-temp \
+        uninstall-cert-manager-operator \
         install-minio install-oadp install-ibu-prereqs capture-cert-state \
         test-ibu-certs test-ibu-preserved test-ibu-both quick-ibu-test clean-ibu
 
@@ -154,6 +156,9 @@ create-issuer: ## Create ClusterIssuer pointing to Pebble (HTTP-01)
 create-dns01-issuer: ## Create ClusterIssuer pointing to Pebble (DNS-01)
 	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 ./scripts/create-dns01-issuer.sh
 
+create-selfsigned-issuer: ## Create self-signed CA chain (disconnected/air-gapped)
+	@./scripts/create-selfsigned-issuer.sh
+
 create-certs: ## Create test certificates (HTTP-01)
 	@./scripts/create-test-certificates.sh
 
@@ -241,6 +246,27 @@ quick-http-test: install-cert-manager-operator ## Quick end-to-end HTTP-01 test
 	done
 	@echo ""
 	@echo "Quick HTTP-01 test complete! Run 'make clean' to clean up."
+
+quick-selfsigned-test: install-cert-manager-operator create-selfsigned-issuer ## Quick end-to-end self-signed CA test
+	@echo ""
+	@echo "$(BOLD)$(BLUE)Quick Self-Signed CA Test Running...$(RESET)"
+	@echo ""
+	@CLUSTER_DOMAIN=$$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "apps-crc.testing"); \
+	ISSUER_NAME=$$(echo "$${CA_ISSUER_NAME:-selfsigned-ca-issuer}"); \
+	printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: test-cert-selfsigned\n  namespace: default\nspec:\n  secretName: test-cert-selfsigned-tls\n  issuerRef:\n    name: '"$$ISSUER_NAME"'\n    kind: ClusterIssuer\n  dnsNames:\n  - test.'"$$CLUSTER_DOMAIN"'\n  - "*.'"$$CLUSTER_DOMAIN"'"\n' | oc apply -f -
+	@echo ""
+	@echo "Waiting for certificate (timeout: 2 minutes)..."
+	@timeout=120; elapsed=0; \
+	while [ $$elapsed -lt $$timeout ]; do \
+		if oc get certificate test-cert-selfsigned -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+			echo "$(GREEN)Certificate issued successfully!$(RESET)"; \
+			break; \
+		fi; \
+		if [ $$((elapsed % 10)) -eq 0 ]; then echo "  Still waiting... ($$elapsed seconds)"; fi; \
+		sleep 2; elapsed=$$((elapsed + 2)); \
+	done
+	@echo ""
+	@echo "Quick self-signed CA test complete! Run 'make clean-selfsigned' to clean up."
 
 quick-dns-test: test-dns01 test-cert ## Quick end-to-end DNS-01 test
 	@echo ""
@@ -390,11 +416,20 @@ clean-dns-config: ## Restore DNS configuration
 	@oc patch dns.operator.openshift.io/default --type=json -p='[{"op": "remove", "path": "/spec/servers"}]' 2>/dev/null || true
 	@echo "DNS configuration restored."
 
-clean-issuers: ## Clean up ClusterIssuers
+clean-issuers: ## Clean up ClusterIssuers (ACME/Pebble)
 	@echo "$(BOLD)$(YELLOW)Cleaning up ClusterIssuers...$(RESET)"
 	@oc delete clusterissuer pebble-issuer pebble-dns01-issuer --ignore-not-found=true
 	@oc delete secret rfc2136-credentials -n default --ignore-not-found=true
 	@echo "$(GREEN)ClusterIssuers cleaned.$(RESET)"
+
+clean-selfsigned: ## Clean up self-signed CA chain
+	@echo "$(BOLD)$(YELLOW)Cleaning up self-signed CA resources...$(RESET)"
+	@oc delete certificate test-cert-selfsigned -n default --ignore-not-found=true
+	@oc delete secret test-cert-selfsigned-tls -n default --ignore-not-found=true
+	@oc delete clusterissuer selfsigned-ca-issuer selfsigned-issuer --ignore-not-found=true
+	@oc delete certificate root-ca -n cert-manager --ignore-not-found=true
+	@oc delete secret root-ca-secret -n cert-manager --ignore-not-found=true
+	@echo "$(GREEN)Self-signed CA resources cleaned.$(RESET)"
 
 clean-monitoring: ## Clean up cert-manager monitoring resources
 	@echo "$(BOLD)$(YELLOW)Cleaning up monitoring resources...$(RESET)"
@@ -407,7 +442,7 @@ clean-temp: ## Clean up temporary files
 	@find . -name ".*.swp" -delete
 	@echo "Temp files cleaned."
 
-clean: clean-certs clean-issuers clean-monitoring clean-pebble clean-fake-dns clean-dns-config ## Clean everything except cert-manager-operator
+clean: clean-certs clean-issuers clean-selfsigned clean-monitoring clean-pebble clean-fake-dns clean-dns-config ## Clean everything except cert-manager-operator
 	@echo ""
 	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
 	@echo "  ╔═════════════════════════════════════════════════════════════╗"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -259,6 +259,23 @@ wait_for_resource() {
 	fi
 }
 
+# Verify cert-manager is installed and webhook is ready
+require_cert_manager() {
+	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
+		log_error "cert-manager not found. Please install cert-manager-operator first."
+		log_info "  Run: make install-cert-manager-operator"
+		exit 1
+	fi
+
+	log_info "Waiting for cert-manager webhook to be ready..."
+	if ! oc wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager; then
+		log_error "Timeout waiting for cert-manager webhook to be ready."
+		log_info "  Check webhook status: oc get deployment cert-manager-webhook -n cert-manager"
+		exit 1
+	fi
+	log_info "cert-manager webhook is ready."
+}
+
 # Print a formatted section header
 # Usage: print_header "Title"
 print_header() {

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -174,20 +174,7 @@ main() {
 
 	require_cmd oc envsubst
 	require_cluster
-
-	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
-		log_error "cert-manager not found. Please install cert-manager-operator first."
-		log_info "  Run: make install-cert-manager-operator"
-		exit 1
-	fi
-
-	log_info "Waiting for cert-manager webhook to be ready..."
-	if ! oc wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager; then
-		log_error "Timeout waiting for cert-manager webhook to be ready."
-		log_info "  Check webhook status: oc get deployment cert-manager-webhook -n cert-manager"
-		exit 1
-	fi
-	log_info "cert-manager webhook is ready."
+	require_cert_manager
 
 	if [ ! -d "$YAML_DIR" ]; then
 		log_error "YAML directory not found: $YAML_DIR"

--- a/scripts/create-selfsigned-issuer.sh
+++ b/scripts/create-selfsigned-issuer.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+################################################################################
+# Script: create-selfsigned-issuer.sh
+# Description: Create a self-signed CA chain for disconnected/air-gapped environments
+#
+# Creates:
+#   1. SelfSigned ClusterIssuer (bootstrap)
+#   2. Root CA Certificate (long-lived, RSA 4096)
+#   3. CA ClusterIssuer (signs leaf certificates)
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"
+
+export SELFSIGNED_ISSUER_NAME="${SELFSIGNED_ISSUER_NAME:-selfsigned-issuer}"
+export CA_ISSUER_NAME="${CA_ISSUER_NAME:-selfsigned-ca-issuer}"
+export ROOT_CA_NAME="${ROOT_CA_NAME:-root-ca}"
+export ROOT_CA_NAMESPACE="${ROOT_CA_NAMESPACE:-cert-manager}"
+export ROOT_CA_COMMON_NAME="${ROOT_CA_COMMON_NAME:-cluster-root-ca}"
+export ROOT_CA_ORG="${ROOT_CA_ORG:-OpenShift}"
+export ROOT_CA_SECRET_NAME="${ROOT_CA_SECRET_NAME:-root-ca-secret}"
+export ROOT_CA_DURATION="${ROOT_CA_DURATION:-87600h}"
+export ROOT_CA_RENEW_BEFORE="${ROOT_CA_RENEW_BEFORE:-8760h}"
+
+check_existing_issuer() {
+	log_info "Checking for existing CA resources..."
+
+	local exists=false
+
+	if oc get clusterissuer "$SELFSIGNED_ISSUER_NAME" &>/dev/null; then
+		log_warn "ClusterIssuer '$SELFSIGNED_ISSUER_NAME' already exists."
+		exists=true
+	fi
+
+	if oc get clusterissuer "$CA_ISSUER_NAME" &>/dev/null; then
+		log_warn "ClusterIssuer '$CA_ISSUER_NAME' already exists."
+		exists=true
+	fi
+
+	if oc get certificate "$ROOT_CA_NAME" -n "$ROOT_CA_NAMESPACE" &>/dev/null; then
+		log_warn "Root CA Certificate '$ROOT_CA_NAME' already exists in namespace '$ROOT_CA_NAMESPACE'."
+		exists=true
+	fi
+
+	if [ "$exists" = true ]; then
+		echo
+		read -p "Overwrite existing resources? (y/N): " -n 1 -r
+		echo
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			log_info "Keeping existing resources."
+			exit 0
+		fi
+	fi
+}
+
+display_configuration() {
+	print_header "Self-Signed CA Configuration"
+	print_summary \
+		"CA Issuer Name" "$CA_ISSUER_NAME" \
+		"Root CA Name" "$ROOT_CA_NAME" \
+		"Root CA Namespace" "$ROOT_CA_NAMESPACE" \
+		"Root CA Common Name" "$ROOT_CA_COMMON_NAME" \
+		"Root CA Organization" "$ROOT_CA_ORG" \
+		"Root CA Secret" "$ROOT_CA_SECRET_NAME" \
+		"Root CA Duration" "$ROOT_CA_DURATION" \
+		"Root CA Renew Before" "$ROOT_CA_RENEW_BEFORE"
+}
+
+create_selfsigned_issuer() {
+	log_info "Step 1/3: Creating SelfSigned ClusterIssuer (bootstrap)..."
+	apply_yaml_template "$YAML_DIR/selfsigned-clusterissuer.yaml" "SelfSigned ClusterIssuer"
+
+	log_info "Waiting for SelfSigned ClusterIssuer to be ready..."
+	retry 10 2 oc wait --for=condition=Ready clusterissuer/"$SELFSIGNED_ISSUER_NAME" --timeout=30s
+	log_success "SelfSigned ClusterIssuer is ready."
+}
+
+create_root_ca() {
+	log_info "Step 2/3: Creating Root CA Certificate..."
+	apply_yaml_template "$YAML_DIR/root-ca-certificate.yaml" "Root CA Certificate"
+
+	log_info "Waiting for Root CA Certificate to be issued..."
+	retry 15 2 oc wait --for=condition=Ready certificate/"$ROOT_CA_NAME" -n "$ROOT_CA_NAMESPACE" --timeout=30s
+	log_success "Root CA Certificate is ready."
+}
+
+create_ca_issuer() {
+	log_info "Step 3/3: Creating CA ClusterIssuer..."
+	apply_yaml_template "$YAML_DIR/ca-clusterissuer.yaml" "CA ClusterIssuer"
+
+	log_info "Waiting for CA ClusterIssuer to be ready..."
+	retry 10 2 oc wait --for=condition=Ready clusterissuer/"$CA_ISSUER_NAME" --timeout=30s
+	log_success "CA ClusterIssuer is ready."
+}
+
+display_next_steps() {
+	echo
+	log_success "Self-signed CA chain created successfully!"
+	echo
+	echo "CA Issuer '$CA_ISSUER_NAME' is ready to sign certificates."
+	echo
+	echo "Next steps:"
+	echo
+	echo "1. View CA chain status:"
+	echo "   oc get clusterissuer"
+	echo "   oc get certificate -n $ROOT_CA_NAMESPACE"
+	echo
+	echo "2. Create a test certificate:"
+	echo "   cat <<EOF | oc apply -f -"
+	echo "   apiVersion: cert-manager.io/v1"
+	echo "   kind: Certificate"
+	echo "   metadata:"
+	echo "     name: my-test-cert"
+	echo "     namespace: default"
+	echo "   spec:"
+	echo "     secretName: my-test-cert-tls"
+	echo "     issuerRef:"
+	echo "       name: $CA_ISSUER_NAME"
+	echo "       kind: ClusterIssuer"
+	echo "     dnsNames:"
+	echo "     - test.example.com"
+	echo "   EOF"
+	echo
+	echo "3. Extract root CA for kubeconfig trust:"
+	echo "   oc get secret $ROOT_CA_SECRET_NAME -n $ROOT_CA_NAMESPACE -o jsonpath='{.data.ca\\.crt}' | base64 -d"
+	echo
+}
+
+main() {
+	print_header "Create Self-Signed CA Chain"
+
+	require_cmd oc envsubst
+	require_cluster
+	require_cert_manager
+
+	if [ ! -d "$YAML_DIR" ]; then
+		log_error "YAML directory not found: $YAML_DIR"
+		exit 1
+	fi
+
+	display_configuration
+	check_existing_issuer
+	create_selfsigned_issuer
+	create_root_ca
+	create_ca_issuer
+	display_next_steps
+}
+
+main

--- a/yaml/issuers/ca-clusterissuer.yaml
+++ b/yaml/issuers/ca-clusterissuer.yaml
@@ -1,0 +1,9 @@
+# CA issuer backed by the self-signed root CA.
+# Use for disconnected/air-gapped environments where ACME is unavailable.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${CA_ISSUER_NAME}
+spec:
+  ca:
+    secretName: ${ROOT_CA_SECRET_NAME}

--- a/yaml/issuers/root-ca-certificate.yaml
+++ b/yaml/issuers/root-ca-certificate.yaml
@@ -1,0 +1,23 @@
+# Root CA issued by the bootstrap SelfSigned issuer.
+# The CA ClusterIssuer references this secret to sign leaf certificates.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${ROOT_CA_NAME}
+  namespace: ${ROOT_CA_NAMESPACE}
+spec:
+  isCA: true
+  commonName: ${ROOT_CA_COMMON_NAME}
+  subject:
+    organizations:
+    - "${ROOT_CA_ORG}"
+  secretName: ${ROOT_CA_SECRET_NAME}
+  duration: ${ROOT_CA_DURATION}
+  renewBefore: ${ROOT_CA_RENEW_BEFORE}
+  privateKey:
+    algorithm: RSA
+    size: 4096
+  issuerRef:
+    name: ${SELFSIGNED_ISSUER_NAME}
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/yaml/issuers/selfsigned-clusterissuer.yaml
+++ b/yaml/issuers/selfsigned-clusterissuer.yaml
@@ -1,0 +1,7 @@
+# Bootstrap issuer for generating the root CA certificate.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: ${SELFSIGNED_ISSUER_NAME}
+spec:
+  selfSigned: {}


### PR DESCRIPTION
## Summary

- Adds self-signed CA chain (SelfSigned ClusterIssuer → Root CA Certificate → CA ClusterIssuer) as an alternative to ACME issuers for disconnected/air-gapped environments
- New script `create-selfsigned-issuer.sh` deploys the full 3-step CA chain with validation
- New Makefile targets: `create-selfsigned-issuer`, `quick-selfsigned-test`, `clean-selfsigned`
- Extracts `require_cert_manager` into `lib/common.sh` to deduplicate prereq checks across issuer scripts

## Context

Raised by @yprokule in the context of RDS Core cert-manager integration — disconnected environments need a self-signed CA path since ACME infrastructure may not be available. See [MR !38](https://gitlab.cee.redhat.com/yprokule/rds-core-kni-qe-69/-/merge_requests/38) for the downstream pattern.

This serves as an example of how to configure cert-manager with a self-signed CA for environments where external ACME servers are not reachable. The YAMLs in `yaml/issuers/` can be used as reference configurations for telco-reference and RDS Core deployments.

## Test plan

- [ ] `make lint` passes
- [ ] `make create-selfsigned-issuer` deploys the full CA chain on a cluster
- [ ] `make quick-selfsigned-test` issues a test cert end-to-end
- [ ] `make clean-selfsigned` removes all self-signed CA resources
- [ ] Existing ACME targets (`make quick-http-test`, `make quick-dns-test`) unaffected

Closes #28