### PR TITLE
Fix bugs and reduce tech debt across scripts

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ Common issues and solutions for cert-manager-scripts.
 
 ## Quick Test Issues
 
-The `quick-test` runs a complete end-to-end workflow and may fail for several reasons.
+The `quick-http-test` (or `quick-dns-test`) runs a complete end-to-end workflow and may fail for several reasons.
 
 ### Common Issues
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -448,6 +448,25 @@ build_lca_annotations() {
 	echo "$annotation_value"
 }
 
+# Check IBU test prerequisites (cert-manager, OADP, MinIO)
+# Usage: require_ibu_prereqs
+require_ibu_prereqs() {
+	require_cmd oc jq envsubst
+	require_cert_manager
+
+	if ! oc get dataprotectionapplication velero -n openshift-adp &>/dev/null; then
+		log_error "OADP is not installed."
+		log_info "Run 'make install-ibu-prereqs' first."
+		exit 1
+	fi
+
+	if ! oc get deployment minio -n minio &>/dev/null; then
+		log_error "MinIO is not installed."
+		log_info "Run 'make install-minio' first."
+		exit 1
+	fi
+}
+
 # Capture TLS secret checksums for a namespace in a single API call
 # Usage: capture_secret_checksums <namespace> <output_file>
 capture_secret_checksums() {

--- a/scripts/check-cluster-network.sh
+++ b/scripts/check-cluster-network.sh
@@ -217,10 +217,7 @@ check_cert_manager_compatibility() {
 # Function to provide recommendations
 provide_recommendations() {
 	local cluster_networks="$1"
-	log_info "========================================"
-	log_info "  Recommendations"
-	log_info "========================================"
-	echo
+	print_header "Recommendations"
 
 	local has_ipv4=false
 	local has_ipv6=false

--- a/scripts/create-apiserver-certificate.sh
+++ b/scripts/create-apiserver-certificate.sh
@@ -154,11 +154,7 @@ wait_for_certificate() {
 }
 
 display_certificate_info() {
-	echo
-	log_info "========================================"
-	log_info "  Certificate Information"
-	log_info "========================================"
-	echo
+	print_header "Certificate Information"
 
 	# Check cluster connectivity first
 	if ! oc whoami &>/dev/null; then
@@ -183,10 +179,7 @@ display_certificate_info() {
 
 display_next_steps() {
 	echo
-	log_info "========================================"
-	log_info "  Next Steps"
-	log_info "========================================"
-	echo
+	print_header "Next Steps"
 
 	cat <<EOF
 The API server certificate has been created but NOT yet applied to the cluster.
@@ -202,8 +195,8 @@ To apply this certificate to the API server:
    3. Wait for the API server to roll out the changes
    4. Verify cluster access still works
 
-For detailed instructions, see the documentation or run:
-   ./scripts/apply-apiserver-certificate.sh
+To verify the certificate was created:
+   make verify-apiserver-cert
 
 To verify the certificate without applying:
    oc get certificate $CERT_NAME -n $CERT_NAMESPACE

--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -31,17 +31,14 @@ log_info "Creating DNS-01 ClusterIssuer..."
 envsubst <"$YAML_DIR/pebble-dns01-simple-clusterissuer.yaml" | oc apply -f -
 
 log_info "Waiting for ClusterIssuer to be ready..."
-sleep 5
+retry 3 5 oc wait --for=condition=Ready clusterissuer/"$ISSUER_NAME" --timeout=10s 2>/dev/null
 
 if oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
 	oc get clusterissuer "$ISSUER_NAME"
 	echo
 	log_info "DNS-01 ClusterIssuer created!"
 	echo
-	log_info "========================================"
-	log_info "  DNS-01 Validation Flow"
-	log_info "========================================"
-	echo
+	print_header "DNS-01 Validation Flow"
 	echo "When you create a wildcard certificate:"
 	echo
 	echo "✅ cert-manager requests a certificate from Pebble"

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -63,10 +63,7 @@ check_existing_issuer() {
 }
 
 display_configuration() {
-	log_info "========================================"
-	log_info "  ClusterIssuer Configuration"
-	log_info "========================================"
-	echo
+	print_header "ClusterIssuer Configuration"
 	echo "Issuer Name:      $ISSUER_NAME"
 	echo "ACME Server:      $ACME_SERVER_URL"
 	echo "Email:            $ACME_EMAIL"
@@ -124,11 +121,7 @@ verify_issuer() {
 
 # Function to display next steps
 display_next_steps() {
-	echo
-	log_info "========================================"
-	log_info "  ClusterIssuer Created!"
-	log_info "========================================"
-	echo
+	print_header "ClusterIssuer Created!"
 	log_info "HTTP-01 Validation Flow:"
 	echo
 	echo "When you create a certificate:"

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -112,11 +112,7 @@ create_test_certificates() {
 
 # Function to show HTTP-01 validation flow
 show_http01_flow() {
-	echo
-	log_info "========================================"
-	log_info "  HTTP-01 Validation Flow"
-	log_info "========================================"
-	echo
+	print_header "HTTP-01 Validation Flow"
 	echo "✅ cert-manager requests a certificate from Pebble"
 	echo "✅ Pebble responds with a challenge token"
 	echo "✅ cert-manager creates a temporary HTTP endpoint with the token"
@@ -182,11 +178,7 @@ wait_for_certificates() {
 
 # Function to display certificate status
 display_certificate_status() {
-	echo
-	log_info "========================================"
-	log_info "  Certificate Status"
-	log_info "========================================"
-	echo
+	print_header "Certificate Status"
 
 	log_info "Certificates:"
 	oc get certificate -n "$CERT_NAMESPACE" 2>/dev/null || echo "No certificates found"
@@ -206,11 +198,7 @@ display_certificate_status() {
 
 # Function to display next steps
 display_next_steps() {
-	echo
-	log_info "========================================"
-	log_info "  Next Steps"
-	log_info "========================================"
-	echo
+	print_header "Next Steps"
 	echo "1. Check certificate details:"
 	echo "   oc describe certificate test-cert-simple -n $CERT_NAMESPACE"
 	echo

--- a/scripts/ibu/label-cert-resources.sh
+++ b/scripts/ibu/label-cert-resources.sh
@@ -36,17 +36,15 @@ check_prerequisites() {
 label_certificates() {
 	log_info "Labeling Certificate CRs with lca.openshift.io/backup=$BACKUP_NAME..."
 
-	local cert_names
-	cert_names=$(oc get certificates -n "$TARGET_NAMESPACE" -o jsonpath='{.items[*].metadata.name}')
-
 	local labeled=0
-	for cert_name in $cert_names; do
+	while IFS= read -r cert_name; do
+		[[ -z "$cert_name" ]] && continue
 		log_info "  Labeling certificate: $cert_name"
 		oc label certificate "$cert_name" -n "$TARGET_NAMESPACE" \
 			"lca.openshift.io/backup=$BACKUP_NAME" \
 			--overwrite 2>/dev/null || true
 		labeled=$((labeled + 1))
-	done
+	done < <(oc get certificates -n "$TARGET_NAMESPACE" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
 	log_success "Labeled $labeled certificates"
 }
@@ -54,19 +52,16 @@ label_certificates() {
 label_secrets() {
 	log_info "Labeling TLS secrets with lca.openshift.io/backup=$BACKUP_NAME..."
 
-	# Get TLS secrets (type kubernetes.io/tls)
-	local secret_names
-	secret_names=$(oc get secrets -n "$TARGET_NAMESPACE" -o json 2>/dev/null |
-		jq -r '.items | map(select(.type == "kubernetes.io/tls")) | .[].metadata.name')
-
 	local labeled=0
-	for secret_name in $secret_names; do
+	while IFS= read -r secret_name; do
+		[[ -z "$secret_name" ]] && continue
 		log_info "  Labeling secret: $secret_name"
 		oc label secret "$secret_name" -n "$TARGET_NAMESPACE" \
 			"lca.openshift.io/backup=$BACKUP_NAME" \
 			--overwrite 2>/dev/null || true
 		labeled=$((labeled + 1))
-	done
+	done < <(oc get secrets -n "$TARGET_NAMESPACE" -o json 2>/dev/null |
+		jq -r '.items | map(select(.type == "kubernetes.io/tls")) | .[].metadata.name')
 
 	log_success "Labeled $labeled TLS secrets"
 }

--- a/scripts/ibu/run-ibu-preserved-test.sh
+++ b/scripts/ibu/run-ibu-preserved-test.sh
@@ -44,34 +44,8 @@ print_banner() {
 
 check_prerequisites() {
 	log_info "Checking prerequisites..."
+	require_ibu_prereqs
 
-	require_cmd oc jq envsubst
-
-	# Check cluster connectivity
-	require_cluster
-
-	# Check cert-manager is installed
-	if ! oc get deployment cert-manager -n cert-manager &>/dev/null; then
-		log_error "cert-manager is not installed."
-		log_info "Run 'make install-cert-manager-operator' first."
-		exit 1
-	fi
-
-	# Check OADP is installed
-	if ! oc get dataprotectionapplication velero -n openshift-adp &>/dev/null; then
-		log_error "OADP is not installed."
-		log_info "Run 'make install-ibu-prereqs' first."
-		exit 1
-	fi
-
-	# Check MinIO is running
-	if ! oc get deployment minio -n minio &>/dev/null; then
-		log_error "MinIO is not installed."
-		log_info "Run 'make install-minio' first."
-		exit 1
-	fi
-
-	# Check for test certificates
 	local cert_count
 	cert_count=$(oc get certificates -n "$TARGET_NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 	if [ "$cert_count" -eq 0 ]; then

--- a/scripts/ibu/run-ibu-test.sh
+++ b/scripts/ibu/run-ibu-test.sh
@@ -37,34 +37,8 @@ print_banner() {
 
 check_prerequisites() {
 	log_info "Checking prerequisites..."
+	require_ibu_prereqs
 
-	require_cmd oc jq envsubst
-
-	# Check cluster connectivity
-	require_cluster
-
-	# Check cert-manager is installed
-	if ! oc get deployment cert-manager -n cert-manager &>/dev/null; then
-		log_error "cert-manager is not installed."
-		log_info "Run 'make install-cert-manager-operator' first."
-		exit 1
-	fi
-
-	# Check OADP is installed
-	if ! oc get dataprotectionapplication velero -n openshift-adp &>/dev/null; then
-		log_error "OADP is not installed."
-		log_info "Run 'make install-ibu-prereqs' first."
-		exit 1
-	fi
-
-	# Check MinIO is running
-	if ! oc get deployment minio -n minio &>/dev/null; then
-		log_error "MinIO is not installed."
-		log_info "Run 'make install-minio' first."
-		exit 1
-	fi
-
-	# Check for test certificates
 	local cert_count
 	cert_count=$(oc get certificates -n "$TARGET_NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 	if [ "$cert_count" -eq 0 ]; then

--- a/scripts/ibu/validate-cert-loss.sh
+++ b/scripts/ibu/validate-cert-loss.sh
@@ -35,15 +35,11 @@ while [[ $# -gt 0 ]]; do
 done
 
 print_validation_header() {
-	echo
-	echo "========================================"
 	if [ "$EXPECT_PRESERVED" = true ]; then
-		echo "  IBU Certificate Preservation Validation"
+		print_header "IBU Certificate Preservation Validation"
 	else
-		echo "  IBU Certificate Loss Validation"
+		print_header "IBU Certificate Loss Validation"
 	fi
-	echo "========================================"
-	echo
 	if [ "$EXPECT_PRESERVED" = true ]; then
 		echo "  Mode: Expecting certificates to be PRESERVED"
 	else
@@ -83,10 +79,8 @@ compare_checksums() {
 	local results="[]"
 
 	# Compare each secret from before
-	local secret_names
-	secret_names=$(jq -r '.[].name' "$before_file")
-
-	for secret_name in $secret_names; do
+	while IFS= read -r secret_name; do
+		[[ -z "$secret_name" ]] && continue
 		total=$((total + 1))
 
 		# Get before checksum
@@ -122,7 +116,7 @@ compare_checksums() {
 		echo "    After:  ${after_cert_checksum:0:16}..." >&2
 		echo "    Status: $status" >&2
 		echo >&2
-	done
+	done < <(jq -r '.[].name' "$before_file")
 
 	# Save results
 	cat >"$results_file" <<EOF

--- a/scripts/install-cert-manager-operator.sh
+++ b/scripts/install-cert-manager-operator.sh
@@ -122,11 +122,7 @@ verify_installation() {
 
 # Function to display next steps
 display_next_steps() {
-	echo
-	log_info "========================================"
-	log_info "Installation completed successfully!"
-	log_info "========================================"
-	echo
+	print_header "Installation completed successfully!"
 	echo "Next steps:"
 	echo "1. Verify the operator is running:"
 	echo "   oc get pods -n $OPERATOR_NAMESPACE"

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -93,18 +93,14 @@ data:
 EOF
 
 		log_info "CoreDNS configured. Waiting for DNS pods to restart..."
-		sleep 10
+		oc rollout status daemonset/dns-default -n openshift-dns --timeout=60s 2>/dev/null || log_warn "DNS rollout may still be in progress"
 	fi
 }
 
 display_next_steps() {
 	local dns_server="fake-dns-api.${FAKEDNS_NAMESPACE}.svc.cluster.local:53"
 
-	echo
-	log_info "========================================"
-	log_info "  Fake DNS API Installation Complete!"
-	log_info "========================================"
-	echo
+	print_header "Fake DNS API Installation Complete!"
 	log_info "This fake DNS server accepts RFC2136 update requests and returns success"
 	log_info "without actually updating DNS. Perfect for air-gapped DNS-01 testing!"
 	echo

--- a/scripts/install-local-dns.sh
+++ b/scripts/install-local-dns.sh
@@ -43,11 +43,7 @@ display_next_steps() {
 	local acmedns_api="http://acme-dns.${ACMEDNS_NAMESPACE}.svc.cluster.local:8080"
 	local acmedns_dns="acme-dns.${ACMEDNS_NAMESPACE}.svc.cluster.local"
 
-	echo
-	log_info "========================================"
-	log_info "  acme-dns Installation Complete!"
-	log_info "========================================"
-	echo
+	print_header "acme-dns Installation Complete!"
 	echo "acme-dns is now running!"
 	echo
 	echo "Next steps:"

--- a/scripts/install-pebble.sh
+++ b/scripts/install-pebble.sh
@@ -57,11 +57,7 @@ verify_installation() {
 }
 
 display_configuration() {
-	echo
-	log_info "========================================"
-	log_info "  Pebble Configuration"
-	log_info "========================================"
-	echo
+	print_header "Pebble Configuration"
 	echo "Namespace:           $PEBBLE_NAMESPACE"
 	echo "DNS Server:          $DNS_SERVER"
 	echo "Always Valid:        $PEBBLE_ALWAYS_VALID"
@@ -81,11 +77,7 @@ display_next_steps() {
 	local route_host=$(oc get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 	local service_url="https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:14000/dir"
 
-	echo
-	log_info "========================================"
-	log_info "  Installation Complete!"
-	log_info "========================================"
-	echo
+	print_header "Installation Complete!"
 	echo "Pebble ACME server is now running!"
 	echo
 	echo "Next steps:"

--- a/scripts/troubleshooting/check-all.sh
+++ b/scripts/troubleshooting/check-all.sh
@@ -20,10 +20,7 @@ log_info "User: $(oc whoami)"
 echo
 
 # Section 1: cert-manager
-echo "========================================"
-echo "  cert-manager Components"
-echo "========================================"
-echo
+print_header "cert-manager Components"
 
 log_info "Checking cert-manager operator..."
 if oc get csv -n cert-manager-operator 2>/dev/null | grep -q "Succeeded"; then
@@ -42,10 +39,7 @@ fi
 echo
 
 # Section 2: Pebble
-echo "========================================"
-echo "  Pebble ACME Server"
-echo "========================================"
-echo
+print_header "Pebble ACME Server"
 
 if oc get namespace pebble &>/dev/null; then
 	log_info "Checking Pebble pods..."
@@ -66,10 +60,7 @@ fi
 echo
 
 # Section 3: DNS Components
-echo "========================================"
-echo "  DNS-01 Components"
-echo "========================================"
-echo
+print_header "DNS-01 Components"
 
 if oc get namespace fake-dns &>/dev/null; then
 	log_info "Checking fake DNS API..."
@@ -81,10 +72,7 @@ fi
 echo
 
 # Section 4: ClusterIssuers
-echo "========================================"
-echo "  ClusterIssuers"
-echo "========================================"
-echo
+print_header "ClusterIssuers"
 
 if oc get clusterissuer &>/dev/null; then
 	oc get clusterissuer
@@ -106,10 +94,7 @@ fi
 echo
 
 # Section 5: Certificates
-echo "========================================"
-echo "  Certificates"
-echo "========================================"
-echo
+print_header "Certificates"
 
 CERTS=$(oc get certificate -A -o json 2>/dev/null | jq -r '.items | length' || echo "0")
 
@@ -139,10 +124,7 @@ fi
 echo
 
 # Section 6: Active Challenges
-echo "========================================"
-echo "  Active Challenges"
-echo "========================================"
-echo
+print_header "Active Challenges"
 
 CHALLENGES=$(oc get challenge -A 2>/dev/null | grep -v "^NAMESPACE" | wc -l | xargs || echo "0")
 
@@ -157,10 +139,7 @@ fi
 echo
 
 # Section 7: Quick Health Summary
-echo "========================================"
-echo "  Health Summary"
-echo "========================================"
-echo
+print_header "Health Summary"
 
 ISSUES=0
 
@@ -190,10 +169,8 @@ else
 fi
 
 echo
-echo "========================================"
-echo "  Troubleshooting Tools"
-echo "========================================"
-echo
+print_header "Troubleshooting Tools"
+
 echo "Check specific certificate:"
 echo "  ./scripts/troubleshooting/check-certificate.sh <name> <namespace>"
 echo

--- a/scripts/troubleshooting/check-certificate.sh
+++ b/scripts/troubleshooting/check-certificate.sh
@@ -56,11 +56,7 @@ check_single_certificate() {
 		log_info "Certificate Details:"
 		oc describe certificate "$CERT_NAME" -n "$NAMESPACE"
 
-		echo
-		echo "========================================"
-		echo "  Checking Certificate Requests"
-		echo "========================================"
-		echo
+		print_header "Checking Certificate Requests"
 
 		# Find related CertificateRequests
 		CR_LIST=$(oc get certificaterequest -n "$NAMESPACE" -o json | jq -r ".items[] | select(.metadata.ownerReferences[]?.name==\"$CERT_NAME\") | .metadata.name" 2>/dev/null || echo "")
@@ -75,11 +71,7 @@ check_single_certificate() {
 			log_warn "No CertificateRequests found"
 		fi
 
-		echo
-		echo "========================================"
-		echo "  Checking ACME Orders"
-		echo "========================================"
-		echo
+		print_header "Checking ACME Orders"
 
 		# Check orders
 		if oc get order -n "$NAMESPACE" &>/dev/null; then
@@ -97,11 +89,7 @@ check_single_certificate() {
 			log_warn "No Orders found"
 		fi
 
-		echo
-		echo "========================================"
-		echo "  Checking ACME Challenges"
-		echo "========================================"
-		echo
+		print_header "Checking ACME Challenges"
 
 		# Check challenges
 		if oc get challenge -n "$NAMESPACE" &>/dev/null; then
@@ -120,11 +108,7 @@ check_single_certificate() {
 		fi
 	fi
 
-	echo
-	echo "========================================"
-	echo "  Troubleshooting Commands"
-	echo "========================================"
-	echo
+	print_header "Troubleshooting Commands"
 	echo "Check cert-manager logs:"
 	echo "  oc logs -n cert-manager deployment/cert-manager --tail=50"
 	echo

--- a/scripts/troubleshooting/check-issuer.sh
+++ b/scripts/troubleshooting/check-issuer.sh
@@ -63,11 +63,7 @@ check_single_issuer() {
 	log_info "Detailed Configuration:"
 	oc describe clusterissuer "$ISSUER_NAME"
 
-	echo
-	echo "========================================"
-	echo "  Testing ACME Server Connectivity"
-	echo "========================================"
-	echo
+	print_header "Testing ACME Server Connectivity"
 
 	# Test Pebble connectivity if using Pebble
 	if [[ "$ACME_SERVER" == *"pebble"* ]]; then
@@ -96,11 +92,7 @@ check_single_issuer() {
 		log_info "Not using Pebble, skipping connectivity test"
 	fi
 
-	echo
-	echo "========================================"
-	echo "  Troubleshooting Commands"
-	echo "========================================"
-	echo
+	print_header "Troubleshooting Commands"
 	echo "View full YAML configuration:"
 	echo "  oc get clusterissuer $ISSUER_NAME -o yaml"
 	echo

--- a/scripts/troubleshooting/check-network-stack.sh
+++ b/scripts/troubleshooting/check-network-stack.sh
@@ -174,11 +174,7 @@ main() {
 	# Detect stack type
 	local stack_type=$(detect_cluster_network)
 
-	echo
-	echo "========================================"
-	echo "  Network Stack Summary"
-	echo "========================================"
-	echo
+	print_header "Network Stack Summary"
 
 	case "$stack_type" in
 	"dual-stack")
@@ -206,11 +202,7 @@ main() {
 		;;
 	esac
 
-	echo
-	echo "========================================"
-	echo "  Detailed Network Information"
-	echo "========================================"
-	echo
+	print_header "Detailed Network Information"
 
 	check_node_addresses
 	echo
@@ -218,11 +210,7 @@ main() {
 	echo
 	check_webhook_connectivity
 
-	echo
-	echo "========================================"
-	echo "  Recommendations"
-	echo "========================================"
-	echo
+	print_header "Recommendations"
 
 	if [ "$stack_type" = "ipv6" ] || [ "$stack_type" = "dual-stack" ]; then
 		log_info "IPv6 Considerations for cert-manager:"

--- a/scripts/troubleshooting/check-workload-partitioning.sh
+++ b/scripts/troubleshooting/check-workload-partitioning.sh
@@ -119,11 +119,7 @@ check_deployment_configs() {
 provide_recommendations() {
 	local has_issues=$1
 
-	echo
-	echo "========================================"
-	echo "  Summary"
-	echo "========================================"
-	echo
+	print_header "Summary"
 
 	if [ $has_issues -eq 0 ]; then
 		log_info "✅ All checks passed!"

--- a/scripts/troubleshooting/diagnose-dns01.sh
+++ b/scripts/troubleshooting/diagnose-dns01.sh
@@ -144,32 +144,16 @@ else
 	log_warn "RFC2136 credentials secret not found in cert-manager namespace"
 fi
 
-echo
-echo "========================================"
-echo "  Recent cert-manager Logs"
-echo "========================================"
-echo
+print_header "Recent cert-manager Logs"
 oc logs -n cert-manager deployment/cert-manager --tail=20 2>/dev/null || log_warn "Could not fetch logs"
 
-echo
-echo "========================================"
-echo "  Recent Pebble Logs"
-echo "========================================"
-echo
+print_header "Recent Pebble Logs"
 oc logs -n pebble -l app=pebble --tail=20 2>/dev/null || log_warn "Could not fetch Pebble logs"
 
-echo
-echo "========================================"
-echo "  Recent Fake DNS API Logs"
-echo "========================================"
-echo
+print_header "Recent Fake DNS API Logs"
 oc logs -n fake-dns -l app=fake-dns-api --tail=20 2>/dev/null || log_warn "Could not fetch fake DNS API logs"
 
-echo
-echo "========================================"
-echo "  Recommendations"
-echo "========================================"
-echo
+print_header "Recommendations"
 echo "1. For air-gapped DNS-01 testing, ensure Pebble has ALWAYS_VALID=1:"
 echo "   PEBBLE_ALWAYS_VALID=1 make test-dns01"
 echo

--- a/scripts/troubleshooting/diagnose-http01.sh
+++ b/scripts/troubleshooting/diagnose-http01.sh
@@ -115,25 +115,13 @@ else
 	log_warn "Network check failed or script not found"
 fi
 
-echo
-echo "========================================"
-echo "  Recent cert-manager Logs"
-echo "========================================"
-echo
+print_header "Recent cert-manager Logs"
 oc logs -n cert-manager deployment/cert-manager --tail=20 2>/dev/null || log_warn "Could not fetch logs"
 
-echo
-echo "========================================"
-echo "  Recent Pebble Logs"
-echo "========================================"
-echo
+print_header "Recent Pebble Logs"
 oc logs -n pebble -l app=pebble --tail=20 2>/dev/null || log_warn "Could not fetch Pebble logs"
 
-echo
-echo "========================================"
-echo "  Recommendations"
-echo "========================================"
-echo
+print_header "Recommendations"
 echo "1. Ensure Pebble is configured with PEBBLE_ALWAYS_VALID=1 for testing:"
 echo "   PEBBLE_ALWAYS_VALID=1 make install-pebble"
 echo

--- a/scripts/troubleshooting/verify-apiserver-certificate.sh
+++ b/scripts/troubleshooting/verify-apiserver-certificate.sh
@@ -227,11 +227,7 @@ check_apiserver_configuration() {
 provide_recommendations() {
 	local total_issues=$1
 
-	echo
-	echo "========================================"
-	echo "  Summary"
-	echo "========================================"
-	echo
+	print_header "Summary"
 
 	if [ $total_issues -eq 0 ]; then
 		log_info "✅ All checks passed!"

--- a/scripts/workflows/display-component-status.sh
+++ b/scripts/workflows/display-component-status.sh
@@ -12,11 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
-echo
-echo "========================================"
-echo "  Component Status"
-echo "========================================"
-echo
+print_header "Component Status"
 
 # Check if cluster is accessible
 if ! oc whoami &>/dev/null; then
@@ -58,7 +54,4 @@ echo ""
 echo "Recent cert-manager logs:"
 oc logs -n cert-manager deployment/cert-manager --tail=30 || log_warn "Cannot retrieve cert-manager logs"
 echo
-echo "========================================"
-echo "  Status Display Complete"
-echo "========================================"
-echo
+print_header "Status Display Complete"

--- a/scripts/workflows/recover-cluster.sh
+++ b/scripts/workflows/recover-cluster.sh
@@ -12,11 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
-echo
-echo "========================================"
-echo "  CRC Cluster Recovery Attempt"
-echo "========================================"
-echo
+print_header "CRC Cluster Recovery Attempt"
 
 # Test 1: Check if DNS resolution is working
 log_info "Checking DNS resolution..."
@@ -85,10 +81,6 @@ if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
 	exit 1
 fi
 
-echo
-echo "========================================"
-echo "  ✅ Cluster Recovery Successful"
-echo "========================================"
-echo
+print_header "Cluster Recovery Successful"
 log_info "Cluster appears to be functional again"
 echo

--- a/scripts/workflows/verify-cluster-access.sh
+++ b/scripts/workflows/verify-cluster-access.sh
@@ -12,11 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
-echo
-echo "========================================"
-echo "  CRC Cluster Health Check"
-echo "========================================"
-echo
+print_header "CRC Cluster Health Check"
 
 # Test 1: Check oc command is available
 log_info "Checking oc CLI availability..."
@@ -135,9 +131,6 @@ else
 fi
 echo
 
-echo "========================================"
-echo "  ✅ Cluster Health Check Passed"
-echo "========================================"
-echo
+print_header "Cluster Health Check Passed"
 log_info "Cluster is ready for testing"
 echo


### PR DESCRIPTION
## Summary

- Fix 3 bugs: broken script reference, wrong Makefile target in docs, unsafe loop variables in IBU scripts
- Reduce tech debt: replace 30+ inline banners with `print_header()`, extract duplicate IBU prereq checks into shared function, replace hardcoded sleeps with proper waits
- Net result: 26 files changed, -207 lines

## Bugs Fixed

- **Broken reference**: `create-apiserver-certificate.sh` referenced non-existent `apply-apiserver-certificate.sh` — replaced with `make verify-apiserver-cert`
- **Wrong target name**: `docs/troubleshooting.md` said `quick-test` instead of `quick-http-test`
- **Unsafe loops**: IBU scripts used unquoted `for var in $list` — converted to `while IFS= read -r` with process substitution

## Tech Debt

- **Inline banners → `print_header()`**: Replaced `echo "========"` / `log_info "========"` patterns across 22 files with the shared `print_header()` function from `lib/common.sh`
- **`require_ibu_prereqs()`**: Extracted identical cert-manager/OADP/MinIO prerequisite checks from `run-ibu-test.sh` and `run-ibu-preserved-test.sh` into a shared function in `lib/common.sh`
- **Hardcoded sleeps**: Replaced `sleep 5` in `create-dns01-issuer.sh` with `retry` + `oc wait`, replaced `sleep 10` in `install-fake-dns.sh` with `oc rollout status`

## Test plan

- [x] `make lint` passes (shfmt + shellcheck)
- [ ] CI integration tests pass on OCP 4.20/4.21 matrix