### PR TITLE
Pin container images and add version-check automation

### DIFF
--- a/.github/workflows/check-acme-dns-version.yml
+++ b/.github/workflows/check-acme-dns-version.yml
@@ -1,0 +1,57 @@
+name: Check acme-dns Version
+
+on:
+  schedule:
+    - cron: '41 8 * * 3'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-version:
+    name: Check for new acme-dns version
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Get current pinned version
+        id: current
+        run: |
+          current=$(grep 'joohoi/acme-dns:' yaml/acme-dns/deployment.yaml | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+          echo "version=$current" >> "$GITHUB_OUTPUT"
+          echo "Current pinned version: $current"
+
+      - name: Query GitHub for latest acme-dns version
+        id: latest
+        run: ./scripts/workflows/query-acme-dns-version.sh
+
+      - name: Compare versions
+        id: compare
+        run: ./scripts/workflows/compare-versions.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
+
+      - name: Update deployment file
+        if: steps.compare.outputs.needs_update == 'true'
+        run: ./scripts/workflows/update-acme-dns-version.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
+
+      - name: Create pull request
+        if: steps.compare.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Bump acme-dns to ${{ steps.latest.outputs.version }}"
+          title: "Bump acme-dns to ${{ steps.latest.outputs.version }}"
+          body: |
+            Automated version bump detected by the weekly acme-dns version check.
+
+            **Current version:** `${{ steps.current.outputs.version }}`
+            **New version:** `${{ steps.latest.outputs.version }}`
+
+            Changes:
+            - Updated acme-dns deployment image tag
+
+            Source: [GitHub Releases](https://github.com/joohoi/acme-dns/releases)
+          branch: bump-acme-dns-${{ steps.latest.outputs.version }}
+          delete-branch: true
+          labels: dependencies

--- a/.github/workflows/check-minio-version.yml
+++ b/.github/workflows/check-minio-version.yml
@@ -1,0 +1,57 @@
+name: Check MinIO Version
+
+on:
+  schedule:
+    - cron: '47 8 * * 4'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-version:
+    name: Check for new MinIO version
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Get current pinned version
+        id: current
+        run: |
+          current=$(grep 'quay.io/minio/minio:' yaml/ibu/minio/deployment.yaml | grep -oE 'RELEASE\.[0-9T-]+Z')
+          echo "version=$current" >> "$GITHUB_OUTPUT"
+          echo "Current pinned version: $current"
+
+      - name: Query quay.io for latest MinIO version
+        id: latest
+        run: ./scripts/workflows/query-minio-version.sh
+
+      - name: Compare versions
+        id: compare
+        run: ./scripts/workflows/compare-versions.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
+
+      - name: Update deployment file
+        if: steps.compare.outputs.needs_update == 'true'
+        run: ./scripts/workflows/update-minio-version.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
+
+      - name: Create pull request
+        if: steps.compare.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Bump MinIO to ${{ steps.latest.outputs.version }}"
+          title: "Bump MinIO to ${{ steps.latest.outputs.version }}"
+          body: |
+            Automated version bump detected by the weekly MinIO version check.
+
+            **Current version:** `${{ steps.current.outputs.version }}`
+            **New version:** `${{ steps.latest.outputs.version }}`
+
+            Changes:
+            - Updated MinIO deployment image tag
+
+            Source: [Quay.io](https://quay.io/repository/minio/minio?tab=tags)
+          branch: bump-minio-${{ steps.latest.outputs.version }}
+          delete-branch: true
+          labels: dependencies

--- a/.github/workflows/check-pebble-version.yml
+++ b/.github/workflows/check-pebble-version.yml
@@ -1,0 +1,58 @@
+name: Check Pebble Version
+
+on:
+  schedule:
+    - cron: '37 8 * * 2'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-version:
+    name: Check for new Pebble version
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Get current pinned version
+        id: current
+        run: |
+          current=$(grep 'ghcr.io/letsencrypt/pebble:' yaml/pebble/deployment.yaml | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+          echo "version=$current" >> "$GITHUB_OUTPUT"
+          echo "Current pinned version: $current"
+
+      - name: Query GitHub for latest Pebble version
+        id: latest
+        run: ./scripts/workflows/query-pebble-version.sh
+
+      - name: Compare versions
+        id: compare
+        run: ./scripts/workflows/compare-versions.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
+
+      - name: Update deployment files
+        if: steps.compare.outputs.needs_update == 'true'
+        run: ./scripts/workflows/update-pebble-version.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
+
+      - name: Create pull request
+        if: steps.compare.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Bump Pebble to ${{ steps.latest.outputs.version }}"
+          title: "Bump Pebble to ${{ steps.latest.outputs.version }}"
+          body: |
+            Automated version bump detected by the weekly Pebble version check.
+
+            **Current version:** `${{ steps.current.outputs.version }}`
+            **New version:** `${{ steps.latest.outputs.version }}`
+
+            Changes:
+            - Updated `pebble` deployment image tag
+            - Updated `pebble-challtestsrv` deployment image tag
+
+            Source: [GitHub Releases](https://github.com/letsencrypt/pebble/releases)
+          branch: bump-pebble-${{ steps.latest.outputs.version }}
+          delete-branch: true
+          labels: dependencies

--- a/.github/workflows/check-ubi9-python-version.yml
+++ b/.github/workflows/check-ubi9-python-version.yml
@@ -1,0 +1,57 @@
+name: Check UBI9 Python Version
+
+on:
+  schedule:
+    - cron: '53 8 * * 5'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-version:
+    name: Check for new UBI9 Python 3.9 version
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Get current pinned version
+        id: current
+        run: |
+          current=$(grep 'ubi9/python-39:' yaml/fake-dns-api/deployment.yaml | grep -oE '[0-9]+\.[0-9]+')
+          echo "version=$current" >> "$GITHUB_OUTPUT"
+          echo "Current pinned version: $current"
+
+      - name: Query Red Hat catalog for latest version
+        id: latest
+        run: ./scripts/workflows/query-ubi9-python-version.sh
+
+      - name: Compare versions
+        id: compare
+        run: ./scripts/workflows/compare-versions.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
+
+      - name: Update deployment file
+        if: steps.compare.outputs.needs_update == 'true'
+        run: ./scripts/workflows/update-ubi9-python-version.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
+
+      - name: Create pull request
+        if: steps.compare.outputs.needs_update == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Bump UBI9 Python 3.9 to ${{ steps.latest.outputs.version }}"
+          title: "Bump UBI9 Python 3.9 to ${{ steps.latest.outputs.version }}"
+          body: |
+            Automated version bump detected by the weekly UBI9 Python version check.
+
+            **Current version:** `${{ steps.current.outputs.version }}`
+            **New version:** `${{ steps.latest.outputs.version }}`
+
+            Changes:
+            - Updated fake-dns-api deployment image tag
+
+            Source: [Red Hat Ecosystem Catalog](https://catalog.redhat.com/en/software/containers/ubi9/python-39)
+          branch: bump-ubi9-python-${{ steps.latest.outputs.version }}
+          delete-branch: true
+          labels: dependencies

--- a/scripts/workflows/query-acme-dns-version.sh
+++ b/scripts/workflows/query-acme-dns-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+################################################################################
+# Script: query-acme-dns-version.sh
+# Description: Query GitHub releases API for latest acme-dns version
+# Used by: check-acme-dns-version.yml
+################################################################################
+
+set -euo pipefail
+
+latest=$(curl -sL "https://api.github.com/repos/joohoi/acme-dns/releases/latest" |
+	jq -r '.tag_name // empty')
+
+if [ -z "$latest" ]; then
+	echo "Failed to fetch latest acme-dns release from GitHub"
+	exit 1
+fi
+
+echo "version=$latest" >>"$GITHUB_OUTPUT"
+echo "Latest available version: $latest"

--- a/scripts/workflows/query-minio-version.sh
+++ b/scripts/workflows/query-minio-version.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+################################################################################
+# Script: query-minio-version.sh
+# Description: Query quay.io API for latest MinIO release tag
+# Used by: check-minio-version.yml
+################################################################################
+
+set -euo pipefail
+
+tags=$(curl -sL "https://quay.io/api/v1/repository/minio/minio/tag/?limit=100&onlyActiveTags=true" |
+	jq -r '.tags[].name // empty')
+
+if [ -z "$tags" ]; then
+	echo "Failed to fetch tags from quay.io"
+	exit 1
+fi
+
+latest=$(echo "$tags" | grep -E '^RELEASE\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z$' | sort -r | head -1)
+
+if [ -z "$latest" ]; then
+	echo "No valid RELEASE tags found"
+	echo "Raw tags:"
+	echo "$tags" | head -20
+	exit 1
+fi
+
+echo "version=$latest" >>"$GITHUB_OUTPUT"
+echo "Latest available version: $latest"

--- a/scripts/workflows/query-pebble-version.sh
+++ b/scripts/workflows/query-pebble-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+################################################################################
+# Script: query-pebble-version.sh
+# Description: Query GitHub releases API for latest Pebble version
+# Used by: check-pebble-version.yml
+################################################################################
+
+set -euo pipefail
+
+latest=$(curl -sL "https://api.github.com/repos/letsencrypt/pebble/releases/latest" |
+	jq -r '.tag_name // empty')
+
+if [ -z "$latest" ]; then
+	echo "Failed to fetch latest Pebble release from GitHub"
+	exit 1
+fi
+
+echo "version=$latest" >>"$GITHUB_OUTPUT"
+echo "Latest available version: $latest"

--- a/scripts/workflows/query-ubi9-python-version.sh
+++ b/scripts/workflows/query-ubi9-python-version.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+################################################################################
+# Script: query-ubi9-python-version.sh
+# Description: Query Red Hat Pyxis API for latest UBI9 Python 3.9 version
+# Used by: check-ubi9-python-version.yml
+################################################################################
+
+set -euo pipefail
+
+tags=$(curl -sL "https://catalog.redhat.io/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/python-39/tags?page_size=100&page=0" |
+	jq -r '.data[].name // empty')
+
+if [ -z "$tags" ]; then
+	echo "Failed to fetch tags from Red Hat catalog API"
+	exit 1
+fi
+
+latest=$(echo "$tags" | grep -oE '^[0-9]+\.[0-9]+$' | sort -V | tail -1)
+
+if [ -z "$latest" ]; then
+	echo "No valid version tags found"
+	echo "Raw tags:"
+	echo "$tags" | head -20
+	exit 1
+fi
+
+echo "version=$latest" >>"$GITHUB_OUTPUT"
+echo "Latest available version: $latest"

--- a/scripts/workflows/update-acme-dns-version.sh
+++ b/scripts/workflows/update-acme-dns-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+################################################################################
+# Script: update-acme-dns-version.sh
+# Description: Update acme-dns version in deployment file
+# Used by: check-acme-dns-version.yml
+################################################################################
+
+set -euo pipefail
+
+current="$1"
+latest="$2"
+
+sed -i "s|joohoi/acme-dns:${current}|joohoi/acme-dns:${latest}|" \
+	yaml/acme-dns/deployment.yaml
+
+echo "Updated acme-dns from $current to $latest"

--- a/scripts/workflows/update-minio-version.sh
+++ b/scripts/workflows/update-minio-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+################################################################################
+# Script: update-minio-version.sh
+# Description: Update MinIO version in deployment file
+# Used by: check-minio-version.yml
+################################################################################
+
+set -euo pipefail
+
+current="$1"
+latest="$2"
+
+sed -i "s|quay.io/minio/minio:${current}|quay.io/minio/minio:${latest}|" \
+	yaml/ibu/minio/deployment.yaml
+
+echo "Updated MinIO from $current to $latest"

--- a/scripts/workflows/update-pebble-version.sh
+++ b/scripts/workflows/update-pebble-version.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+################################################################################
+# Script: update-pebble-version.sh
+# Description: Update Pebble version across deployment files
+# Used by: check-pebble-version.yml
+################################################################################
+
+set -euo pipefail
+
+current="$1"
+latest="$2"
+
+sed -i "s|ghcr.io/letsencrypt/pebble:${current}|ghcr.io/letsencrypt/pebble:${latest}|" \
+	yaml/pebble/deployment.yaml
+
+sed -i "s|ghcr.io/letsencrypt/pebble-challtestsrv:${current}|ghcr.io/letsencrypt/pebble-challtestsrv:${latest}|" \
+	yaml/pebble-challtestsrv/deployment.yaml
+
+echo "Updated Pebble from $current to $latest in both deployment files"

--- a/scripts/workflows/update-ubi9-python-version.sh
+++ b/scripts/workflows/update-ubi9-python-version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+################################################################################
+# Script: update-ubi9-python-version.sh
+# Description: Update UBI9 Python 3.9 version in deployment file
+# Used by: check-ubi9-python-version.yml
+################################################################################
+
+set -euo pipefail
+
+current="$1"
+latest="$2"
+
+sed -i "s|ubi9/python-39:${current}|ubi9/python-39:${latest}|" \
+	yaml/fake-dns-api/deployment.yaml
+
+echo "Updated UBI9 Python 3.9 from $current to $latest"

--- a/yaml/acme-dns/deployment.yaml
+++ b/yaml/acme-dns/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: acme-dns
-        image: joohoi/acme-dns:latest
+        image: joohoi/acme-dns:v2.0.2
         imagePullPolicy: IfNotPresent
         ports:
         - name: dns-udp

--- a/yaml/fake-dns-api/deployment.yaml
+++ b/yaml/fake-dns-api/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: fake-dns-api
       containers:
       - name: dns-api
-        image: registry.access.redhat.com/ubi9/python-39:latest
+        image: registry.access.redhat.com/ubi9/python-39:9.8
         imagePullPolicy: IfNotPresent
         command:
         - python3

--- a/yaml/ibu/minio/deployment.yaml
+++ b/yaml/ibu/minio/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: quay.io/minio/minio:latest
+          image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
           args:
             - server
             - /data

--- a/yaml/pebble-challtestsrv/deployment.yaml
+++ b/yaml/pebble-challtestsrv/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: challtestsrv
-        image: letsencrypt/pebble-challtestsrv:latest
+        image: ghcr.io/letsencrypt/pebble-challtestsrv:v2.10.1
         imagePullPolicy: IfNotPresent
         args:
         - -defaultIPv4

--- a/yaml/pebble/deployment.yaml
+++ b/yaml/pebble/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: pebble
-        image: ghcr.io/letsencrypt/pebble:latest
+        image: ghcr.io/letsencrypt/pebble:v2.10.1
         imagePullPolicy: IfNotPresent
         args:
         - -config


### PR DESCRIPTION
## Summary

- Pin all container images from `:latest` to specific versions for reproducibility:
  - Pebble → v2.10.1
  - Pebble challtestsrv → v2.10.1 (also migrated from Docker Hub to GHCR for consistency)
  - acme-dns → v2.0.2
  - UBI9 Python 3.9 → 9.8
  - MinIO → RELEASE.2025-09-07T16-13-09Z
- Add automated weekly version-check workflows for all pinned images:
  - **Tuesday**: Pebble (GitHub releases API)
  - **Wednesday**: acme-dns (GitHub releases API)
  - **Thursday**: MinIO (quay.io API — GitHub releases don't always match available registry tags)
  - **Friday**: UBI9 Python 3.9 (Red Hat Pyxis catalog API)

Each workflow follows the existing cert-manager operator check pattern (Monday) — detect new versions, update deployment YAML, and create a PR automatically.

**Note:** cert-manager v1.19.4 was removed from this PR — that version exists for the jetstack-cert-manager component image but not for the operator (which is still at v1.19.0 on registry.redhat.io). The existing `check-operator-version.yml` will auto-detect when a new operator version is published.

## Jira

[CNF-24256](https://redhat.atlassian.net/browse/CNF-24256)

## Reference

- [Pebble v2.10.1 Release](https://github.com/letsencrypt/pebble/releases/tag/v2.10.1)

## Test plan

- [ ] CI lint checks pass (shellcheck + shfmt)
- [ ] Integration tests pass (no operator version change, so existing v1.19.0 is used)
- [ ] After merge, trigger each new workflow via `workflow_dispatch` to validate