### PR TITLE
Remove consoleless-fix artifacts and ignore binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 test-output/
 *.log
 
+# Screenshots and binary artifacts
+*.png
+


### PR DESCRIPTION
## Summary

- Delete 6 untracked development artifacts from the cert-manager-operator consoleless fix work (PR #455) that were cluttering the repo root
- Add `*.png` to `.gitignore` to prevent screenshots and binary artifacts from being accidentally committed

Files removed (untracked, never committed):
- `DEPLOYMENT-SUMMARY.md`
- `FINAL-SUMMARY.md`
- `QE-TESTING-INSTRUCTIONS.md`
- `custom-catalog.yaml`
- `verify-consoleless.sh`
- `gist-check.png`

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify no other files reference removed artifacts

Fixes #72