### PR TITLE
Replace inline retry/wait loops with shared library functions

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -211,6 +211,32 @@ retry() {
 	done
 }
 
+# Wait for a condition to become true with fixed polling interval
+# Usage: wait_for_condition <max_attempts> <interval_seconds> <command...>
+# Example: wait_for_condition 30 2 check_issuer_ready
+wait_for_condition() {
+	local max_attempts="$1"
+	local interval="$2"
+	shift 2
+
+	local attempt=1
+	while true; do
+		if "$@" 2>/dev/null; then
+			return 0
+		fi
+
+		if [[ $attempt -ge $max_attempts ]]; then
+			return 1
+		fi
+
+		if [[ $((attempt % 5)) -eq 0 ]]; then
+			log_info "Still waiting... ($attempt/$max_attempts)"
+		fi
+		sleep "$interval"
+		attempt=$((attempt + 1))
+	done
+}
+
 # ============================================================================
 # SUMMARY OUTPUT
 # ============================================================================

--- a/scripts/create-apiserver-certificate.sh
+++ b/scripts/create-apiserver-certificate.sh
@@ -109,48 +109,24 @@ EOF
 	fi
 }
 
+check_apiserver_cert_ready() {
+	oc whoami &>/dev/null || return 1
+	local ready
+	ready=$(oc get certificate "$CERT_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+	[ "$ready" = "True" ]
+}
+
 wait_for_certificate() {
 	log_info "Waiting for certificate to be issued..."
-	echo
 
-	# Use shorter timeout for CI environments to avoid cluster instability issues
-	local max_wait=${CERT_WAIT_TIMEOUT:-60}
-	local wait_time=0
-
-	while [ $wait_time -lt $max_wait ]; do
-		# Check cluster connectivity first
-		if ! oc whoami &>/dev/null; then
-			log_warn "Cluster connectivity lost during certificate wait"
-			return 1
-		fi
-
-		local ready=$(oc get certificate "$CERT_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
-
-		if [ "$ready" = "True" ]; then
-			log_info "✅ Certificate is READY!"
-			return 0
-		fi
-
-		if [ $((wait_time % 10)) -eq 0 ]; then
-			echo -n " [${wait_time}s/${max_wait}s]"
-		else
-			echo -n "."
-		fi
-
-		sleep 2
-		wait_time=$((wait_time + 2))
-	done
-	echo
-
-	if [ $wait_time -ge $max_wait ]; then
-		log_warn "Timeout waiting for certificate to be ready (${max_wait}s)."
+	local max_attempts=$(((${CERT_WAIT_TIMEOUT:-60} + 1) / 2))
+	if wait_for_condition "$max_attempts" 2 check_apiserver_cert_ready; then
+		log_success "Certificate is READY!"
+	else
+		log_warn "Timeout waiting for certificate to be ready."
 		log_info "The certificate resource was created - it may become ready later."
 		log_info "Check certificate status: oc describe certificate $CERT_NAME -n $CERT_NAMESPACE"
-		# Return success since certificate was created, even if not ready yet
-		return 0
 	fi
-
-	return 0
 }
 
 display_certificate_info() {

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -72,31 +72,18 @@ create_issuer() {
 	apply_yaml_template "$YAML_DIR/pebble-clusterissuer.yaml" "ClusterIssuer"
 }
 
+check_issuer_ready() {
+	local ready
+	ready=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+	[ "$ready" = "True" ]
+}
+
 verify_issuer() {
 	log_info "Waiting for ClusterIssuer to be ready..."
 
-	local max_attempts=30
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local ready=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
-
-		if [ "$ready" = "True" ]; then
-			log_info "ClusterIssuer is ready!"
-			break
-		fi
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 5)) -eq 0 ]; then
-			echo -n " [${attempt}/${max_attempts}]"
-		else
-			echo -n "."
-		fi
-		sleep 2
-	done
-	echo
-
-	if [ $attempt -eq $max_attempts ]; then
+	if wait_for_condition 30 2 check_issuer_ready; then
+		log_success "ClusterIssuer is ready!"
+	else
 		log_warn "Timeout waiting for ClusterIssuer to be ready."
 		log_info "Check status with: oc describe clusterissuer $ISSUER_NAME"
 	fi

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -113,55 +113,24 @@ show_http01_flow() {
 	echo
 }
 
-# Function to wait for certificates
+check_test_certs_ready() {
+	for cert in test-cert-simple test-cert-app test-cert-api; do
+		if oc get certificate "$cert" -n "$CERT_NAMESPACE" &>/dev/null; then
+			local ready
+			ready=$(oc get certificate "$cert" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' || echo "False")
+			[ "$ready" != "True" ] && return 1
+		fi
+	done
+	return 0
+}
+
 wait_for_certificates() {
 	log_info "Waiting for certificates to be issued..."
-	echo
+	show_http01_flow
 
-	local max_wait=60
-	local wait_time=0
-	local shown_flow=false
-
-	while [ $wait_time -lt $max_wait ]; do
-		local all_ready=true
-
-		# Check each certificate
-		for cert in test-cert-simple test-cert-app test-cert-api; do
-			if oc get certificate "$cert" -n "$CERT_NAMESPACE" &>/dev/null; then
-				local ready
-				ready=$(oc get certificate "$cert" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "False")
-
-				if [ "$ready" != "True" ]; then
-					all_ready=false
-
-					# Show flow once when challenges are detected
-					if [ "$shown_flow" = false ]; then
-						if oc get challenge -n "$CERT_NAMESPACE" 2>/dev/null | grep -q "test-cert"; then
-							show_http01_flow
-							shown_flow=true
-						fi
-					fi
-				fi
-			fi
-		done
-
-		if [ "$all_ready" = true ]; then
-			log_success "All certificates are ready!"
-			break
-		fi
-
-		if [ $((wait_time % 10)) -eq 0 ]; then
-			echo -n " [${wait_time}s/${max_wait}s]"
-		else
-			echo -n "."
-		fi
-
-		sleep 2
-		wait_time=$((wait_time + 2))
-	done
-	echo
-
-	if [ $wait_time -ge $max_wait ]; then
+	if wait_for_condition 30 2 check_test_certs_ready; then
+		log_success "All certificates are ready!"
+	else
 		log_warn "Timeout waiting for all certificates to be ready."
 		log_info "This is normal if using PEBBLE_ALWAYS_VALID=0 without proper DNS/HTTP setup."
 		log_info "Check certificate status below for details."

--- a/scripts/ibu/create-multi-algo-certs.sh
+++ b/scripts/ibu/create-multi-algo-certs.sh
@@ -109,32 +109,23 @@ create_all_certificates() {
 	log_info "All certificate resources created."
 }
 
+check_all_certs_ready() {
+	local not_ready
+	not_ready=$(oc get certificates -n "$TARGET_NAMESPACE" -l app="$CERT_LABEL" -o json |
+		jq '[.items[] | select((.status.conditions // [] | map(select(.type=="Ready" and .status=="True")) | length) == 0)] | length')
+	[ "$not_ready" -eq 0 ]
+}
+
 wait_for_certificates() {
 	log_info "Waiting for certificates to become ready..."
 
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local not_ready
-		not_ready=$(oc get certificates -n "$TARGET_NAMESPACE" -l app="$CERT_LABEL" -o json 2>/dev/null |
-			jq '[.items[] | select((.status.conditions // [] | map(select(.type=="Ready" and .status=="True")) | length) == 0)] | length')
-
-		if [ "$not_ready" -eq 0 ]; then
-			log_success "All certificates are ready!"
-			return 0
-		fi
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 5)) -eq 0 ]; then
-			log_info "Still waiting... ($not_ready not ready, ${attempt}/${max_attempts})"
-		fi
-		sleep 2
-	done
-
-	log_error "Timeout waiting for certificates to become ready."
-	log_info "Check status: oc get certificates -n $TARGET_NAMESPACE -l app=$CERT_LABEL"
-	exit 1
+	if wait_for_condition 60 2 check_all_certs_ready; then
+		log_success "All certificates are ready!"
+	else
+		log_error "Timeout waiting for certificates to become ready."
+		log_info "Check status: oc get certificates -n $TARGET_NAMESPACE -l app=$CERT_LABEL"
+		exit 1
+	fi
 }
 
 verify_key_formats() {

--- a/scripts/ibu/install-oadp.sh
+++ b/scripts/ibu/install-oadp.sh
@@ -82,31 +82,22 @@ configure_dpa() {
 	wait_for_dpa
 }
 
+check_dpa_reconciled() {
+	local status
+	status=$(oc get dataprotectionapplication velero -n "$OADP_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Reconciled")].status}')
+	[ "$status" = "True" ]
+}
+
 wait_for_dpa() {
 	log_info "Waiting for DataProtectionApplication to reconcile..."
 
-	local max_attempts=60
-	local attempt=0
-
-	while [ $attempt -lt $max_attempts ]; do
-		local status
-		status=$(oc get dataprotectionapplication velero -n "$OADP_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Reconciled")].status}' 2>/dev/null || echo "")
-
-		if [ "$status" = "True" ]; then
-			log_success "DataProtectionApplication is reconciled!"
-			return 0
-		fi
-
-		attempt=$((attempt + 1))
-		if [ $((attempt % 6)) -eq 0 ]; then
-			log_info "Waiting for DPA... ($attempt/$max_attempts)"
-		fi
-		sleep 5
-	done
-
-	log_error "Timeout waiting for DPA to reconcile."
-	log_info "Check status with: oc describe dpa velero -n $OADP_NAMESPACE"
-	return 1
+	if wait_for_condition 60 5 check_dpa_reconciled; then
+		log_success "DataProtectionApplication is reconciled!"
+	else
+		log_error "Timeout waiting for DPA to reconcile."
+		log_info "Check status with: oc describe dpa velero -n $OADP_NAMESPACE"
+		return 1
+	fi
 }
 
 verify_installation() {

--- a/scripts/troubleshooting/verify-apiserver-certificate.sh
+++ b/scripts/troubleshooting/verify-apiserver-certificate.sh
@@ -25,23 +25,10 @@ SECRET_NAME="apiserver-cert-tls"
 check_prerequisites() {
 	require_cmd oc jq
 
-	# Try multiple times to connect - cluster may be temporarily unstable
-	local max_attempts=3
-	local attempt=1
-	while [ $attempt -le $max_attempts ]; do
-		if oc whoami &>/dev/null; then
-			return 0
-		fi
-		if [ $attempt -lt $max_attempts ]; then
-			log_warn "Cluster connection attempt $attempt/$max_attempts failed, retrying..."
-			sleep 5
-		fi
-		attempt=$((attempt + 1))
-	done
-
-	log_error "Not logged in to OpenShift cluster after $max_attempts attempts."
-	log_error "Cluster may be unstable. Please check cluster connectivity."
-	exit 1
+	if ! retry 3 5 oc whoami; then
+		log_error "Cluster may be unstable. Please check cluster connectivity."
+		exit 1
+	fi
 }
 
 verify_api_server_access() {

--- a/scripts/workflows/verify-apiserver-cert-with-retry.sh
+++ b/scripts/workflows/verify-apiserver-cert-with-retry.sh
@@ -11,16 +11,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
+check_cluster() {
+	oc whoami &>/dev/null && oc get nodes &>/dev/null
+}
+
 log_info "Waiting for cluster connectivity before verification..."
-for i in 1 2 3 4 5; do
-	if oc whoami &>/dev/null && oc get nodes &>/dev/null; then
-		log_info "Cluster connectivity confirmed"
-		make verify-apiserver-cert
-		exit $?
-	fi
-	log_warn "Waiting for cluster connectivity (attempt $i/5)..."
-	sleep 5
-done
+if wait_for_condition 5 5 check_cluster; then
+	log_info "Cluster connectivity confirmed"
+	make verify-apiserver-cert
+	exit $?
+fi
 log_warn "Cluster connectivity not restored - skipping verification"
 log_info "The certificate was created, but verification could not be completed"
 exit 0

--- a/scripts/workflows/wait-for-cluster-operators.sh
+++ b/scripts/workflows/wait-for-cluster-operators.sh
@@ -8,21 +8,20 @@
 
 set -euo pipefail
 
-echo "Waiting for cluster operators to stabilize (up to 5 minutes)..."
-timeout=300
-elapsed=0
-while [ $elapsed -lt $timeout ]; do
-	degraded=$(oc get clusteroperators --no-headers 2>/dev/null | awk '($3!="True" || $4=="True" || $5=="True")' | wc -l | xargs)
-	if [ "$degraded" -eq 0 ]; then
-		echo "All cluster operators are healthy!"
-		oc get clusteroperators
-		break
-	fi
-	if [ $((elapsed % 30)) -eq 0 ]; then
-		echo "Still waiting... ($elapsed seconds, $degraded operators not ready)"
-	fi
-	sleep 10
-	elapsed=$((elapsed + 10))
-done
-echo "Cluster operator status:"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
+
+check_operators_healthy() {
+	local degraded
+	degraded=$(oc get clusteroperators --no-headers | awk '($3!="True" || $4=="True" || $5=="True")' | wc -l | xargs)
+	[ "$degraded" -eq 0 ]
+}
+
+log_info "Waiting for cluster operators to stabilize (up to 5 minutes)..."
+if wait_for_condition 30 10 check_operators_healthy; then
+	log_success "All cluster operators are healthy!"
+else
+	log_warn "Timeout waiting for cluster operators to stabilize."
+fi
+log_info "Cluster operator status:"
 oc get clusteroperators || true


### PR DESCRIPTION
## Summary
- Add `wait_for_condition` to `lib/common.sh` for fixed-interval status polling (complements `retry` which uses exponential backoff)
- Refactor 8 scripts to use `retry` or `wait_for_condition` instead of hand-rolled while loops with dot-printing progress
- `retry`: transient failures (cluster connectivity checks)
- `wait_for_condition`: status polling (cert readiness, DPA reconcile, cluster operator health)

## Test plan
- [x] `make lint` passes (shfmt + shellcheck)
- [x] No remaining inline retry/wait loops (`grep -rn 'while.*attempt\|while.*wait_time\|while.*elapsed' scripts/`)
- [x] No remaining dot-progress patterns (`grep -rn 'echo -n "\."' scripts/`)
- [ ] CI passes

Closes #79