### PR TITLE
Add multi-algorithm certificate testing for IBU key type validation

### DIFF
--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -79,6 +79,14 @@ jobs:
         env:
           CERT_MANAGER_VERSION: ${{ inputs.cert-manager-version }}
 
+      - name: Run multi-algorithm certificate test
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 2
+          retry_on: error
+          command: make quick-multi-algo-test
+
       - name: Verify workload partitioning configuration
         uses: nick-fields/retry@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,9 @@ make preflight     # Check all tool dependencies and cluster prerequisites
 
 ### Quick End-to-End Tests
 ```bash
-make quick-http-test   # Install operator + Pebble (ALWAYS_VALID=1) + HTTP-01 cert
-make quick-dns-test    # Install fake DNS + Pebble + DNS-01 wildcard cert
+make quick-http-test       # Install operator + Pebble (ALWAYS_VALID=1) + HTTP-01 cert
+make quick-dns-test        # Install fake DNS + Pebble + DNS-01 wildcard cert
+make quick-multi-algo-test # Install operator + create ECDSA/RSA/Ed25519 certs + verify PEM formats
 ```
 
 ### Step-by-Step Workflow
@@ -47,12 +48,16 @@ make test-ibu-certs        # Scenario 1: certificate loss (default IBU)
 make test-ibu-preserved    # Scenario 2: certificate preservation (LCA labels)
 make test-ibu-both         # Run both scenarios
 make quick-ibu-test        # End-to-end IBU test
+make create-multi-algo-certs  # Create certs with all key algorithms (ECDSA, RSA, Ed25519)
+make verify-key-formats       # Verify PEM key formats of TLS secrets
+make test-ibu-multi-algo      # IBU cert loss test with all key algorithms
 ```
 
 ### Cleanup
 ```bash
 make clean         # Remove certs, issuers, Pebble, fake DNS (keeps operator)
 make clean-ibu     # Remove IBU resources (MinIO, OADP, backups)
+make clean-multi-algo-certs            # Remove multi-algorithm test certs
 make uninstall-cert-manager-operator   # Remove operator (interactive confirm)
 ```
 
@@ -95,6 +100,7 @@ Organized by component: `cert-manager-operator/`, `pebble/`, `fake-dns-api/`, `i
 | `PEBBLE_NAMESPACE` | `pebble` | Pebble server namespace |
 | `LOG_LEVEL` | `info` | `quiet\|error\|warn\|info\|debug` — controls common.sh logging |
 | `DRY_RUN` | `false` | Enable dry-run mode |
+| `MULTI_ALGO` | `false` | Use multi-algorithm certs (ECDSA, RSA, Ed25519) in IBU tests |
 
 ### lib/common.sh API
 
@@ -130,7 +136,8 @@ Key functions:
 - **OLM**: `wait_for_csv <namespace> <grep_pattern> <max_attempts>` — waits for CSV to reach Succeeded phase
 - **OADP**: `wait_for_backup_restore <type> <name> <namespace> <max_attempts>` — waits for backup/restore completion
 - **IBU**: `build_lca_annotations <namespace>` — builds lca.openshift.io/apply-label annotation value
