### PR TITLE
Add cert-manager Prometheus monitoring and alerting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,8 +398,7 @@ clean-issuers: ## Clean up ClusterIssuers
 
 clean-monitoring: ## Clean up cert-manager monitoring resources
 	@echo "$(BOLD)$(YELLOW)Cleaning up monitoring resources...$(RESET)"
-	@oc delete servicemonitor cert-manager -n cert-manager --ignore-not-found=true
-	@oc delete prometheusrule cert-manager-alerts -n cert-manager --ignore-not-found=true
+	@oc delete servicemonitor/cert-manager prometheusrule/cert-manager-alerts -n cert-manager --ignore-not-found=true
 	@echo "$(GREEN)Monitoring resources cleaned.$(RESET)"
 
 clean-temp: ## Clean up temporary files
@@ -408,7 +407,7 @@ clean-temp: ## Clean up temporary files
 	@find . -name ".*.swp" -delete
 	@echo "Temp files cleaned."
 
-clean: clean-certs clean-issuers clean-pebble clean-fake-dns clean-dns-config ## Clean everything except cert-manager-operator
+clean: clean-certs clean-issuers clean-monitoring clean-pebble clean-fake-dns clean-dns-config ## Clean everything except cert-manager-operator
 	@echo ""
 	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
 	@echo "  ╔═════════════════════════════════════════════════════════════╗"

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ BG_BLUE := \033[44m
 # Target Definitions
 # ────────────────────────────────────────────────────────────────────────────────
 .PHONY: all help banner preflight lint install-cert-manager-operator install-pebble \
-        install-fake-dns install-all create-issuer create-dns01-issuer create-certs \
-        create-apiserver-cert verify-apiserver-cert \
+        install-fake-dns install-all install-monitoring create-issuer create-dns01-issuer \
+        create-certs create-apiserver-cert verify-apiserver-cert \
         test-all test-dns01 quick-http-test quick-dns-test test-cert verify-cert \
         troubleshoot check-cert check-issuer check-network check-network-stack check-workload-partitioning \
         diagnose-http01 diagnose-dns01 clean clean-certs clean-pebble clean-fake-dns \
-        clean-dns-config clean-issuers clean-temp uninstall-cert-manager-operator \
+        clean-dns-config clean-issuers clean-monitoring clean-temp uninstall-cert-manager-operator \
         install-minio install-oadp install-ibu-prereqs capture-cert-state \
         test-ibu-certs test-ibu-preserved test-ibu-both quick-ibu-test clean-ibu
 
@@ -132,6 +132,9 @@ install-fake-dns: ## Install fake DNS API for air-gapped DNS-01 testing
 	@echo "$(BOLD)$(BLUE)Installing fake DNS API for air-gapped testing...$(RESET)"
 	@./scripts/install-fake-dns.sh
 	@echo ""
+
+install-monitoring: ## Install cert-manager Prometheus monitoring and alerts
+	@./scripts/install-monitoring.sh
 
 install-all: install-cert-manager-operator install-pebble ## Install cert-manager-operator and Pebble
 	@echo ""
@@ -392,6 +395,12 @@ clean-issuers: ## Clean up ClusterIssuers
 	@oc delete clusterissuer pebble-issuer pebble-dns01-issuer --ignore-not-found=true
 	@oc delete secret rfc2136-credentials -n default --ignore-not-found=true
 	@echo "$(GREEN)ClusterIssuers cleaned.$(RESET)"
+
+clean-monitoring: ## Clean up cert-manager monitoring resources
+	@echo "$(BOLD)$(YELLOW)Cleaning up monitoring resources...$(RESET)"
+	@oc delete servicemonitor cert-manager -n cert-manager --ignore-not-found=true
+	@oc delete prometheusrule cert-manager-alerts -n cert-manager --ignore-not-found=true
+	@echo "$(GREEN)Monitoring resources cleaned.$(RESET)"
 
 clean-temp: ## Clean up temporary files
 	@echo "Cleaning temporary files..."

--- a/scripts/install-monitoring.sh
+++ b/scripts/install-monitoring.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+################################################################################
+# Script: install-monitoring.sh
+# Description: Deploy cert-manager Prometheus monitoring (ServiceMonitor + alerts)
+#
+# Prerequisites:
+#   - cert-manager operator installed
+#   - User workload monitoring enabled (enableUserWorkload: true)
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+YAML_DIR="${SCRIPT_DIR}/../yaml/monitoring"
+
+export CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
+
+check_user_workload_monitoring() {
+	log_info "Checking if user workload monitoring is enabled..."
+
+	local uwm_enabled
+	uwm_enabled=$(oc get configmap cluster-monitoring-config -n openshift-monitoring \
+		-o jsonpath='{.data.config\.yaml}' 2>/dev/null || echo "")
+
+	if echo "$uwm_enabled" | grep -q "enableUserWorkload.*true"; then
+		log_success "User workload monitoring is enabled."
+	else
+		log_warn "User workload monitoring may not be enabled."
+		log_info "To enable, apply this ConfigMap:"
+		echo
+		echo "  oc apply -f - <<EOF"
+		echo "  apiVersion: v1"
+		echo "  kind: ConfigMap"
+		echo "  metadata:"
+		echo "    name: cluster-monitoring-config"
+		echo "    namespace: openshift-monitoring"
+		echo "  data:"
+		echo "    config.yaml: |"
+		echo "      enableUserWorkload: true"
+		echo "  EOF"
+		echo
+		read -p "Continue anyway? (y/N): " -n 1 -r
+		echo
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			log_info "Cancelled."
+			exit 0
+		fi
+	fi
+}
+
+check_existing_resources() {
+	log_info "Checking for existing monitoring resources..."
+
+	local exists=false
+
+	if oc get servicemonitor cert-manager -n "$CERT_MANAGER_NAMESPACE" &>/dev/null; then
+		log_warn "ServiceMonitor 'cert-manager' already exists."
+		exists=true
+	fi
+
+	if oc get prometheusrule cert-manager-alerts -n "$CERT_MANAGER_NAMESPACE" &>/dev/null; then
+		log_warn "PrometheusRule 'cert-manager-alerts' already exists."
+		exists=true
+	fi
+
+	if [ "$exists" = true ]; then
+		echo
+		read -p "Overwrite existing resources? (y/N): " -n 1 -r
+		echo
+		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+			log_info "Keeping existing resources."
+			exit 0
+		fi
+	fi
+}
+
+install_service_monitor() {
+	log_info "Step 1/2: Creating ServiceMonitor..."
+	apply_yaml_template "$YAML_DIR/service-monitor.yaml" "ServiceMonitor"
+	log_success "ServiceMonitor created."
+}
+
+install_prometheus_rules() {
+	log_info "Step 2/2: Creating PrometheusRule alerts..."
+	apply_yaml_template "$YAML_DIR/prometheus-rules.yaml" "PrometheusRule"
+	log_success "PrometheusRule created."
+}
+
+verify_monitoring() {
+	log_info "Verifying monitoring resources..."
+	echo
+
+	echo "ServiceMonitor:"
+	oc get servicemonitor -n "$CERT_MANAGER_NAMESPACE" 2>/dev/null || echo "  No ServiceMonitors found"
+	echo
+
+	echo "PrometheusRule:"
+	oc get prometheusrule -n "$CERT_MANAGER_NAMESPACE" 2>/dev/null || echo "  No PrometheusRules found"
+	echo
+}
+
+display_next_steps() {
+	echo
+	log_success "cert-manager monitoring configured!"
+	echo
+	echo "Alerts configured:"
+	echo "  - CertManagerAbsent         (critical) cert-manager not scraped for 15m"
+	echo "  - CertManagerCertExpirySoon  (warning)  certificate expiring within 21 days"
+	echo "  - CertManagerCertNotReady    (warning)  certificate not ready for 10m"
+	echo "  - CertManagerHittingRateLimits (warning) ACME 4xx errors detected"
+	echo
+	echo "Next steps:"
+	echo
+	echo "1. Verify metrics are being scraped:"
+	echo "   oc get servicemonitor -n $CERT_MANAGER_NAMESPACE"
+	echo
+	echo "2. Check alert rules in the OpenShift console:"
+	echo "   Observe > Alerting > Alerting Rules"
+	echo
+	echo "3. Verify cert-manager metrics (from a Prometheus pod):"
+	echo "   curl http://cert-manager.$CERT_MANAGER_NAMESPACE.svc:9402/metrics"
+	echo
+}
+
+main() {
+	print_header "Install cert-manager Monitoring"
+
+	require_cmd oc envsubst
+	require_cluster
+
+	if ! oc get deployment -n "$CERT_MANAGER_NAMESPACE" cert-manager &>/dev/null; then
+		log_error "cert-manager not found. Please install cert-manager-operator first."
+		log_info "  Run: make install-cert-manager-operator"
+		exit 1
+	fi
+
+	if [ ! -d "$YAML_DIR" ]; then
+		log_error "YAML directory not found: $YAML_DIR"
+		exit 1
+	fi
+
+	print_summary \
+		"Namespace" "$CERT_MANAGER_NAMESPACE"
+
+	check_user_workload_monitoring
+	check_existing_resources
+	install_service_monitor
+	install_prometheus_rules
+	verify_monitoring
+	display_next_steps
+}
+
+main

--- a/scripts/install-monitoring.sh
+++ b/scripts/install-monitoring.sh
@@ -93,11 +93,11 @@ verify_monitoring() {
 	log_info "Verifying monitoring resources..."
 	echo
 
-	echo "ServiceMonitor:"
+	log_info "ServiceMonitor:"
 	oc get servicemonitor -n "$CERT_MANAGER_NAMESPACE" 2>/dev/null || echo "  No ServiceMonitors found"
 	echo
 
-	echo "PrometheusRule:"
+	log_info "PrometheusRule:"
 	oc get prometheusrule -n "$CERT_MANAGER_NAMESPACE" 2>/dev/null || echo "  No PrometheusRules found"
 	echo
 }
@@ -110,7 +110,7 @@ display_next_steps() {
 	echo "  - CertManagerAbsent         (critical) cert-manager not scraped for 15m"
 	echo "  - CertManagerCertExpirySoon  (warning)  certificate expiring within 21 days"
 	echo "  - CertManagerCertNotReady    (warning)  certificate not ready for 10m"
-	echo "  - CertManagerHittingRateLimits (warning) ACME 4xx errors detected"
+	echo "  - CertManagerACMEClientErrors  (warning) ACME 4xx errors detected"
 	echo
 	echo "Next steps:"
 	echo

--- a/yaml/monitoring/prometheus-rules.yaml
+++ b/yaml/monitoring/prometheus-rules.yaml
@@ -41,7 +41,7 @@ spec:
         description: "Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} is not ready to serve traffic."
       labels:
         severity: warning
-    - alert: CertManagerHittingRateLimits
+    - alert: CertManagerACMEClientErrors
       expr: |
         sum by (host) (
           rate(certmanager_http_acme_client_request_count{status=~"4.."}[5m])

--- a/yaml/monitoring/prometheus-rules.yaml
+++ b/yaml/monitoring/prometheus-rules.yaml
@@ -26,8 +26,8 @@ spec:
         ) < (21 * 24 * 3600)
       for: 1h
       annotations:
-        summary: "Certificate {{ $labels.name }} expires in {{ $value | humanizeDuration }}"
-        description: "Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in {{ $value | humanizeDuration }}. It should have been renewed automatically."
+        summary: "Certificate {{ $labels.name }} expiring soon"
+        description: "Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} is expiring within 21 days. It should have been renewed automatically."
       labels:
         severity: warning
     - alert: CertManagerCertNotReady

--- a/yaml/monitoring/prometheus-rules.yaml
+++ b/yaml/monitoring/prometheus-rules.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-manager-alerts
+  namespace: ${CERT_MANAGER_NAMESPACE}
+  labels:
+    app: cert-manager
+spec:
+  groups:
+  - name: cert-manager
+    rules:
+    - alert: CertManagerAbsent
+      expr: absent(up{job="cert-manager"})
+      for: 15m
+      annotations:
+        summary: "cert-manager has disappeared from Prometheus service discovery"
+        description: "cert-manager is not being scraped by Prometheus. Certificate management is not operational."
+        runbook_url: "https://cert-manager.io/docs/troubleshooting/"
+      labels:
+        severity: critical
+    - alert: CertManagerCertExpirySoon
+      expr: |
+        avg by (exported_namespace, namespace, name) (
+          certmanager_certificate_expiration_timestamp_seconds - time()
+        ) < (21 * 24 * 3600)
+      for: 1h
+      annotations:
+        summary: "Certificate {{ $labels.name }} expires in {{ $value | humanizeDuration }}"
+        description: "Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} expires in {{ $value | humanizeDuration }}. It should have been renewed automatically."
+      labels:
+        severity: warning
+    - alert: CertManagerCertNotReady
+      expr: |
+        max by (name, exported_namespace, namespace, condition) (
+          certmanager_certificate_ready_status{condition!="True"}
+        ) == 1
+      for: 10m
+      annotations:
+        summary: "Certificate {{ $labels.name }} is not ready"
+        description: "Certificate {{ $labels.name }} in namespace {{ $labels.exported_namespace }} is not ready to serve traffic."
+      labels:
+        severity: warning
+    - alert: CertManagerHittingRateLimits
+      expr: |
+        sum by (host) (
+          rate(certmanager_http_acme_client_request_count{status=~"4.."}[5m])
+        ) > 0
+      for: 15m
+      annotations:
+        summary: "cert-manager is receiving ACME client errors from {{ $labels.host }}"
+        description: "cert-manager is receiving 4xx responses from ACME server {{ $labels.host }}. This may indicate rate limiting or configuration issues."
+      labels:
+        severity: warning

--- a/yaml/monitoring/service-monitor.yaml
+++ b/yaml/monitoring/service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cert-manager
+  namespace: ${CERT_MANAGER_NAMESPACE}
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+spec:
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+    - ${CERT_MANAGER_NAMESPACE}
+  selector:
+    matchExpressions:
+    - key: app.kubernetes.io/name
+      operator: In
+      values:
+      - cainjector
+      - cert-manager
+      - webhook
+  endpoints:
+  - port: tcp-prometheus-servicemonitor
+    interval: 30s
+    honorLabels: true


### PR DESCRIPTION
## Summary

- Adds `ServiceMonitor` to scrape cert-manager controller, cainjector, and webhook metrics (port 9402)
- Adds `PrometheusRule` with 4 standard alerts:
  - **CertManagerAbsent** (critical) — cert-manager not scraped for 15m
  - **CertManagerCertExpirySoon** (warning) — certificate expiring within 21 days
  - **CertManagerCertNotReady** (warning) — certificate not ready for 10m
  - **CertManagerHittingRateLimits** (warning) — ACME 4xx errors detected
- New script `install-monitoring.sh` with user workload monitoring prerequisite check
- New Makefile targets: `install-monitoring`, `clean-monitoring`

## Context

Team members are setting up cert-manager alerting and hitting configuration issues. The OpenShift cert-manager operator exposes metrics but does not ship PrometheusRule resources — these must be created manually.

## Prerequisites

User workload monitoring must be enabled:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cluster-monitoring-config
  namespace: openshift-monitoring
data:
  config.yaml: |
    enableUserWorkload: true
```

## Test plan

- [ ] `make lint` passes
- [ ] `make install-monitoring` deploys ServiceMonitor + PrometheusRule
- [ ] Alerts appear in OpenShift console (Observe > Alerting > Alerting Rules)
- [ ] `make clean-monitoring` removes monitoring resources

Closes #30