### PR TITLE
Add confirm() helper and SKIP_CONFIRM for non-interactive mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ Organized by component: `cert-manager-operator/`, `pebble/`, `fake-dns-api/`, `i
 | `PEBBLE_NAMESPACE` | `pebble` | Pebble server namespace |
 | `LOG_LEVEL` | `info` | `quiet\|error\|warn\|info\|debug` — controls common.sh logging |
 | `DRY_RUN` | `false` | Enable dry-run mode |
+| `SKIP_CONFIRM` | `0` | Set to `1` to skip interactive confirmation prompts (CI/automation) |
 | `MULTI_ALGO` | `false` | Use multi-algorithm certs (ECDSA, RSA, Ed25519) in IBU tests |
 
 ### lib/common.sh API

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -230,6 +230,22 @@ print_summary() {
 }
 
 # ============================================================================
+# INTERACTIVE PROMPTS
+# ============================================================================
+# Prompt for confirmation, auto-accept when SKIP_CONFIRM=1 or non-interactive
+# Usage: confirm "Continue anyway?" || exit 0
+confirm() {
+	local prompt="${1:-Continue?}"
+	if [[ "${SKIP_CONFIRM:-0}" == "1" ]] || [[ ! -t 0 ]]; then
+		log_debug "Auto-confirmed: $prompt (SKIP_CONFIRM=$SKIP_CONFIRM)"
+		return 0
+	fi
+	read -p "$prompt (y/N): " -n 1 -r
+	echo
+	[[ $REPLY =~ ^[Yy]$ ]]
+}
+
+# ============================================================================
 # UTILITY FUNCTIONS
 # ============================================================================
 # Check if running with cluster-admin privileges

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -25,9 +25,7 @@ check_pebble() {
 		log_info "This issuer will point to: $ACME_SERVER_URL"
 		log_warn "If using Pebble, install it first: make install-pebble"
 		echo
-		read -p "Continue anyway? (y/N): " -n 1 -r
-		echo
-		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+		if ! confirm "Continue anyway?"; then
 			log_info "Cancelled."
 			exit 0
 		fi
@@ -53,9 +51,7 @@ check_existing_issuer() {
 		log_debug "Current ACME server: $current_server"
 
 		echo
-		read -p "Overwrite existing issuer? (y/N): " -n 1 -r
-		echo
-		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+		if ! confirm "Overwrite existing issuer?"; then
 			log_info "Keeping existing issuer."
 			exit 0
 		fi

--- a/scripts/create-selfsigned-issuer.sh
+++ b/scripts/create-selfsigned-issuer.sh
@@ -49,9 +49,7 @@ check_existing_issuer() {
 
 	if [ "$exists" = true ]; then
 		echo
-		read -p "Overwrite existing resources? (y/N): " -n 1 -r
-		echo
-		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+		if ! confirm "Overwrite existing resources?"; then
 			log_info "Keeping existing resources."
 			exit 0
 		fi

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -41,9 +41,7 @@ check_prerequisites() {
 	# Check if namespace exists
 	if ! oc get namespace "$CERT_NAMESPACE" &>/dev/null; then
 		log_warn "Namespace '$CERT_NAMESPACE' does not exist."
-		read -p "Create namespace '$CERT_NAMESPACE'? (y/N): " -n 1 -r
-		echo
-		if [[ $REPLY =~ ^[Yy]$ ]]; then
+		if confirm "Create namespace '$CERT_NAMESPACE'?"; then
 			oc create namespace "$CERT_NAMESPACE"
 			log_info "Namespace '$CERT_NAMESPACE' created."
 		else

--- a/scripts/install-monitoring.sh
+++ b/scripts/install-monitoring.sh
@@ -42,9 +42,7 @@ check_user_workload_monitoring() {
 		echo "      enableUserWorkload: true"
 		echo "  EOF"
 		echo
-		read -p "Continue anyway? (y/N): " -n 1 -r
-		echo
-		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+		if ! confirm "Continue anyway?"; then
 			log_info "Cancelled."
 			exit 0
 		fi
@@ -68,9 +66,7 @@ check_existing_resources() {
 
 	if [ "$exists" = true ]; then
 		echo
-		read -p "Overwrite existing resources? (y/N): " -n 1 -r
-		echo
-		if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+		if ! confirm "Overwrite existing resources?"; then
 			log_info "Keeping existing resources."
 			exit 0
 		fi


### PR DESCRIPTION
## Summary
- Add `confirm()` function to `lib/common.sh` that auto-accepts when `SKIP_CONFIRM=1` or stdin is not a terminal
- Replace all `read -p` confirmation prompts across 4 scripts with this shared function
- Prevents scripts from hanging in CI/automation pipelines
- Document `SKIP_CONFIRM` in CLAUDE.md environment variables table

## Test plan
- [ ] `make lint` passes
- [ ] `SKIP_CONFIRM=1 ./scripts/create-issuer.sh` runs without prompting
- [ ] Interactive mode still prompts when `SKIP_CONFIRM` is unset and stdin is a terminal

Fixes #48