-- **IBU**: `capture_secret_checksums <namespace> <output_file>` — captures TLS secret checksums in a single API call
+- **IBU**: `capture_secret_checksums <namespace> <output_file>` — captures TLS secret checksums and PEM types in a single API call
+- **IBU**: `get_key_pem_type <base64_key_data>` — returns PEM header type (`EC PRIVATE KEY`, `RSA PRIVATE KEY`, `PRIVATE KEY`, or `UNKNOWN`)
 
 ## IBU Certificate Validation
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ BG_BLUE := \033[44m
         clean-dns-config clean-issuers clean-selfsigned clean-monitoring clean-temp \
         uninstall-cert-manager-operator \
         install-minio install-oadp install-ibu-prereqs capture-cert-state \
-        test-ibu-certs test-ibu-preserved test-ibu-both quick-ibu-test clean-ibu
+        test-ibu-certs test-ibu-preserved test-ibu-both quick-ibu-test clean-ibu \
+        create-multi-algo-certs verify-key-formats test-ibu-multi-algo clean-multi-algo-certs \
+        quick-multi-algo-test
 
 # Default target
 all: help
@@ -286,6 +288,16 @@ quick-dns-test: test-dns01 test-cert ## Quick end-to-end DNS-01 test
 	@echo ""
 	@echo "Quick DNS-01 test complete! Run 'make clean' to clean up."
 
+quick-multi-algo-test: install-cert-manager-operator create-multi-algo-certs ## Quick multi-algorithm certificate test (ECDSA, RSA, Ed25519)
+	@echo ""
+	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
+	@echo "  ╔═════════════════════════════════════════════════════════════╗"
+	@echo "  ║    Multi-Algorithm Certificate Test Complete!               ║"
+	@echo "  ╚═════════════════════════════════════════════════════════════╝"
+	@echo "$(RESET)"
+	@echo ""
+	@echo "Run 'make clean-multi-algo-certs' to clean up."
+
 # ────────────────────────────────────────────────────────────────────────────────
 # Troubleshooting
 # ────────────────────────────────────────────────────────────────────────────────
@@ -371,6 +383,25 @@ quick-ibu-test: install-cert-manager-operator install-ibu-prereqs ## End-to-end 
 	@echo ""
 	@echo "$(BOLD)$(BLUE)Running IBU certificate loss test...$(RESET)"
 	@./scripts/ibu/run-ibu-test.sh
+
+create-multi-algo-certs: ## Create test certs with all key algorithms (ECDSA, RSA, Ed25519)
+	@echo "$(BOLD)$(BLUE)Creating multi-algorithm test certificates...$(RESET)"
+	@./scripts/ibu/create-multi-algo-certs.sh
+	@echo ""
+
+verify-key-formats: ## Verify PEM key formats of TLS secrets in namespace
+	@./scripts/ibu/verify-key-formats.sh
+
+test-ibu-multi-algo: ## Run IBU cert loss test with all key algorithms
+	@echo "$(BOLD)$(BLUE)Running multi-algorithm IBU certificate loss test...$(RESET)"
+	@MULTI_ALGO=true ./scripts/ibu/run-ibu-test.sh
+	@echo ""
+
+clean-multi-algo-certs: ## Clean up multi-algorithm test certificates
+	@echo "$(BOLD)$(YELLOW)Cleaning up multi-algorithm test certificates...$(RESET)"
+	@oc delete certificate -n default -l app=ibu-multi-algo-test --ignore-not-found=true 2>/dev/null || true
+	@oc delete secret -n default ibu-cert-ecdsa-p256-tls ibu-cert-ecdsa-p384-tls ibu-cert-rsa-2048-tls ibu-cert-rsa-4096-tls ibu-cert-ed25519-tls --ignore-not-found=true 2>/dev/null || true
+	@echo "$(GREEN)Multi-algorithm test certificates cleaned.$(RESET)"
 
 clean-ibu: ## Clean up IBU test resources (MinIO, OADP, backups)
 	@echo "$(BOLD)$(YELLOW)Cleaning up IBU test resources...$(RESET)"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -467,6 +467,24 @@ require_ibu_prereqs() {
 	fi
 }
 
+# Extract PEM type from base64-encoded key data
+# Usage: get_key_pem_type <base64_key_data>
+# Returns: "EC PRIVATE KEY", "RSA PRIVATE KEY", "PRIVATE KEY", or "UNKNOWN"
+get_key_pem_type() {
+	local b64_data="$1"
+	[[ -z "$b64_data" ]] && echo "UNKNOWN" && return
+
+	local header
+	header=$(echo "$b64_data" | base64 -d 2>/dev/null | head -1 || echo "")
+
+	case "$header" in
+	*"EC PRIVATE KEY"*) echo "EC PRIVATE KEY" ;;
+	*"RSA PRIVATE KEY"*) echo "RSA PRIVATE KEY" ;;
+	*"PRIVATE KEY"*) echo "PRIVATE KEY" ;;
+	*) echo "UNKNOWN" ;;
+	esac
+}
+
 # Capture TLS secret checksums for a namespace in a single API call
 # Usage: capture_secret_checksums <namespace> <output_file>
 capture_secret_checksums() {
@@ -493,14 +511,17 @@ capture_secret_checksums() {
 		fi
 
 		local key_checksum=""
+		local pem_type="UNKNOWN"
 		if [[ -n "$key_data" ]]; then
 			key_checksum=$(echo "$key_data" | shasum -a 256 | cut -d' ' -f1)
+			pem_type=$(get_key_pem_type "$key_data")
 		fi
 
 		jq --arg name "$name" \
 			--arg cert_checksum "$cert_checksum" \
 			--arg key_checksum "$key_checksum" \
-			'. += [{name: $name, cert_checksum: $cert_checksum, key_checksum: $key_checksum}]' \
+			--arg pem_type "$pem_type" \
+			'. += [{name: $name, cert_checksum: $cert_checksum, key_checksum: $key_checksum, pem_type: $pem_type}]' \
 			"$checksums_file" >"$checksums_file.tmp" && mv "$checksums_file.tmp" "$checksums_file"
 	done <<<"$secret_entries"
 }

--- a/scripts/ibu/create-multi-algo-certs.sh
+++ b/scripts/ibu/create-multi-algo-certs.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+
+################################################################################
+# Script: create-multi-algo-certs.sh
+# Description: Create test certificates with different key algorithms to validate
+#              IBU behavior across ECDSA, RSA, and Ed25519 key types.
+################################################################################
+
+set -euo pipefail
+
+# Get script directory and source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Configuration
+export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
+ISSUER_NAME="${ISSUER_NAME:-selfsigned-issuer}"
+CERT_LABEL="ibu-multi-algo-test"
+
+# Algorithm definitions: name:algorithm:size:expected_pem_type
+ALGO_SPECS=(
+	"ecdsa-p256:ECDSA:256:EC PRIVATE KEY"
+	"ecdsa-p384:ECDSA:384:EC PRIVATE KEY"
+	"rsa-2048:RSA:2048:RSA PRIVATE KEY"
+	"rsa-4096:RSA:4096:RSA PRIVATE KEY"
+	"ed25519:Ed25519::PRIVATE KEY"
+)
+
+check_prerequisites() {
+	log_info "Checking prerequisites..."
+	require_cmd oc jq
+	require_cluster
+	require_cert_manager
+	log_success "Prerequisites met."
+}
+
+ensure_selfsigned_issuer() {
+	if oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
+		log_info "ClusterIssuer '$ISSUER_NAME' already exists."
+		return 0
+	fi
+
+	log_info "Creating selfsigned ClusterIssuer..."
+	cat <<EOF | oc apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: $ISSUER_NAME
+spec:
+  selfSigned: {}
+EOF
+}
+
+create_algo_certificate() {
+	local name_suffix="$1"
+	local algorithm="$2"
+	local size="$3"
+
+	local cert_name="ibu-cert-${name_suffix}"
+	local secret_name="${cert_name}-tls"
+
+	if oc get certificate "$cert_name" -n "$TARGET_NAMESPACE" &>/dev/null; then
+		log_warn "Certificate '$cert_name' already exists, skipping."
+		return 0
+	fi
+
+	log_info "Creating certificate: $cert_name (algorithm=$algorithm${size:+, size=$size})..."
+
+	local private_key_block=""
+	if [[ -n "$size" ]]; then
+		private_key_block="  privateKey:
+    algorithm: $algorithm
+    size: $size"
+	else
+		private_key_block="  privateKey:
+    algorithm: $algorithm"
+	fi
+
+	cat <<EOF | oc apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: $cert_name
+  namespace: $TARGET_NAMESPACE
+  labels:
+    app: $CERT_LABEL
+spec:
+  secretName: $secret_name
+  issuerRef:
+    name: $ISSUER_NAME
+    kind: ClusterIssuer
+  dnsNames:
+    - "${name_suffix}.ibu-test.example.com"
+  duration: 8760h
+$private_key_block
+EOF
+}
+
+create_all_certificates() {
+	log_info "Creating multi-algorithm test certificates in namespace '$TARGET_NAMESPACE'..."
+	echo
+
+	for spec in "${ALGO_SPECS[@]}"; do
+		IFS=':' read -r name_suffix algorithm size _ <<<"$spec"
+		create_algo_certificate "$name_suffix" "$algorithm" "$size"
+	done
+
+	echo
+	log_info "All certificate resources created."
+}
+
+wait_for_certificates() {
+	log_info "Waiting for certificates to become ready..."
+
+	local max_attempts=60
+	local attempt=0
+
+	while [ $attempt -lt $max_attempts ]; do
+		local not_ready
+		not_ready=$(oc get certificates -n "$TARGET_NAMESPACE" -l app="$CERT_LABEL" -o json 2>/dev/null |
+			jq '[.items[] | select((.status.conditions // [] | map(select(.type=="Ready" and .status=="True")) | length) == 0)] | length')
+
+		if [ "$not_ready" -eq 0 ]; then
+			log_success "All certificates are ready!"
+			return 0
+		fi
+
+		attempt=$((attempt + 1))
+		if [ $((attempt % 5)) -eq 0 ]; then
+			log_info "Still waiting... ($not_ready not ready, ${attempt}/${max_attempts})"
+		fi
+		sleep 2
+	done
+
+	log_error "Timeout waiting for certificates to become ready."
+	log_info "Check status: oc get certificates -n $TARGET_NAMESPACE -l app=$CERT_LABEL"
+	exit 1
+}
+
+verify_key_formats() {
+	print_header "Key Format Verification"
+
+	local pass_count=0
+	local fail_count=0
+
+	local secrets_json
+	secrets_json=$(oc get secrets -n "$TARGET_NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+
+	printf "  %-22s %-18s %-18s %s\n" "CERTIFICATE" "EXPECTED" "ACTUAL" "STATUS"
+	printf "  %-22s %-18s %-18s %s\n" "───────────" "────────" "──────" "──────"
+
+	for spec in "${ALGO_SPECS[@]}"; do
+		IFS=':' read -r name_suffix _ _ expected <<<"$spec"
+		local cert_name="ibu-cert-${name_suffix}"
+		local secret_name="${cert_name}-tls"
+
+		local key_b64
+		key_b64=$(echo "$secrets_json" | jq -r --arg name "$secret_name" \
+			'.items[] | select(.metadata.name == $name) | .data["tls.key"] // ""')
+
+		local actual
+		actual=$(get_key_pem_type "$key_b64")
+
+		local status
+		if [ "$actual" = "$expected" ]; then
+			status="PASS"
+			pass_count=$((pass_count + 1))
+		else
+			status="FAIL"
+			fail_count=$((fail_count + 1))
+		fi
+
+		printf "  %-22s %-18s %-18s %s\n" "$cert_name" "$expected" "$actual" "$status"
+	done
+
+	echo
+	if [ "$fail_count" -eq 0 ]; then
+		log_success "All ${pass_count} key formats match expected PEM types."
+	else
+		log_error "${fail_count} key format(s) did not match expected PEM type."
+		exit 1
+	fi
+}
+
+print_algo_summary() {
+	echo
+	echo "  Certificates created for IBU multi-algorithm testing:"
+	echo
+	printf "  %-22s %-10s %-6s %s\n" "NAME" "ALGORITHM" "SIZE" "EXPECTED PEM TYPE"
+	printf "  %-22s %-10s %-6s %s\n" "────" "─────────" "────" "─────────────────"
+
+	for spec in "${ALGO_SPECS[@]}"; do
+		IFS=':' read -r name_suffix algorithm size expected <<<"$spec"
+		printf "  %-22s %-10s %-6s %s\n" \
+			"ibu-cert-${name_suffix}" "$algorithm" "${size:-n/a}" "$expected"
+	done
+	echo
+}
+
+main() {
+	print_header "Multi-Algorithm Certificate Creation"
+	check_prerequisites
+	ensure_selfsigned_issuer
+	create_all_certificates
+	wait_for_certificates
+	verify_key_formats
+	print_algo_summary
+
+	log_success "Multi-algorithm certificates ready for IBU testing."
+	echo
+	echo "  Next steps:"
+	echo "    make verify-key-formats    # Re-verify key formats"
+	echo "    make test-ibu-multi-algo   # Run IBU test with all algorithms"
+	echo "    make clean-multi-algo-certs # Clean up"
+	echo
+}
+
+main "$@"

--- a/scripts/ibu/run-ibu-preserved-test.sh
+++ b/scripts/ibu/run-ibu-preserved-test.sh
@@ -26,6 +26,7 @@ export STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"
 export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 export BACKUP_NAME="${BACKUP_NAME:-ibu-preserved-$(date +%s)}"
 export RESTORE_NAME="${RESTORE_NAME:-${BACKUP_NAME}-restore}"
+MULTI_ALGO="${MULTI_ALGO:-false}"
 
 print_banner() {
 	echo
@@ -50,8 +51,13 @@ check_prerequisites() {
 	cert_count=$(oc get certificates -n "$TARGET_NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 	if [ "$cert_count" -eq 0 ]; then
 		log_warn "No certificates found in namespace $TARGET_NAMESPACE"
-		log_info "Creating test certificate..."
-		create_test_certificate
+		if [ "$MULTI_ALGO" = "true" ]; then
+			log_info "Creating multi-algorithm test certificates..."
+			"$SCRIPT_DIR/create-multi-algo-certs.sh"
+		else
+			log_info "Creating test certificate..."
+			create_test_certificate
+		fi
 	fi
 
 	log_success "All prerequisites met!"

--- a/scripts/ibu/run-ibu-test.sh
+++ b/scripts/ibu/run-ibu-test.sh
@@ -20,6 +20,7 @@ source "$SCRIPT_DIR/../../lib/common.sh"
 # Configuration
 export STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"
 export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
+MULTI_ALGO="${MULTI_ALGO:-false}"
 
 print_banner() {
 	echo
@@ -43,8 +44,13 @@ check_prerequisites() {
 	cert_count=$(oc get certificates -n "$TARGET_NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ')
 	if [ "$cert_count" -eq 0 ]; then
 		log_warn "No certificates found in namespace $TARGET_NAMESPACE"
-		log_info "Creating test certificate using existing setup..."
-		create_test_certificate
+		if [ "$MULTI_ALGO" = "true" ]; then
+			log_info "Creating multi-algorithm test certificates..."
+			"$SCRIPT_DIR/create-multi-algo-certs.sh"
+		else
+			log_info "Creating test certificate using existing setup..."
+			create_test_certificate
+		fi
 	fi
 
 	log_success "All prerequisites met!"

--- a/scripts/ibu/validate-cert-loss.sh
+++ b/scripts/ibu/validate-cert-loss.sh
@@ -278,6 +278,69 @@ main() {
 	IFS=',' read -r changed unchanged missing total <<<"$results"
 
 	print_report "$changed" "$unchanged" "$missing" "$total"
+	local report_result=$?
+
+	compare_key_formats
+
+	return $report_result
+}
+
+compare_key_formats() {
+	local before_file="$STATE_DIR/checksums-before.json"
+	local after_file="$STATE_DIR/checksums-after.json"
+
+	if [ ! -f "$before_file" ] || [ ! -f "$after_file" ]; then
+		return 0
+	fi
+
+	local has_pem_type
+	has_pem_type=$(jq -r '.[0].pem_type // empty' "$before_file" 2>/dev/null || echo "")
+	if [ -z "$has_pem_type" ]; then
+		return 0
+	fi
+
+	echo
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	echo "  Key PEM Format Comparison"
+	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+	echo
+
+	local format_changed=0
+	local format_unchanged=0
+
+	printf "  %-35s %-20s %-20s %s\n" "SECRET" "BEFORE" "AFTER" "STATUS"
+	printf "  %-35s %-20s %-20s %s\n" "──────" "──────" "─────" "──────"
+
+	while IFS= read -r secret_name; do
+		[[ -z "$secret_name" ]] && continue
+
+		local before_type
+		before_type=$(jq -r --arg name "$secret_name" \
+			'.[] | select(.name == $name) | .pem_type // "MISSING"' "$before_file")
+
+		local after_type
+		after_type=$(jq -r --arg name "$secret_name" \
+			'.[] | select(.name == $name) | .pem_type // "MISSING"' "$after_file")
+
+		local status
+		if [ "$before_type" = "$after_type" ]; then
+			status="UNCHANGED"
+			format_unchanged=$((format_unchanged + 1))
+		else
+			status="CHANGED"
+			format_changed=$((format_changed + 1))
+		fi
+
+		printf "  %-35s %-20s %-20s %s\n" "$secret_name" "$before_type" "$after_type" "$status"
+	done < <(jq -r '.[].name' "$before_file")
+
+	echo
+	if [ "$format_changed" -gt 0 ]; then
+		log_info "Key format changes detected: $format_changed changed, $format_unchanged unchanged"
+		log_info "Format changes may indicate LCA PKCS#8 normalization occurred."
+	else
+		log_info "No key format changes detected ($format_unchanged secrets)."
+	fi
 }
 
 main

--- a/scripts/ibu/verify-key-formats.sh
+++ b/scripts/ibu/verify-key-formats.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+################################################################################
+# Script: verify-key-formats.sh
+# Description: Verify PEM key formats of all TLS secrets in a namespace.
+#              Reports the PEM header type for each secret's tls.key field.
+################################################################################
+
+set -euo pipefail
+
+# Get script directory and source common library
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+# Configuration
+TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
+
+check_prerequisites() {
+	log_info "Checking prerequisites..."
+	require_cmd oc jq
+	require_cluster
+	log_success "Prerequisites met."
+}
+
+verify_all_key_formats() {
+	print_header "TLS Secret Key Formats - Namespace: $TARGET_NAMESPACE"
+
+	local tmp_file
+	tmp_file=$(mktemp)
+	trap 'rm -f "$tmp_file"' RETURN
+
+	capture_secret_checksums "$TARGET_NAMESPACE" "$tmp_file"
+
+	local count
+	count=$(jq 'length' "$tmp_file")
+
+	if [ "$count" -eq 0 ]; then
+		log_warn "No TLS secrets found in namespace '$TARGET_NAMESPACE'."
+		return 0
+	fi
+
+	printf "  %-40s %s\n" "SECRET NAME" "PEM TYPE"
+	printf "  %-40s %s\n" "───────────" "────────"
+
+	local sec1_count=0
+	local pkcs1_count=0
+	local pkcs8_count=0
+	local unknown_count=0
+
+	while IFS=$'\t' read -r name pem_type; do
+		printf "  %-40s %s\n" "$name" "$pem_type"
+
+		case "$pem_type" in
+		"EC PRIVATE KEY") sec1_count=$((sec1_count + 1)) ;;
+		"RSA PRIVATE KEY") pkcs1_count=$((pkcs1_count + 1)) ;;
+		"PRIVATE KEY") pkcs8_count=$((pkcs8_count + 1)) ;;
+		*) unknown_count=$((unknown_count + 1)) ;;
+		esac
+	done < <(jq -r '.[] | [.name, .pem_type] | @tsv' "$tmp_file")
+
+	echo
+	print_summary \
+		"Total TLS Secrets" "$count" \
+		"EC PRIVATE KEY (SEC1)" "$sec1_count" \
+		"RSA PRIVATE KEY (PKCS#1)" "$pkcs1_count" \
+		"PRIVATE KEY (PKCS#8)" "$pkcs8_count" \
+		"UNKNOWN" "$unknown_count"
+}
+
+main() {
+	check_prerequisites
+	verify_all_key_formats
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds support for creating and verifying certificates with different key algorithms (ECDSA P-256/P-384, RSA 2048/4096, Ed25519) to validate IBU behavior across all key types
- Motivated by [openshift-kni/lifecycle-agent#7610](https://github.com/openshift-kni/lifecycle-agent/pull/7610) which adds PKCS#8 normalization for cert-manager private keys during IBU — we need test coverage for all the key formats that normalization handles
- Adds CI integration test step so every PR validates multi-algorithm cert creation

## Key changes

**New scripts:**
- `scripts/ibu/create-multi-algo-certs.sh` — creates 5 certs (ECDSA P-256, P-384, RSA 2048, 4096, Ed25519) via selfsigned issuer, verifies PEM formats
- `scripts/ibu/verify-key-formats.sh` — standalone PEM format inspection for all TLS secrets in a namespace

**Library (`lib/common.sh`):**
- `get_key_pem_type()` — extracts PEM header type from base64 key data
- `capture_secret_checksums()` — now includes `pem_type` field in output JSON

**IBU integration:**
- `MULTI_ALGO` env var support in `run-ibu-test.sh` and `run-ibu-preserved-test.sh`
- Key format comparison section in `validate-cert-loss.sh`

**CI:**
- `make quick-multi-algo-test` — new quick test target (selfsigned issuer, no Pebble needed)
- New step in `reusable-integration-test.yml` runs the multi-algo test on every PR

## Cert-manager key type compatibility (from LCA PR)

| Key Algorithm | cert-manager PEM Header | Recert Compatible | LCA Fix |
|---|---|---|---|
| ECDSA (P-256/P-384) | `BEGIN EC PRIVATE KEY` (SEC1) | No | Converted to PKCS#8 |
| RSA (2048/4096) | `BEGIN RSA PRIVATE KEY` (PKCS#1) | No | Converted to PKCS#8 |
| Ed25519 | `BEGIN PRIVATE KEY` (PKCS#8) | No (unsupported by recert) | Skipped with warning |

## Test plan

- [x] `make lint` passes (shellcheck + shfmt)
- [ ] CI integration test creates all 5 cert types and verifies PEM formats
- [ ] Existing quick-http-test and API server cert tests still pass