### PR TITLE
Fix operator version check failing on Red Hat catalog API

### DIFF
--- a/.github/workflows/check-operator-version.yml
+++ b/.github/workflows/check-operator-version.yml
@@ -1,6 +1,12 @@
 name: Check Operator Version
 
 on:
+  pull_request:
+    paths:
+      - 'scripts/workflows/query-operator-version.sh'
+      - 'scripts/workflows/compare-versions.sh'
+      - 'scripts/workflows/update-operator-version.sh'
+      - '.github/workflows/check-operator-version.yml'
   schedule:
     - cron: '23 8 * * 1'
   workflow_dispatch:
@@ -33,11 +39,11 @@ jobs:
         run: ./scripts/workflows/compare-versions.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
 
       - name: Update default version and nightly matrix
-        if: steps.compare.outputs.needs_update == 'true'
+        if: steps.compare.outputs.needs_update == 'true' && github.event_name != 'pull_request'
         run: ./scripts/workflows/update-operator-version.sh "${{ steps.current.outputs.version }}" "${{ steps.latest.outputs.version }}"
 
       - name: Create pull request
-        if: steps.compare.outputs.needs_update == 'true'
+        if: steps.compare.outputs.needs_update == 'true' && github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "Bump cert-manager operator to ${{ steps.latest.outputs.version }}"

--- a/scripts/workflows/query-operator-version.sh
+++ b/scripts/workflows/query-operator-version.sh
@@ -8,8 +8,8 @@
 
 set -euo pipefail
 
-tags=$(curl -s "https://catalog.redhat.io/api/containers/v1/repositories/registry/registry.redhat.io/repository/cert-manager/cert-manager-operator-rhel9/tags?page_size=100&page=0" |
-	jq -r '.data[].name // empty')
+tags=$(curl -s "https://catalog.redhat.com/api/containers/v1/images?filter=repositories.repository==cert-manager/cert-manager-operator-rhel9&page_size=50&sort_by=creation_date%5Bdesc%5D" |
+	jq -r '[.data[].repositories[0].tags[].name] | unique[]')
 
 if [ -z "$tags" ]; then
 	echo "Failed to fetch tags from Red Hat catalog API"


### PR DESCRIPTION
## Summary

- Red Hat retired `catalog.redhat.io`, causing the weekly version check to fail with curl exit code 6 (host resolution failure) since at least 2026-05-25
- Switched API calls to `catalog.redhat.com` using the `/images` endpoint with a repository filter (the old `/repositories/.../tags` path returns 404 on the new host)
- Added `pull_request` trigger (path-scoped to workflow and script files) so API breakage like this is caught before merging — update/PR-creation steps are gated to `schedule`/`workflow_dispatch` only

## Test plan

- [ ] CI passes on this PR (the version check workflow itself runs against these changed paths)
- [ ] Verify the query script outputs the correct latest version