### PR TITLE
Replace hardcoded sleep calls with proper wait/retry checks

### DIFF
--- a/scripts/ibu/run-ibu-preserved-test.sh
+++ b/scripts/ibu/run-ibu-preserved-test.sh
@@ -93,9 +93,8 @@ capture_after_state() {
 	log_info "Step 4/5: Capturing post-IBU certificate state..."
 	echo
 
-	# Wait for resources to stabilize
 	log_info "Waiting for resources to stabilize..."
-	sleep 15
+	retry 6 5 oc wait --for=condition=Ready certificates --all -n "$TARGET_NAMESPACE" --timeout=5s
 
 	STATE_LABEL=after "$SCRIPT_DIR/capture-cert-state.sh"
 }

--- a/scripts/ibu/run-ibu-test.sh
+++ b/scripts/ibu/run-ibu-test.sh
@@ -79,9 +79,8 @@ capture_after_state() {
 	log_info "Step 3/4: Capturing post-IBU certificate state..."
 	echo
 
-	# Wait a bit for cert-manager to fully reconcile
 	log_info "Waiting for cert-manager to reconcile certificates..."
-	sleep 30
+	retry 12 5 oc wait --for=condition=Ready certificates --all -n "$TARGET_NAMESPACE" --timeout=5s
 
 	STATE_LABEL=after "$SCRIPT_DIR/capture-cert-state.sh"
 }

--- a/scripts/ibu/simulate-ibu-backup-restore.sh
+++ b/scripts/ibu/simulate-ibu-backup-restore.sh
@@ -107,8 +107,7 @@ wait_for_cert_manager_reconcile() {
 	log_info "Cleaning up restored CertificateRequests..."
 	oc delete certificaterequests --all -n "$TARGET_NAMESPACE" --ignore-not-found=true 2>/dev/null || true
 
-	# Wait for cert-manager to process
-	sleep 30
+	retry 12 5 oc wait --for=condition=Ready certificates --all -n "$TARGET_NAMESPACE" --timeout=5s
 
 	# Check certificate status
 	log_info "Current certificate status:"

--- a/scripts/workflows/recover-cluster.sh
+++ b/scripts/workflows/recover-cluster.sh
@@ -30,10 +30,7 @@ if ! getent hosts "$API_HOST" &>/dev/null; then
 	# Try to ping the host to refresh DNS cache
 	ping -c 1 "$API_HOST" &>/dev/null || true
 
-	# Wait a bit for DNS to propagate
-	sleep 5
-
-	if getent hosts "$API_HOST" &>/dev/null; then
+	if retry 3 5 getent hosts "$API_HOST"; then
 		log_info "✅ DNS resolution recovered"
 	else
 		log_error "❌ DNS resolution still failing"
@@ -50,9 +47,8 @@ if ! oc whoami &>/dev/null; then
 
 	# Try to force a token refresh
 	oc version &>/dev/null || true
-	sleep 2
 
-	if oc whoami &>/dev/null; then
+	if retry 3 3 oc whoami; then
 		log_info "✅ Authentication recovered"
 	else
 		log_error "❌ Authentication still failing"
@@ -62,22 +58,10 @@ fi
 
 # Test 3: Check API server responsiveness
 log_info "Checking API server responsiveness..."
-MAX_RETRIES=5
-RETRY_COUNT=0
-
-while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-	if oc get namespace default &>/dev/null; then
-		log_info "✅ API server is responsive"
-		break
-	else
-		RETRY_COUNT=$((RETRY_COUNT + 1))
-		log_warn "API server not responding (attempt $RETRY_COUNT/$MAX_RETRIES)"
-		sleep 5
-	fi
-done
-
-if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
-	log_error "❌ API server not responsive after $MAX_RETRIES attempts"
+if retry 5 5 oc get namespace default; then
+	log_info "✅ API server is responsive"
+else
+	log_error "❌ API server not responsive after 5 attempts"
 	exit 1
 fi
 

--- a/scripts/workflows/verify-apiserver-cert-with-retry.sh
+++ b/scripts/workflows/verify-apiserver-cert-with-retry.sh
@@ -8,17 +8,19 @@
 
 set -euo pipefail
 
-echo "Waiting for cluster to stabilize before verification..."
-sleep 5
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
+
+log_info "Waiting for cluster connectivity before verification..."
 for i in 1 2 3 4 5; do
 	if oc whoami &>/dev/null && oc get nodes &>/dev/null; then
-		echo "Cluster connectivity confirmed"
+		log_info "Cluster connectivity confirmed"
 		make verify-apiserver-cert
 		exit $?
 	fi
-	echo "Waiting for cluster connectivity (attempt $i/5)..."
+	log_warn "Waiting for cluster connectivity (attempt $i/5)..."
 	sleep 5
 done
-echo "Cluster connectivity not restored - skipping verification"
-echo "The certificate was created, but verification could not be completed"
+log_warn "Cluster connectivity not restored - skipping verification"
+log_info "The certificate was created, but verification could not be completed"
 exit 0


### PR DESCRIPTION
## Summary

- Replace bare `sleep` calls with `oc wait`, `retry`, or structured polling
- IBU scripts: `sleep 15/30` for cert reconciliation replaced with `retry + oc wait --for=condition=Ready`
- `recover-cluster.sh`: inline retry loops replaced with shared `retry` helper from common.sh
- `verify-apiserver-cert-with-retry.sh`: removed unconditional initial sleep, added common.sh sourcing

Sleeps inside existing polling loops (create-issuer.sh, etc.) are left as-is since they are already part of structured retry logic.

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify IBU test scripts use proper readiness checks
- [ ] Verify recover-cluster.sh retry behavior

Fixes #57