### PR TITLE
Replace unquoted for-in loops with while-read to prevent word-splitting

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -423,9 +423,10 @@ build_lca_annotations() {
 
 	local cert_names
 	cert_names=$(oc get certificates -n "$namespace" \
-		-o jsonpath='{.items[*].metadata.name}')
+		-o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
-	for cert_name in $cert_names; do
+	while IFS= read -r cert_name; do
+		[[ -z "$cert_name" ]] && continue
 		annotation_parts+=("cert-manager.io/v1/certificates/$namespace/$cert_name")
 
 		local secret_name
@@ -437,7 +438,7 @@ build_lca_annotations() {
 				annotation_parts+=("v1/secrets/$namespace/$secret_name")
 			fi
 		fi
-	done
+	done <<<"$cert_names"
 
 	local annotation_value
 	annotation_value=$(

--- a/scripts/check-cluster-network.sh
+++ b/scripts/check-cluster-network.sh
@@ -59,32 +59,36 @@ check_ip_families() {
 	fi
 
 	# Check cluster network CIDRs
-	local cluster_cidrs=$(echo "$cluster_networks" | jq -r '.spec.clusterNetwork[]?.cidr' 2>/dev/null | tr '\n' ' ')
-	local service_cidrs=$(echo "$cluster_networks" | jq -r '.spec.serviceNetwork[]?' 2>/dev/null | tr '\n' ' ')
+	local cluster_cidrs
+	cluster_cidrs=$(echo "$cluster_networks" | jq -r '.spec.clusterNetwork[]?.cidr' 2>/dev/null)
+	local service_cidrs
+	service_cidrs=$(echo "$cluster_networks" | jq -r '.spec.serviceNetwork[]?' 2>/dev/null)
 
 	echo "  Cluster Networks:"
 	local has_ipv4=false
 	local has_ipv6=false
 
-	for cidr in $cluster_cidrs; do
+	while IFS= read -r cidr; do
+		[[ -z "$cidr" ]] && continue
 		echo "    - $cidr"
 		if [[ "$cidr" =~ : ]]; then
 			has_ipv6=true
 		else
 			has_ipv4=true
 		fi
-	done
+	done <<<"$cluster_cidrs"
 
 	echo
 	echo "  Service Networks:"
-	for cidr in $service_cidrs; do
+	while IFS= read -r cidr; do
+		[[ -z "$cidr" ]] && continue
 		echo "    - $cidr"
 		if [[ "$cidr" =~ : ]]; then
 			has_ipv6=true
 		else
 			has_ipv4=true
 		fi
-	done
+	done <<<"$service_cidrs"
 	echo
 
 	# Determine network stack
@@ -171,16 +175,18 @@ check_node_addresses() {
 
 	for i in $(seq 0 $((display_count - 1))); do
 		local node_name=$(echo "$nodes" | jq -r ".items[$i].metadata.name")
-		local internal_ips=$(echo "$nodes" | jq -r ".items[$i].status.addresses[] | select(.type==\"InternalIP\") | .address" | tr '\n' ' ')
+		local internal_ips
+		internal_ips=$(echo "$nodes" | jq -r ".items[$i].status.addresses[] | select(.type==\"InternalIP\") | .address")
 
 		echo "  Node: $node_name"
-		for ip in $internal_ips; do
+		while IFS= read -r ip; do
+			[[ -z "$ip" ]] && continue
 			if [[ "$ip" =~ : ]]; then
 				echo "    - $ip (IPv6)"
 			else
 				echo "    - $ip (IPv4)"
 			fi
-		done
+		done <<<"$internal_ips"
 	done
 
 	if [ "$node_count" -gt 3 ]; then
@@ -224,13 +230,14 @@ provide_recommendations() {
 
 	local cluster_cidrs
 	cluster_cidrs=$(echo "$cluster_networks" | jq -r '.spec.clusterNetwork[]?.cidr' 2>/dev/null)
-	for cidr in $cluster_cidrs; do
+	while IFS= read -r cidr; do
+		[[ -z "$cidr" ]] && continue
 		if [[ "$cidr" =~ : ]]; then
 			has_ipv6=true
 		else
 			has_ipv4=true
 		fi
-	done
+	done <<<"$cluster_cidrs"
 
 	if [ "$has_ipv4" = true ] && [ "$has_ipv6" = true ]; then
 		echo "Your cluster supports DUAL-STACK networking:"

--- a/scripts/troubleshooting/check-all.sh
+++ b/scripts/troubleshooting/check-all.sh
@@ -110,9 +110,10 @@ if [ "$CERTS" -gt 0 ]; then
 	if [ -n "$FAILED" ]; then
 		echo
 		log_warn "Failed certificates:"
-		for cert in $FAILED; do
+		while IFS= read -r cert; do
+			[[ -z "$cert" ]] && continue
 			echo "  ❌ $cert"
-		done
+		done <<<"$FAILED"
 		echo
 		echo "Run detailed check with:"
 		echo "  ./scripts/troubleshooting/check-certificate.sh <name> <namespace>"

--- a/scripts/troubleshooting/check-certificate.sh
+++ b/scripts/troubleshooting/check-certificate.sh
@@ -62,11 +62,12 @@ check_single_certificate() {
 		CR_LIST=$(oc get certificaterequest -n "$NAMESPACE" -o json | jq -r ".items[] | select(.metadata.ownerReferences[]?.name==\"$CERT_NAME\") | .metadata.name" 2>/dev/null || echo "")
 
 		if [ -n "$CR_LIST" ]; then
-			for cr in $CR_LIST; do
+			while IFS= read -r cr; do
+				[[ -z "$cr" ]] && continue
 				log_info "CertificateRequest: $cr"
 				oc describe certificaterequest "$cr" -n "$NAMESPACE"
 				echo
-			done
+			done <<<"$CR_LIST"
 		else
 			log_warn "No CertificateRequests found"
 		fi
@@ -77,11 +78,12 @@ check_single_certificate() {
 		if oc get order -n "$NAMESPACE" &>/dev/null; then
 			ORDERS=$(oc get order -n "$NAMESPACE" -o name 2>/dev/null || echo "")
 			if [ -n "$ORDERS" ]; then
-				for order in $ORDERS; do
-					log_info "Order: $(basename $order)"
+				while IFS= read -r order; do
+					[[ -z "$order" ]] && continue
+					log_info "Order: $(basename "$order")"
 					oc describe "$order" -n "$NAMESPACE"
 					echo
-				done
+				done <<<"$ORDERS"
 			else
 				log_warn "No Orders found"
 			fi
@@ -95,11 +97,12 @@ check_single_certificate() {
 		if oc get challenge -n "$NAMESPACE" &>/dev/null; then
 			CHALLENGES=$(oc get challenge -n "$NAMESPACE" -o name 2>/dev/null || echo "")
 			if [ -n "$CHALLENGES" ]; then
-				for challenge in $CHALLENGES; do
-					log_info "Challenge: $(basename $challenge)"
+				while IFS= read -r challenge; do
+					[[ -z "$challenge" ]] && continue
+					log_info "Challenge: $(basename "$challenge")"
 					oc describe "$challenge" -n "$NAMESPACE"
 					echo
-				done
+				done <<<"$CHALLENGES"
 			else
 				log_warn "No Challenges found"
 			fi

--- a/scripts/troubleshooting/diagnose-dns01.sh
+++ b/scripts/troubleshooting/diagnose-dns01.sh
@@ -85,14 +85,15 @@ log_info "Checking DNS-01 ClusterIssuers..."
 DNS01_ISSUERS=$(oc get clusterissuer -o json | jq -r '.items[] | select(.spec.acme.solvers[]?.dns01 != null) | .metadata.name' 2>/dev/null || echo "")
 
 if [ -n "$DNS01_ISSUERS" ]; then
-	for issuer in $DNS01_ISSUERS; do
+	while IFS= read -r issuer; do
+		[[ -z "$issuer" ]] && continue
 		READY=$(oc get clusterissuer "$issuer" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 		if [ "$READY" = "True" ]; then
 			echo "✅ $issuer is ready"
 		else
 			log_warn "$issuer is not ready (Status: $READY)"
 		fi
-	done
+	done <<<"$DNS01_ISSUERS"
 else
 	log_warn "No DNS-01 ClusterIssuers found"
 fi
@@ -107,7 +108,8 @@ if [ -n "$CHALLENGES" ]; then
 	echo "Found DNS-01 challenges:"
 	echo
 
-	for challenge in $CHALLENGES; do
+	while IFS= read -r challenge; do
+		[[ -z "$challenge" ]] && continue
 		NAMESPACE=$(echo "$challenge" | cut -d'/' -f1)
 		NAME=$(echo "$challenge" | cut -d'/' -f2)
 
@@ -129,7 +131,7 @@ if [ -n "$CHALLENGES" ]; then
 		fi
 
 		echo
-	done
+	done <<<"$CHALLENGES"
 else
 	log_info "No active DNS-01 challenges found"
 fi

--- a/scripts/troubleshooting/diagnose-http01.sh
+++ b/scripts/troubleshooting/diagnose-http01.sh
@@ -53,14 +53,15 @@ log_info "Checking HTTP-01 ClusterIssuers..."
 HTTP01_ISSUERS=$(oc get clusterissuer -o json | jq -r '.items[] | select(.spec.acme.solvers[]?.http01 != null) | .metadata.name' 2>/dev/null || echo "")
 
 if [ -n "$HTTP01_ISSUERS" ]; then
-	for issuer in $HTTP01_ISSUERS; do
+	while IFS= read -r issuer; do
+		[[ -z "$issuer" ]] && continue
 		READY=$(oc get clusterissuer "$issuer" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 		if [ "$READY" = "True" ]; then
 			echo "✅ $issuer is ready"
 		else
 			log_warn "$issuer is not ready (Status: $READY)"
 		fi
-	done
+	done <<<"$HTTP01_ISSUERS"
 else
 	log_warn "No HTTP-01 ClusterIssuers found"
 fi
@@ -75,7 +76,8 @@ if [ -n "$CHALLENGES" ]; then
 	echo "Found HTTP-01 challenges:"
 	echo
 
-	for challenge in $CHALLENGES; do
+	while IFS= read -r challenge; do
+		[[ -z "$challenge" ]] && continue
 		NAMESPACE=$(echo "$challenge" | cut -d'/' -f1)
 		NAME=$(echo "$challenge" | cut -d'/' -f2)
 
@@ -100,7 +102,7 @@ if [ -n "$CHALLENGES" ]; then
 		fi
 
 		echo
-	done
+	done <<<"$CHALLENGES"
 else
 	log_info "No active HTTP-01 challenges found"
 fi

--- a/scripts/workflows/verify-script-references.sh
+++ b/scripts/workflows/verify-script-references.sh
@@ -13,12 +13,13 @@ echo "Checking make target references in documentation..."
 MAKEFILE_TARGETS=$(grep -oE '^[a-z][a-z0-9_-]*:' Makefile | sed 's/://')
 DOC_REFS=$(grep -roh 'make [a-z][a-z0-9_-]*' docs/ guide/ README.md 2>/dev/null | sed 's/make //' | sort -u)
 
-for ref in $DOC_REFS; do
+while IFS= read -r ref; do
+	[[ -z "$ref" ]] && continue
 	if ! echo "$MAKEFILE_TARGETS" | grep -qx "$ref"; then
 		echo "❌ docs reference non-existent target: make $ref"
 		FAILURES=$((FAILURES + 1))
 	fi
-done
+done <<<"$DOC_REFS"
 if [ "$FAILURES" -eq 0 ]; then
 	echo "✅ All make target references in docs are valid"
 fi


### PR DESCRIPTION
## Summary
- Convert all `for x in $var` loops to `while IFS= read -r x` with herestring input
- The unquoted expansion is unsafe if values contain spaces or glob characters
- Also removes unnecessary `tr '\n' ' '` conversions since while-read handles newline-separated input natively
- Also quotes `$(basename $order)` arguments that were missing quotes

## Test plan
- [ ] `make lint` passes
- [ ] Verify troubleshooting scripts still iterate correctly with multi-line oc output

Fixes #49