### PR TITLE
Add CI test coverage for DNS-01 and self-signed flows

### DIFF
--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -79,6 +79,34 @@ jobs:
         env:
           CERT_MANAGER_VERSION: ${{ inputs.cert-manager-version }}
 
+      - name: Clean up HTTP-01 test resources
+        if: always()
+        run: make clean-certs clean-issuers clean-pebble || true
+
+      - name: Run quick self-signed CA test
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 2
+          retry_on: error
+          command: make quick-selfsigned-test
+
+      - name: Clean up self-signed test resources
+        if: always()
+        run: make clean-selfsigned || true
+
+      - name: Run quick DNS-01 test
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: make quick-dns-test
+
+      - name: Clean up DNS-01 test resources
+        if: always()
+        run: make clean-certs clean-issuers clean-pebble clean-fake-dns || true
+
       - name: Run multi-algorithm certificate test
         uses: nick-fields/retry@v4
         with:


### PR DESCRIPTION
## Summary
- Add `quick-selfsigned-test` and `quick-dns-test` steps to the reusable integration test workflow
- Self-signed test runs first (faster, no external dependencies), then DNS-01 (requires fake-dns)
- Cleanup steps between tests prevent resource conflicts
- Integration tests now cover all three challenge types: HTTP-01, self-signed CA, and DNS-01

## Test plan
- [x] `make lint` passes
- [ ] CI runs all three test types in the integration test matrix
- [ ] No timeout or resource conflict failures between test steps

Closes #62