### PR TITLE
Add cert-manager v1.20.0 to CI test matrices

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
           cm_input="${{ github.event.inputs.cert-manager-version }}"
           ocp_input="${{ github.event.inputs.ocp-version }}"
           cm_versions=${cm_input:+"[\"${cm_input}\"]"}
-          cm_versions=${cm_versions:-'["v1.18.1", "v1.19.0"]'}
+          cm_versions=${cm_versions:-'["v1.18.1", "v1.19.0", "v1.20.0"]'}
           ocp_versions=${ocp_input:+"[\"${ocp_input}\"]"}
           ocp_versions=${ocp_versions:-'["4.20", "4.21"]'}
           echo "matrix={\"cert-manager-version\":${cm_versions},\"ocp-version\":${ocp_versions}}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -110,7 +110,7 @@ jobs:
           fi
 
   integration-test:
-    name: Integration Test (OCP ${{ matrix.ocp-version }})
+    name: Integration Test (OCP ${{ matrix.ocp-version }} / CM ${{ matrix.cert-manager-version }})
     needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure]
     if: |
       github.actor != 'dependabot[bot]' &&
@@ -122,10 +122,11 @@ jobs:
       fail-fast: false
       matrix:
         ocp-version: ['4.20', '4.21']
+        cert-manager-version: ['v1.19.0', 'v1.20.0']
     uses: ./.github/workflows/reusable-integration-test.yml
     with:
       ocp-version: ${{ matrix.ocp-version }}
-      cert-manager-version: v1.19.0
+      cert-manager-version: ${{ matrix.cert-manager-version }}
       checkout-ref: ${{ github.sha }}
     secrets:
       CRC_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}


### PR DESCRIPTION
## Summary
- Add v1.20.0 to nightly matrix: now tests v1.18.1, v1.19.0, and v1.20.0
- Update PR integration test to gate on v1.20.0 (latest)

## Test plan
- [ ] CI triggers and runs with v1.20.0

Fixes #65