### PR TITLE
Add jq to documented prerequisites and require_cmd checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For DNS-01 with air-gapped fake DNS, use `make quick-dns-test` instead.
 
 - OpenShift cluster (4.20+)
 - `oc` CLI with cluster-admin privileges
+- `jq`: `brew install jq` (macOS) or `dnf install jq` (RHEL/Fedora)
 - `envsubst`: `brew install gettext` (macOS) or `dnf install gettext` (RHEL/Fedora)
 
 ## Development

--- a/scripts/troubleshooting/check-all.sh
+++ b/scripts/troubleshooting/check-all.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR/../../lib/common.sh"
 
 print_header "Complete System Diagnostics"
 
-require_cmd oc
+require_cmd oc jq
 require_cluster
 
 log_info "Cluster: $(oc whoami --show-server)"

--- a/scripts/troubleshooting/check-certificate.sh
+++ b/scripts/troubleshooting/check-certificate.sh
@@ -123,6 +123,8 @@ check_single_certificate() {
 	echo
 }
 
+require_cmd oc jq
+
 # Main logic
 if [ $# -eq 0 ]; then
 	# No arguments - check all certificates

--- a/scripts/troubleshooting/check-issuer.sh
+++ b/scripts/troubleshooting/check-issuer.sh
@@ -104,6 +104,8 @@ check_single_issuer() {
 	echo
 }
 
+require_cmd oc jq
+
 # Main logic
 if [ $# -eq 0 ]; then
 	# No arguments - check all ClusterIssuers

--- a/scripts/troubleshooting/diagnose-dns01.sh
+++ b/scripts/troubleshooting/diagnose-dns01.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
+require_cmd oc jq
+
 print_header "DNS-01 Challenge Diagnostics"
 
 # Check cert-manager

--- a/scripts/troubleshooting/diagnose-http01.sh
+++ b/scripts/troubleshooting/diagnose-http01.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
+require_cmd oc jq
+
 print_header "HTTP-01 Challenge Diagnostics"
 
 # Check cert-manager

--- a/scripts/troubleshooting/verify-apiserver-certificate.sh
+++ b/scripts/troubleshooting/verify-apiserver-certificate.sh
@@ -23,7 +23,7 @@ CERT_NAME="apiserver-cert"
 SECRET_NAME="apiserver-cert-tls"
 
 check_prerequisites() {
-	require_cmd oc
+	require_cmd oc jq
 
 	# Try multiple times to connect - cluster may be temporarily unstable
 	local max_attempts=3


### PR DESCRIPTION
## Summary

- Add `require_cmd jq` to 6 troubleshooting scripts that use `jq` without validating it is installed
- Add `jq` to README prerequisites section

Scripts updated:
- `check-all.sh` — added `jq` to existing `require_cmd oc`
- `check-certificate.sh` — added `require_cmd oc jq`
- `check-issuer.sh` — added `require_cmd oc jq`
- `diagnose-dns01.sh` — added `require_cmd oc jq`
- `diagnose-http01.sh` — added `require_cmd oc jq`
- `verify-apiserver-certificate.sh` — added `jq` to existing `require_cmd oc`

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify scripts fail gracefully when `jq` is not installed

Fixes #47