### PR TITLE
Use apply_yaml_template consistently instead of inline envsubst

### DIFF
--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -27,8 +27,7 @@ oc create secret generic rfc2136-credentials \
 	--namespace cert-manager \
 	--dry-run=client -o yaml | oc apply -f -
 
-log_info "Creating DNS-01 ClusterIssuer..."
-envsubst <"$YAML_DIR/pebble-dns01-simple-clusterissuer.yaml" | oc apply -f -
+apply_yaml_template "$YAML_DIR/pebble-dns01-simple-clusterissuer.yaml" "DNS-01 ClusterIssuer"
 
 log_info "Waiting for ClusterIssuer to be ready..."
 retry 3 5 oc wait --for=condition=Ready clusterissuer/"$ISSUER_NAME" --timeout=10s 2>/dev/null

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -69,16 +69,7 @@ display_configuration() {
 }
 
 create_issuer() {
-	log_info "Creating ClusterIssuer '$ISSUER_NAME'..."
-
-	envsubst <"$YAML_DIR/pebble-clusterissuer.yaml" | oc apply -f -
-
-	if [ $? -eq 0 ]; then
-		log_info "ClusterIssuer created successfully."
-	else
-		log_error "Failed to create ClusterIssuer."
-		exit 1
-	fi
+	apply_yaml_template "$YAML_DIR/pebble-clusterissuer.yaml" "ClusterIssuer"
 }
 
 verify_issuer() {

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -72,13 +72,7 @@ create_certificate() {
 		return 0
 	fi
 
-	envsubst <"$YAML_DIR/test-certificate.yaml" | oc apply -f -
-
-	if [ $? -eq 0 ]; then
-		log_info "Certificate '$cert_name' created."
-	else
-		log_error "Failed to create certificate '$cert_name'."
-	fi
+	apply_yaml_template "$YAML_DIR/test-certificate.yaml" "Certificate"
 }
 
 # Function to create multiple test certificates

--- a/scripts/ibu/simulate-ibu-backup-restore.sh
+++ b/scripts/ibu/simulate-ibu-backup-restore.sh
@@ -58,8 +58,7 @@ check_prerequisites() {
 create_backup() {
 	log_info "Creating backup: $BACKUP_NAME"
 
-	# Apply backup CR with variable substitution
-	envsubst <"$YAML_DIR/backup.yaml" | oc apply -f -
+	apply_yaml_template "$YAML_DIR/backup.yaml" "Backup"
 
 	# Wait for backup to complete
 	wait_for_backup_restore "backup" "$BACKUP_NAME" "$OADP_NAMESPACE"
@@ -92,8 +91,7 @@ delete_namespace_resources() {
 restore_from_backup() {
 	log_info "Restoring from backup: $BACKUP_NAME"
 
-	# Apply restore CR with variable substitution
-	envsubst <"$YAML_DIR/restore.yaml" | oc apply -f -
+	apply_yaml_template "$YAML_DIR/restore.yaml" "Restore"
 
 	# Wait for restore to complete
 	wait_for_backup_restore "restore" "$RESTORE_NAME" "$OADP_NAMESPACE"

--- a/scripts/ibu/simulate-ibu-preserved.sh
+++ b/scripts/ibu/simulate-ibu-preserved.sh
@@ -61,8 +61,7 @@ create_preserved_backup() {
 
 	log_info "Using apply-label annotation: $apply_label_annotation"
 
-	# Apply backup CR with LCA annotation
-	envsubst <"$YAML_DIR/backup-preserved.yaml" | oc apply -f -
+	apply_yaml_template "$YAML_DIR/backup-preserved.yaml" "Backup"
 
 	# Wait for backup to complete
 	wait_for_backup_restore "backup" "$BACKUP_NAME" "$OADP_NAMESPACE"
@@ -95,8 +94,7 @@ delete_namespace_resources() {
 restore_from_backup() {
 	log_info "Restoring from preserved backup: $BACKUP_NAME"
 
-	# Apply restore CR
-	envsubst <"$YAML_DIR/restore-preserved.yaml" | oc apply -f -
+	apply_yaml_template "$YAML_DIR/restore-preserved.yaml" "Restore"
 
 	# Wait for restore to complete
 	wait_for_backup_restore "restore" "$RESTORE_NAME" "$OADP_NAMESPACE"

--- a/scripts/install-pebble-challtestsrv.sh
+++ b/scripts/install-pebble-challtestsrv.sh
@@ -26,11 +26,8 @@ fi
 
 log_info "Installing Challenge Test Server..."
 
-log_info "Applying deployment..."
-envsubst <"$YAML_DIR/deployment.yaml" | oc apply -f -
-
-log_info "Applying service..."
-envsubst <"$YAML_DIR/service.yaml" | oc apply -f -
+apply_yaml_template "$YAML_DIR/deployment.yaml" "Deployment"
+apply_yaml_template "$YAML_DIR/service.yaml" "Service"
 
 log_info "Waiting for Challenge Test Server to be ready..."
 oc wait --for=condition=available --timeout=120s \


### PR DESCRIPTION
## Summary

- Replace 9 raw `envsubst | oc apply` calls with the shared `apply_yaml_template` helper from `lib/common.sh`
- Gains file-existence validation and consistent logging across all scripts
- Removes redundant inline log/error-handling code around the old calls

Scripts updated:
- `scripts/create-dns01-issuer.sh`
- `scripts/create-issuer.sh`
- `scripts/create-test-certificates.sh`
- `scripts/install-pebble-challtestsrv.sh`
- `scripts/ibu/simulate-ibu-backup-restore.sh`
- `scripts/ibu/simulate-ibu-preserved.sh`

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify no remaining `envsubst.*| oc apply` calls outside lib/common.sh

Fixes #55