### PR TITLE
Extract duplicate IBU test certificate function into shared library

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -415,6 +415,67 @@ wait_for_backup_restore() {
 	return 1
 }
 
+# Create a selfsigned test certificate for IBU validation
+# Usage: create_ibu_test_certificate <namespace>
+create_ibu_test_certificate() {
+	local namespace="$1"
+	local issuer="selfsigned-issuer"
+
+	if ! oc get clusterissuer "$issuer" &>/dev/null; then
+		log_info "Creating selfsigned ClusterIssuer..."
+		cat <<-EOF | oc apply -f -
+			apiVersion: cert-manager.io/v1
+			kind: ClusterIssuer
+			metadata:
+			  name: selfsigned-issuer
+			spec:
+			  selfSigned: {}
+		EOF
+	fi
+
+	log_info "Using ClusterIssuer: $issuer"
+
+	cat <<-EOF | oc apply -f -
+		apiVersion: cert-manager.io/v1
+		kind: Certificate
+		metadata:
+		  name: ibu-test-cert
+		  namespace: $namespace
+		  labels:
+		    app: ibu-test
+		spec:
+		  secretName: ibu-test-cert-tls
+		  issuerRef:
+		    name: $issuer
+		    kind: ClusterIssuer
+		  dnsNames:
+		    - ibu-test.example.com
+		    - "*.ibu-test.example.com"
+		  duration: 8760h
+	EOF
+
+	log_info "Waiting for certificate to be issued..."
+	local max_attempts=30
+	local attempt=0
+
+	while [ $attempt -lt $max_attempts ]; do
+		local ready
+		ready=$(oc get certificate ibu-test-cert -n "$namespace" \
+			-o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+
+		if [ "$ready" = "True" ]; then
+			log_success "Test certificate is ready!"
+			return 0
+		fi
+
+		attempt=$((attempt + 1))
+		sleep 2
+	done
+
+	log_error "Timeout waiting for test certificate"
+	return 1
+}
+
 # Build lca.openshift.io/apply-label annotation value for cert resources
 # Usage: build_lca_annotations <namespace>
 build_lca_annotations() {

--- a/scripts/ibu/run-ibu-preserved-test.sh
+++ b/scripts/ibu/run-ibu-preserved-test.sh
@@ -65,62 +65,7 @@ check_prerequisites() {
 
 create_test_certificate() {
 	log_info "Creating test certificate for IBU preservation validation..."
-
-	local issuer="selfsigned-issuer"
-
-	# Create selfsigned issuer if it doesn't exist
-	if ! oc get clusterissuer "$issuer" &>/dev/null; then
-		log_info "Creating selfsigned ClusterIssuer..."
-		cat <<EOF | oc apply -f -
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: selfsigned-issuer
-spec:
-  selfSigned: {}
-EOF
-	fi
-
-	# Create a test certificate with preservation label
-	cat <<EOF | oc apply -f -
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: ibu-test-cert
-  namespace: $TARGET_NAMESPACE
-  labels:
-    app: ibu-test
-spec:
-  secretName: ibu-test-cert-tls
-  issuerRef:
-    name: $issuer
-    kind: ClusterIssuer
-  dnsNames:
-    - ibu-test.example.com
-    - "*.ibu-test.example.com"
-  duration: 8760h
-EOF
-
-	# Wait for certificate to be ready
-	log_info "Waiting for certificate to be issued..."
-	local max_attempts=30
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local ready
-		ready=$(oc get certificate ibu-test-cert -n "$TARGET_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
-
-		if [ "$ready" = "True" ]; then
-			log_success "Test certificate is ready!"
-			return 0
-		fi
-
-		attempt=$((attempt + 1))
-		sleep 2
-	done
-
-	log_error "Timeout waiting for test certificate"
-	exit 1
+	create_ibu_test_certificate "$TARGET_NAMESPACE"
 }
 
 label_resources_for_preservation() {

--- a/scripts/ibu/run-ibu-test.sh
+++ b/scripts/ibu/run-ibu-test.sh
@@ -58,66 +58,7 @@ check_prerequisites() {
 
 create_test_certificate() {
 	log_info "Creating test certificate for IBU validation..."
-
-	# Prefer selfsigned-issuer for IBU testing (quick, no external dependencies)
-	local issuer="selfsigned-issuer"
-
-	# Create selfsigned issuer if it doesn't exist
-	if ! oc get clusterissuer "$issuer" &>/dev/null; then
-		log_info "Creating selfsigned ClusterIssuer..."
-		cat <<EOF | oc apply -f -
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: selfsigned-issuer
-spec:
-  selfSigned: {}
-EOF
-	fi
-
-	log_info "Using ClusterIssuer: $issuer"
-
-	# Create a simple test certificate
-	cat <<EOF | oc apply -f -
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: ibu-test-cert
-  namespace: $TARGET_NAMESPACE
-  labels:
-    app: ibu-test
-spec:
-  secretName: ibu-test-cert-tls
-  issuerRef:
-    name: $issuer
-    kind: ClusterIssuer
-  dnsNames:
-    - ibu-test.example.com
-    - "*.ibu-test.example.com"
-  duration: 8760h
-EOF
-
-	# Wait for certificate to be ready
-	log_info "Waiting for certificate to be issued..."
-	local max_attempts=30
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local ready
-		ready=$(oc get certificate ibu-test-cert -n "$TARGET_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
-
-		if [ "$ready" = "True" ]; then
-			log_success "Test certificate is ready!"
-			return 0
-		fi
-
-		attempt=$((attempt + 1))
-		sleep 2
-	done
-
-	log_error "Timeout waiting for test certificate"
-	log_info "Check certificate status: oc describe certificate ibu-test-cert -n $TARGET_NAMESPACE"
-	exit 1
+	create_ibu_test_certificate "$TARGET_NAMESPACE"
 }
 
 capture_before_state() {


### PR DESCRIPTION
## Summary
- Extract `create_test_certificate()` from both `run-ibu-test.sh` and `run-ibu-preserved-test.sh` into `lib/common.sh` as `create_ibu_test_certificate()`
- Both scripts now call the shared function, eliminating ~120 lines of duplicated code
- Prevents future drift between the two implementations

## Test plan
- [ ] `make lint` passes
- [ ] `make test-ibu-certs` still works (creates test cert via shared function)
- [ ] `make test-ibu-preserved` still works

Fixes #54