### PR TITLE
Fix Pyxis API endpoints for version check workflows

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -80,6 +80,32 @@ jobs:
       - name: Verify key files exist
         run: ./scripts/workflows/verify-key-files.sh
 
+  version-query-check:
+    name: Verify Version Query Scripts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run all version query scripts
+        run: |
+          failed=0
+          for script in scripts/workflows/query-*-version.sh; do
+            name=$(basename "$script")
+            echo "--- $name ---"
+            if GITHUB_OUTPUT=/dev/null bash "$script"; then
+              echo "PASS: $name"
+            else
+              echo "FAIL: $name"
+              failed=$((failed + 1))
+            fi
+            echo ""
+          done
+          if [ "$failed" -gt 0 ]; then
+            echo "$failed version query script(s) failed"
+            exit 1
+          fi
+
   integration-test:
     name: Integration Test (OCP ${{ matrix.ocp-version }})
     needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure]

--- a/scripts/workflows/query-operator-version.sh
+++ b/scripts/workflows/query-operator-version.sh
@@ -8,7 +8,7 @@
 
 set -euo pipefail
 
-tags=$(curl -s "https://catalog.redhat.com/api/containers/v1/images?filter=repositories.repository==cert-manager/cert-manager-operator-rhel9&page_size=50&sort_by=creation_date%5Bdesc%5D" |
+tags=$(curl -sL "https://catalog.redhat.com/api/containers/v1/images?filter=repositories.repository==cert-manager/cert-manager-operator-rhel9" |
 	jq -r '[.data[].repositories[0].tags[].name] | unique[]')
 
 if [ -z "$tags" ]; then

--- a/scripts/workflows/query-ubi9-python-version.sh
+++ b/scripts/workflows/query-ubi9-python-version.sh
@@ -8,8 +8,8 @@
 
 set -euo pipefail
 
-tags=$(curl -sL "https://catalog.redhat.io/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/python-39/tags?page_size=100&page=0" |
-	jq -r '.data[].name // empty')
+tags=$(curl -sL "https://catalog.redhat.com/api/containers/v1/images?filter=repositories.repository==ubi9/python-39" |
+	jq -r '[.data[].repositories[0].tags[].name] | unique[]')
 
 if [ -z "$tags" ]; then
 	echo "Failed to fetch tags from Red Hat catalog API"


### PR DESCRIPTION
## Summary
- Fix `query-ubi9-python-version.sh`: domain `catalog.redhat.io` is dead (DNS fails with exit code 6), switched to `catalog.redhat.com` images endpoint
- Fix `query-operator-version.sh`: `page_size` and `sort_by` query params are no longer accepted by the Pyxis API, removed them

Both scripts now use `catalog.redhat.com/api/containers/v1/images?filter=repositories.repository==...` which returns data correctly.

## Test plan
- [x] Verified `query-ubi9-python-version.sh` returns `9.8` locally
- [x] Verified `query-operator-version.sh` returns `v1.19.0` locally
- [x] `make lint` passes