### PR TITLE
Fix check-all.sh to return non-zero exit code when issues found

### DIFF
--- a/scripts/troubleshooting/check-all.sh
+++ b/scripts/troubleshooting/check-all.sh
@@ -183,3 +183,7 @@ echo
 echo "Diagnose DNS-01 issues:"
 echo "  ./scripts/troubleshooting/diagnose-dns01.sh"
 echo
+
+if [ "$ISSUES" -gt 0 ]; then
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Exit 1 when `$ISSUES > 0` instead of always exiting 0
- Allows CI pipelines to gate on `make troubleshoot` results

## Test plan
- [ ] `make lint` passes
- [ ] Script exits 0 on a healthy cluster
- [ ] Script exits 1 when cert-manager components are missing

Fixes #52