### PR TITLE
Use mktemp -d for IBU state directory instead of fixed path

### DIFF
--- a/scripts/ibu/capture-cert-state.sh
+++ b/scripts/ibu/capture-cert-state.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
 
 # Configuration
-STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"
+STATE_DIR="${STATE_DIR:?STATE_DIR must be set by the calling script}"
 STATE_LABEL="${STATE_LABEL:-before}"
 TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 

--- a/scripts/ibu/run-ibu-preserved-test.sh
+++ b/scripts/ibu/run-ibu-preserved-test.sh
@@ -22,7 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
 # Configuration
-export STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"
+export STATE_DIR="${STATE_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/ibu-cert-state.XXXXXX")}"
 export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 export BACKUP_NAME="${BACKUP_NAME:-ibu-preserved-$(date +%s)}"
 export RESTORE_NAME="${RESTORE_NAME:-${BACKUP_NAME}-restore}"

--- a/scripts/ibu/run-ibu-test.sh
+++ b/scripts/ibu/run-ibu-test.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
 # Configuration
-export STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"
+export STATE_DIR="${STATE_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/ibu-cert-state.XXXXXX")}"
 export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 MULTI_ALGO="${MULTI_ALGO:-false}"
 

--- a/scripts/ibu/validate-cert-loss.sh
+++ b/scripts/ibu/validate-cert-loss.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
 
 # Configuration
-STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"
+STATE_DIR="${STATE_DIR:?STATE_DIR must be set by the calling script}"
 EXPECT_PRESERVED=false
 
 # Parse arguments


### PR DESCRIPTION
## Summary

- Replace hardcoded `/tmp/ibu-cert-state` default with `mktemp -d` to generate unique temp directories
- Prevents collisions when concurrent CI runs use the same path
- Helper scripts (`capture-cert-state.sh`, `validate-cert-loss.sh`) now require `STATE_DIR` to be set by the calling entry-point script via `${STATE_DIR:?}`
- Users can still override with `STATE_DIR=/custom/path make test-ibu-certs`

## Test plan

- [ ] Verify `make lint` passes
- [ ] Verify IBU test scripts create unique temp directories

Fixes #77