### PR TITLE
Add setup_cleanup trap to IBU scripts for partial-failure cleanup

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -163,9 +163,9 @@ setup_cleanup() {
 		local exit_code=$?
 		local duration=$(($(date +%s) - _START_TIME))
 
-		# Clean up temp files
+		# Clean up temp files and directories
 		for f in "${_TEMP_FILES[@]:-}"; do
-			[[ -f "$f" ]] && rm -f "$f"
+			[[ -e "$f" ]] && rm -rf "$f"
 		done
 
 		if [[ $LOG_LEVEL -ge 3 ]]; then

--- a/scripts/ibu/capture-cert-state.sh
+++ b/scripts/ibu/capture-cert-state.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 # Configuration
 STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"

--- a/scripts/ibu/create-multi-algo-certs.sh
+++ b/scripts/ibu/create-multi-algo-certs.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 # Configuration
 export TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"

--- a/scripts/ibu/install-minio.sh
+++ b/scripts/ibu/install-minio.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/minio"
 MINIO_NAMESPACE="${MINIO_NAMESPACE:-minio}"

--- a/scripts/ibu/install-oadp.sh
+++ b/scripts/ibu/install-oadp.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/oadp"
 OADP_NAMESPACE="${OADP_NAMESPACE:-openshift-adp}"

--- a/scripts/ibu/label-cert-resources.sh
+++ b/scripts/ibu/label-cert-resources.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 # Configuration
 TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"

--- a/scripts/ibu/run-ibu-preserved-test.sh
+++ b/scripts/ibu/run-ibu-preserved-test.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
+setup_cleanup
 
 # Configuration
 export STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"

--- a/scripts/ibu/run-ibu-test.sh
+++ b/scripts/ibu/run-ibu-test.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
+setup_cleanup
 
 # Configuration
 export STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"

--- a/scripts/ibu/simulate-ibu-backup-restore.sh
+++ b/scripts/ibu/simulate-ibu-backup-restore.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/backup"
 OADP_NAMESPACE="${OADP_NAMESPACE:-openshift-adp}"

--- a/scripts/ibu/simulate-ibu-preserved.sh
+++ b/scripts/ibu/simulate-ibu-preserved.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/backup"
 OADP_NAMESPACE="${OADP_NAMESPACE:-openshift-adp}"

--- a/scripts/ibu/validate-cert-loss.sh
+++ b/scripts/ibu/validate-cert-loss.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 # Configuration
 STATE_DIR="${STATE_DIR:-/tmp/ibu-cert-state}"

--- a/scripts/ibu/verify-key-formats.sh
+++ b/scripts/ibu/verify-key-formats.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+setup_cleanup
 
 # Configuration
 TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
@@ -27,7 +28,7 @@ verify_all_key_formats() {
 
 	local tmp_file
 	tmp_file=$(mktemp)
-	trap 'rm -f "$tmp_file"' RETURN
+	register_temp_file "$tmp_file"
 
 	capture_secret_checksums "$TARGET_NAMESPACE" "$tmp_file"
 


### PR DESCRIPTION
## Summary
- Add `setup_cleanup` call to all 11 IBU scripts for EXIT trap handling (temp file cleanup + duration logging)
- Update `lib/common.sh` cleanup function to handle directories (`rm -rf`) in addition to files
- Replace function-scoped `trap RETURN` in `verify-key-formats.sh` with `register_temp_file` for consistent cleanup on any exit path

## Test plan
- [x] `make lint` passes (shfmt + shellcheck)
- [x] All 11 IBU scripts have `setup_cleanup` (`grep -c setup_cleanup scripts/ibu/*.sh`)
- [ ] CI passes

Closes #78