### PR TITLE
Use print_header consistently instead of inline banner boxes

### DIFF
--- a/scripts/ibu/label-cert-resources.sh
+++ b/scripts/ibu/label-cert-resources.sh
@@ -66,12 +66,8 @@ label_secrets() {
 	log_success "Labeled $labeled TLS secrets"
 }
 
-print_summary() {
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo "  Resource Labeling Complete"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
+print_labeling_summary() {
+	print_header "Resource Labeling Complete"
 	echo "  Labeled resources with: lca.openshift.io/backup=$BACKUP_NAME"
 	echo
 	echo "  These resources will be preserved during IBU when using"
@@ -80,7 +76,6 @@ print_summary() {
 	echo "  Verify labels:"
 	echo "    oc get certificates -n $TARGET_NAMESPACE --show-labels"
 	echo "    oc get secrets -n $TARGET_NAMESPACE --show-labels"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	echo
 }
 
@@ -103,7 +98,7 @@ main() {
 	log_info "Annotation value for Backup CR:"
 	echo "  lca.openshift.io/apply-label: $annotation_value"
 
-	print_summary
+	print_labeling_summary
 	log_success "Resource labeling complete!"
 }
 

--- a/scripts/ibu/run-ibu-preserved-test.sh
+++ b/scripts/ibu/run-ibu-preserved-test.sh
@@ -29,11 +29,7 @@ export RESTORE_NAME="${RESTORE_NAME:-${BACKUP_NAME}-restore}"
 MULTI_ALGO="${MULTI_ALGO:-false}"
 
 print_banner() {
-	echo
-	echo "╔═══════════════════════════════════════════════════════════════╗"
-	echo "║       IBU Certificate PRESERVATION Test (Scenario 2)         ║"
-	echo "╚═══════════════════════════════════════════════════════════════╝"
-	echo
+	print_header "IBU Certificate PRESERVATION Test (Scenario 2)"
 	echo "  This test validates that cert-manager certificates CAN BE"
 	echo "  preserved during IBU when using lca.openshift.io/apply-label."
 	echo
@@ -114,11 +110,7 @@ cleanup_state() {
 }
 
 print_final_summary() {
-	echo
-	echo "╔═══════════════════════════════════════════════════════════════╗"
-	echo "║       IBU Certificate Preservation Test Complete              ║"
-	echo "╚═══════════════════════════════════════════════════════════════╝"
-	echo
+	print_header "IBU Certificate Preservation Test Complete"
 	echo "  State files preserved in: $STATE_DIR"
 	echo
 	echo "  To review results:"
@@ -136,11 +128,7 @@ main() {
 	print_banner
 	check_prerequisites
 
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo "  Starting IBU Certificate Preservation Test"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
+	print_header "Starting IBU Certificate Preservation Test"
 
 	label_resources_for_preservation
 	capture_before_state

--- a/scripts/ibu/run-ibu-test.sh
+++ b/scripts/ibu/run-ibu-test.sh
@@ -23,11 +23,7 @@ export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 MULTI_ALGO="${MULTI_ALGO:-false}"
 
 print_banner() {
-	echo
-	echo "╔═══════════════════════════════════════════════════════════════╗"
-	echo "║         IBU Certificate Loss Validation Test                  ║"
-	echo "╚═══════════════════════════════════════════════════════════════╝"
-	echo
+	print_header "IBU Certificate Loss Validation Test"
 	echo "  This test validates that cert-manager certificates are NOT"
 	echo "  preserved during Image-Based Upgrade (IBU) operations."
 	echo
@@ -100,11 +96,7 @@ cleanup_state() {
 }
 
 print_final_summary() {
-	echo
-	echo "╔═══════════════════════════════════════════════════════════════╗"
-	echo "║         IBU Certificate Loss Test Complete                    ║"
-	echo "╚═══════════════════════════════════════════════════════════════╝"
-	echo
+	print_header "IBU Certificate Loss Test Complete"
 	echo "  State files preserved in: $STATE_DIR"
 	echo
 	echo "  To review results:"
@@ -122,11 +114,7 @@ main() {
 	print_banner
 	check_prerequisites
 
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo "  Starting IBU Certificate Loss Test"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
+	print_header "Starting IBU Certificate Loss Test"
 
 	capture_before_state
 	simulate_ibu

--- a/scripts/ibu/simulate-ibu-backup-restore.sh
+++ b/scripts/ibu/simulate-ibu-backup-restore.sh
@@ -112,12 +112,8 @@ wait_for_cert_manager_reconcile() {
 	oc get certificates -n "$TARGET_NAMESPACE"
 }
 
-print_summary() {
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo "  IBU Simulation Complete"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
+print_simulation_summary() {
+	print_header "IBU Simulation Complete"
 	echo "  Backup:   $BACKUP_NAME"
 	echo "  Restore:  $RESTORE_NAME"
 	echo
@@ -127,7 +123,6 @@ print_summary() {
 	echo "  3. Restored from backup"
 	echo
 	echo "  Next step: Run validate-cert-loss.sh to compare states"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	echo
 }
 
@@ -144,7 +139,7 @@ main() {
 	restore_from_backup
 	wait_for_cert_manager_reconcile
 
-	print_summary
+	print_simulation_summary
 	log_success "IBU simulation complete!"
 }
 

--- a/scripts/ibu/simulate-ibu-preserved.sh
+++ b/scripts/ibu/simulate-ibu-preserved.sh
@@ -119,12 +119,8 @@ verify_restored_resources() {
 	oc get certificates -n "$TARGET_NAMESPACE" -o wide
 }
 
-print_summary() {
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo "  IBU Preserved Simulation Complete"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
+print_simulation_summary() {
+	print_header "IBU Preserved Simulation Complete"
 	echo "  Backup:   $BACKUP_NAME"
 	echo "  Restore:  $RESTORE_NAME"
 	echo "  Mode:     Certificate Preservation (LCA-style)"
@@ -135,7 +131,6 @@ print_summary() {
 	echo "  3. Restored from backup (including original cert data)"
 	echo
 	echo "  Next step: Validate that certificates were preserved"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	echo
 }
 
@@ -153,7 +148,7 @@ main() {
 	restore_from_backup
 	verify_restored_resources
 
-	print_summary
+	print_simulation_summary
 	log_success "IBU preserved simulation complete!"
 }
 

--- a/scripts/ibu/validate-cert-loss.sh
+++ b/scripts/ibu/validate-cert-loss.sh
@@ -142,21 +142,15 @@ print_report() {
 	local missing=$3
 	local total=$4
 
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	if [ "$EXPECT_PRESERVED" = true ]; then
-		echo "  IBU Certificate Preservation Validation Report"
+		print_header "IBU Certificate Preservation Validation Report"
 	else
-		echo "  IBU Certificate Loss Validation Report"
+		print_header "IBU Certificate Loss Validation Report"
 	fi
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
 	printf "  %-25s %s\n" "Total Secrets Compared:" "$total"
 	printf "  %-25s %s\n" "Changed (New Certs):" "$changed"
 	printf "  %-25s %s\n" "Unchanged (Same Certs):" "$unchanged"
 	printf "  %-25s %s\n" "Missing:" "$missing"
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 	echo
 
 	# Determine test result based on expected behavior
@@ -299,11 +293,7 @@ compare_key_formats() {
 		return 0
 	fi
 
-	echo
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo "  Key PEM Format Comparison"
-	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	echo
+	print_header "Key PEM Format Comparison"
 
 	local format_changed=0
 	local format_unchanged=0

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -14,11 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
 
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  CERT-MANAGER SCRIPTS - PREFLIGHT CHECK"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo ""
+print_header "CERT-MANAGER SCRIPTS - PREFLIGHT CHECK"
 
 FAILED=0
 WARNINGS=0
@@ -133,10 +129,7 @@ fi
 # ============================================================================
 # Summary
 # ============================================================================
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  SUMMARY"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+print_header "SUMMARY"
 
 if [[ $FAILED -eq 0 && $WARNINGS -eq 0 ]]; then
 	log_success "All checks passed!"


### PR DESCRIPTION
## Summary
- Replace inline Unicode box-drawing banners (`╔═╗`/`║`/`╚═╝`) and heavy-line section headers (`━━━`) with `print_header` from `lib/common.sh` across 7 scripts
- Rename local `print_summary()` functions that shadowed the library version to script-specific names (`print_simulation_summary`, `print_labeling_summary`)
- Net removal of 56 lines of formatting boilerplate

## Test plan
- [x] `make lint` passes (shfmt + shellcheck)
- [x] Zero remaining Unicode banner characters in `scripts/` (`grep -rn '━\|╔\|╗\|╚\|╝\|║' scripts/`)
- [ ] CI passes

Closes #80