### PR TITLE
Harden security contexts for fake-dns and Pebble deployments

### DIFF
--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Clean up HTTP-01 test resources
         if: always()
         timeout-minutes: 2
+        continue-on-error: true
         run: make clean-certs clean-issuers || true
 
       - name: Run quick self-signed CA test
@@ -106,6 +107,7 @@ jobs:
       - name: Clean up self-signed test resources
         if: always()
         timeout-minutes: 2
+        continue-on-error: true
         run: make clean-selfsigned || true
 
       - name: Verify Pebble health before DNS-01 test
@@ -136,6 +138,7 @@ jobs:
       - name: Clean up DNS-01 test resources
         if: always()
         timeout-minutes: 2
+        continue-on-error: true
         run: make clean-certs clean-issuers clean-pebble clean-fake-dns || true
 
       - name: Run multi-algorithm certificate test

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Clean up HTTP-01 test resources
         if: always()
-        run: make clean-certs clean-issuers clean-pebble || true
+        run: make clean-certs clean-issuers || true
 
       - name: Run quick self-signed CA test
         uses: nick-fields/retry@v4

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -26,6 +26,7 @@ jobs:
   test:
     name: OCP ${{ inputs.ocp-version }} / cert-manager ${{ inputs.cert-manager-version || 'default' }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Check Red Hat Status
         uses: palmsoftware/redhat-status@v0
@@ -87,6 +88,7 @@ jobs:
 
       - name: Clean up HTTP-01 test resources
         if: always()
+        timeout-minutes: 2
         run: make clean-certs clean-issuers || true
 
       - name: Run quick self-signed CA test
@@ -103,6 +105,7 @@ jobs:
 
       - name: Clean up self-signed test resources
         if: always()
+        timeout-minutes: 2
         run: make clean-selfsigned || true
 
       - name: Verify Pebble health before DNS-01 test
@@ -132,6 +135,7 @@ jobs:
 
       - name: Clean up DNS-01 test resources
         if: always()
+        timeout-minutes: 2
         run: make clean-certs clean-issuers clean-pebble clean-fake-dns || true
 
       - name: Run multi-algorithm certificate test

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -168,6 +168,10 @@ jobs:
           retry_on: error
           command: ./scripts/workflows/verify-cluster-access.sh
 
+      - name: Recreate issuer for API server cert test
+        run: |
+          PEBBLE_ALWAYS_VALID=1 make install-pebble create-issuer || true
+
       - name: Create API server certificate
         uses: nick-fields/retry@v4
         with:

--- a/.github/workflows/reusable-integration-test.yml
+++ b/.github/workflows/reusable-integration-test.yml
@@ -75,6 +75,12 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           retry_on: error
+          on_retry_command: |
+            echo "=== Pebble diagnostics ==="
+            oc get pods -n pebble -o wide 2>/dev/null || true
+            oc get events -n pebble --sort-by='.lastTimestamp' 2>/dev/null | tail -15 || true
+            echo "=== cert-manager diagnostics ==="
+            oc get pods -n cert-manager 2>/dev/null || true
           command: make quick-http-test
         env:
           CERT_MANAGER_VERSION: ${{ inputs.cert-manager-version }}
@@ -89,11 +95,26 @@ jobs:
           timeout_minutes: 10
           max_attempts: 2
           retry_on: error
+          on_retry_command: |
+            echo "=== cert-manager diagnostics ==="
+            oc get pods -n cert-manager 2>/dev/null || true
+            oc get events -n cert-manager --sort-by='.lastTimestamp' 2>/dev/null | tail -10 || true
           command: make quick-selfsigned-test
 
       - name: Clean up self-signed test resources
         if: always()
         run: make clean-selfsigned || true
+
+      - name: Verify Pebble health before DNS-01 test
+        run: |
+          echo "Checking Pebble pod status before DNS-01 test..."
+          oc get pods -n pebble -o wide 2>/dev/null || true
+          oc get events -n pebble --sort-by='.lastTimestamp' 2>/dev/null | tail -10 || true
+          if ! oc get deployment pebble -n pebble -o jsonpath='{.status.availableReplicas}' 2>/dev/null | grep -q '^[1-9]'; then
+            echo "WARNING: Pebble is not healthy, DNS-01 test may fail"
+          else
+            echo "Pebble is healthy"
+          fi
 
       - name: Run quick DNS-01 test
         uses: nick-fields/retry@v4
@@ -101,6 +122,12 @@ jobs:
           timeout_minutes: 30
           max_attempts: 2
           retry_on: error
+          on_retry_command: |
+            echo "=== Pebble diagnostics ==="
+            oc get pods -n pebble -o wide 2>/dev/null || true
+            oc get events -n pebble --sort-by='.lastTimestamp' 2>/dev/null | tail -15 || true
+            echo "=== fake-dns diagnostics ==="
+            oc get pods -n fake-dns -o wide 2>/dev/null || true
           command: make quick-dns-test
 
       - name: Clean up DNS-01 test resources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ Key functions:
 - **Logging**: `log_error`, `log_warn`, `log_info`, `log_success`, `log_debug` — color-aware, respects `LOG_LEVEL`
 - **Dependencies**: `require_cmd oc yq jq` — validates commands with install hints
 - **Cluster**: `require_cluster` / `require_cluster_admin` — validates connectivity and privileges
+- **Cluster**: `require_healthy_cluster [max_attempts] [interval]` — waits for dns, network, ingress operators to be Available
 - **Environment**: `load_env` — loads `.env` from script or parent directory
 - **Retry**: `retry <max_attempts> <delay> <command...>` — exponential backoff
 - **Wait**: `wait_for_resource <type/name> <namespace> <timeout>` — uses `oc wait --for=condition=available`

--- a/Makefile
+++ b/Makefile
@@ -428,13 +428,13 @@ clean-certs: ## Clean up certificates, orders, and challenges
 
 clean-pebble: ## Clean up Pebble ACME test server
 	@echo "$(BOLD)$(YELLOW)Cleaning up Pebble...$(RESET)"
-	@oc delete namespace pebble --ignore-not-found=true
+	@oc delete namespace pebble --ignore-not-found=true --timeout=60s --wait=false
 	@oc delete secret pebble-dns01-issuer-account-key pebble-issuer-account-key -n cert-manager --ignore-not-found=true
 	@echo "$(GREEN)Pebble cleaned.$(RESET)"
 
 clean-fake-dns: ## Clean up fake DNS API
 	@echo "$(BOLD)$(YELLOW)Cleaning up fake DNS...$(RESET)"
-	@oc delete namespace fake-dns --ignore-not-found=true
+	@oc delete namespace fake-dns --ignore-not-found=true --timeout=60s --wait=false
 	@echo "$(GREEN)Fake DNS cleaned.$(RESET)"
 
 clean-dns-config: ## Restore DNS configuration

--- a/Makefile
+++ b/Makefile
@@ -210,11 +210,6 @@ test-all: install-all create-issuer create-certs ## Complete HTTP-01 setup (inst
 	@echo "  oc get order,challenge -A"
 
 test-dns01: install-fake-dns ## Complete DNS-01 setup (air-gapped)
-	@echo "Reinstalling Pebble with fake DNS..."
-	@oc delete namespace pebble --ignore-not-found=true
-	@sleep 10
-	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 PEBBLE_ALWAYS_VALID=1 ./scripts/install-pebble.sh
-	@echo ""
 	@echo "Creating DNS-01 issuer..."
 	@DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 ./scripts/create-dns01-issuer.sh
 	@echo ""

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -285,6 +285,39 @@ require_cluster_admin() {
 	log_debug "Cluster-admin privileges confirmed"
 }
 
+# Wait for critical cluster operators to be healthy before deploying workloads.
+# Checks dns, network, and ingress operators — degraded state in any of these
+# prevents pods from scheduling, pulling images, or receiving traffic.
+# Usage: require_healthy_cluster [max_attempts] [interval]
+require_healthy_cluster() {
+	local max_attempts="${1:-30}"
+	local interval="${2:-10}"
+
+	check_critical_operators() {
+		local unhealthy
+		unhealthy=$(oc get clusteroperator dns network ingress \
+			-o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' 2>/dev/null |
+			grep -cve '^True$' || true)
+		[ "$unhealthy" -eq 0 ]
+	}
+
+	log_info "Checking critical cluster operators (dns, network, ingress)..."
+	if check_critical_operators; then
+		log_info "Critical cluster operators are healthy."
+		return 0
+	fi
+
+	log_warn "Critical cluster operators not yet healthy. Waiting up to $((max_attempts * interval))s..."
+	if wait_for_condition "$max_attempts" "$interval" check_critical_operators; then
+		log_success "Critical cluster operators are healthy."
+	else
+		log_error "Critical cluster operators still unhealthy after $((max_attempts * interval))s."
+		log_error "Operator status:"
+		oc get clusteroperator dns network ingress 2>/dev/null || true
+		return 1
+	fi
+}
+
 # Wait for a resource to be ready
 # Usage: wait_for_resource <type/name> <namespace> <timeout>
 wait_for_resource() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -331,8 +331,24 @@ wait_for_resource() {
 		return 0
 	else
 		log_error "$resource failed to become ready within $timeout"
+		dump_resource_diagnostics "$namespace" "$resource"
 		return 1
 	fi
+}
+
+# Dump diagnostic info for a namespace and optional resource
+# Usage: dump_resource_diagnostics <namespace> [resource]
+dump_resource_diagnostics() {
+	local namespace="$1"
+	local resource="${2:-}"
+
+	log_warn "--- Diagnostics for namespace '$namespace' ---"
+	oc get pods -n "$namespace" -o wide 2>/dev/null || true
+	if [[ -n "$resource" ]]; then
+		oc describe "$resource" -n "$namespace" 2>/dev/null | tail -30 || true
+	fi
+	oc get events -n "$namespace" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+	log_warn "--- End diagnostics ---"
 }
 
 # Verify cert-manager is installed and webhook is ready

--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -21,6 +21,18 @@ print_header "Create DNS-01 ClusterIssuer"
 
 require_cluster
 
+check_pebble_responding() {
+	oc get deployment pebble -n "${PEBBLE_NAMESPACE:-pebble}" -o jsonpath='{.status.availableReplicas}' 2>/dev/null | grep -q '^[1-9]'
+}
+
+log_info "Waiting for Pebble ACME server to be available..."
+if wait_for_condition 60 10 check_pebble_responding; then
+	log_info "Pebble ACME server is available."
+else
+	log_error "Pebble ACME server is not available. Install Pebble first: make install-pebble"
+	exit 1
+fi
+
 log_info "Creating dummy RFC2136 secret in cert-manager namespace..."
 oc create secret generic rfc2136-credentials \
 	--from-literal=tsig-secret="$(echo -n "dummy-secret-key" | base64)" \
@@ -30,7 +42,7 @@ oc create secret generic rfc2136-credentials \
 apply_yaml_template "$YAML_DIR/pebble-dns01-simple-clusterissuer.yaml" "DNS-01 ClusterIssuer"
 
 log_info "Waiting for ClusterIssuer to be ready..."
-retry 3 5 oc wait --for=condition=Ready clusterissuer/"$ISSUER_NAME" --timeout=10s 2>/dev/null
+retry 5 10 oc wait --for=condition=Ready clusterissuer/"$ISSUER_NAME" --timeout=30s 2>/dev/null
 
 if oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
 	oc get clusterissuer "$ISSUER_NAME"

--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -30,6 +30,7 @@ if wait_for_condition 60 10 check_pebble_responding; then
 	log_info "Pebble ACME server is available."
 else
 	log_error "Pebble ACME server is not available. Install Pebble first: make install-pebble"
+	dump_resource_diagnostics "${PEBBLE_NAMESPACE:-pebble}" "deployment/pebble"
 	exit 1
 fi
 

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -19,10 +19,6 @@ install_fake_dns() {
 
 	apply_yaml_template "$YAML_DIR/namespace.yaml" "Namespace"
 	apply_yaml_template "$YAML_DIR/serviceaccount.yaml" "ServiceAccount"
-
-	log_info "Granting anyuid SCC to fake-dns-api ServiceAccount..."
-	oc adm policy add-scc-to-user anyuid -z fake-dns-api -n "$FAKEDNS_NAMESPACE"
-
 	apply_yaml_template "$YAML_DIR/configmap.yaml" "ConfigMap"
 	apply_yaml_template "$YAML_DIR/deployment.yaml" "Deployment"
 	apply_yaml_template "$YAML_DIR/service.yaml" "Service"
@@ -146,6 +142,7 @@ main() {
 
 	require_cmd oc envsubst
 	require_cluster
+	require_healthy_cluster
 
 	install_fake_dns
 	wait_for_resource "deployment/fake-dns-api" "$FAKEDNS_NAMESPACE" "600s"

--- a/scripts/install-local-dns.sh
+++ b/scripts/install-local-dns.sh
@@ -75,6 +75,7 @@ main() {
 
 	require_cmd oc envsubst
 	require_cluster
+	require_healthy_cluster
 
 	if [ ! -d "$YAML_DIR" ]; then
 		log_error "YAML directory not found: $YAML_DIR"

--- a/scripts/install-pebble-challtestsrv.sh
+++ b/scripts/install-pebble-challtestsrv.sh
@@ -18,6 +18,7 @@ print_header "Install Pebble Challenge Test Server"
 
 require_cmd oc
 require_cluster
+require_healthy_cluster
 
 if ! oc get namespace "$PEBBLE_NAMESPACE" &>/dev/null; then
 	log_error "Pebble namespace '$PEBBLE_NAMESPACE' not found. Install Pebble first."

--- a/scripts/install-pebble.sh
+++ b/scripts/install-pebble.sh
@@ -136,6 +136,7 @@ main() {
 	fi
 
 	display_configuration
+	require_healthy_cluster
 
 	if check_deployment_exists pebble "$PEBBLE_NAMESPACE"; then
 		log_info "Pebble is already installed and healthy."

--- a/scripts/workflows/wait-for-cluster-operators.sh
+++ b/scripts/workflows/wait-for-cluster-operators.sh
@@ -2,7 +2,7 @@
 
 ################################################################################
 # Script: wait-for-cluster-operators.sh
-# Description: Poll cluster operators until all are healthy (5 min timeout)
+# Description: Poll cluster operators until all are healthy
 # Used by: reusable-integration-test.yml
 ################################################################################
 
@@ -17,11 +17,13 @@ check_operators_healthy() {
 	[ "$degraded" -eq 0 ]
 }
 
-log_info "Waiting for cluster operators to stabilize (up to 5 minutes)..."
-if wait_for_condition 30 10 check_operators_healthy; then
+log_info "Waiting for cluster operators to stabilize (up to 10 minutes)..."
+if wait_for_condition 60 10 check_operators_healthy; then
 	log_success "All cluster operators are healthy!"
 else
-	log_warn "Timeout waiting for cluster operators to stabilize."
+	log_warn "Timeout waiting for all cluster operators. Checking critical operators..."
 fi
 log_info "Cluster operator status:"
 oc get clusteroperators || true
+
+require_healthy_cluster 30 10

--- a/yaml/fake-dns-api/README.md
+++ b/yaml/fake-dns-api/README.md
@@ -36,7 +36,7 @@ envsubst < yaml/fake-dns-api/service.yaml | oc apply -f -
 ## How It Works
 
 The fake DNS API server:
-1. Listens on port 53 for DNS queries (SOA, TXT)
+1. Listens on port 5353 for DNS queries (SOA, TXT), exposed as port 53 via the Service
 2. Accepts RFC2136 dynamic DNS UPDATE requests
 3. Stores TXT records in memory
 4. Returns stored records when queried

--- a/yaml/fake-dns-api/configmap.yaml
+++ b/yaml/fake-dns-api/configmap.yaml
@@ -14,6 +14,7 @@ data:
     for testing DNS-01 challenges in air-gapped environments.
     """
     
+    import os
     import socket
     import struct
     import threading
@@ -200,7 +201,7 @@ data:
             logger.error(f"Error handling DNS packet: {e}")
             return None
     
-    def start_dns_server(port=53):
+    def start_dns_server(port=5353):
         """Start UDP DNS server"""
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.bind(('0.0.0.0', port))
@@ -225,7 +226,8 @@ data:
         logger.info("Starting fake DNS API server for air-gapped testing")
         
         # Start DNS server in background thread
-        dns_thread = threading.Thread(target=start_dns_server, daemon=True)
+        dns_port = int(os.environ.get('DNS_PORT', '5353'))
+        dns_thread = threading.Thread(target=start_dns_server, args=(dns_port,), daemon=True)
         dns_thread.start()
         
         # Start health server in main thread

--- a/yaml/fake-dns-api/deployment.yaml
+++ b/yaml/fake-dns-api/deployment.yaml
@@ -2,7 +2,7 @@
 #
 # Runs the fake DNS API server on UBI9 Python. Accepts RFC2136 DNS updates and
 # responds to SOA/TXT queries for air-gapped cert-manager DNS-01 testing.
-# Requires root privileges for binding to privileged port 53.
+# Listens on unprivileged port 5353; the Service maps external port 53 to it.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,11 +30,14 @@ spec:
         - /app/dns-api.py
         ports:
         - name: dns
-          containerPort: 53
+          containerPort: 5353
           protocol: UDP
         - name: health
           containerPort: 8080
           protocol: TCP
+        env:
+        - name: DNS_PORT
+          value: "5353"
         volumeMounts:
         - name: script
           mountPath: /app
@@ -51,8 +54,13 @@ spec:
           initialDelaySeconds: 2
           periodSeconds: 5
         securityContext:
-          # Need elevated privileges for port 53
-          runAsUser: 0
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: script
         configMap:

--- a/yaml/fake-dns-api/service.yaml
+++ b/yaml/fake-dns-api/service.yaml
@@ -14,7 +14,7 @@ spec:
   ports:
   - name: dns
     port: 53
-    targetPort: 53
+    targetPort: 5353
     protocol: UDP
   - name: health
     port: 8080

--- a/yaml/fake-dns-api/serviceaccount.yaml
+++ b/yaml/fake-dns-api/serviceaccount.yaml
@@ -1,7 +1,6 @@
 # Fake DNS API: ServiceAccount
 #
-# ServiceAccount for the fake DNS API pod. Required for OpenShift security
-# context constraints when running with elevated privileges for port 53.
+# ServiceAccount for the fake DNS API pod.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/yaml/pebble/deployment.yaml
+++ b/yaml/pebble/deployment.yaml
@@ -47,14 +47,9 @@ spec:
             port: 14000
             scheme: HTTPS
           initialDelaySeconds: 5
-          periodSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /dir
-            port: 14000
-            scheme: HTTPS
-          initialDelaySeconds: 10
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         volumeMounts:
         - name: config
           mountPath: /test/config

--- a/yaml/pebble/deployment.yaml
+++ b/yaml/pebble/deployment.yaml
@@ -41,6 +41,20 @@ spec:
           value: "1"
         - name: PEBBLE_VA_ALWAYS_VALID
           value: "${PEBBLE_ALWAYS_VALID}"
+        readinessProbe:
+          httpGet:
+            path: /dir
+            port: 14000
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /dir
+            port: 14000
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - name: config
           mountPath: /test/config

--- a/yaml/pebble/deployment.yaml
+++ b/yaml/pebble/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: pebble
-        image: ghcr.io/letsencrypt/pebble:v2.10.1
+        image: ghcr.io/letsencrypt/pebble:2.10.1
         imagePullPolicy: IfNotPresent
         args:
         - -config


### PR DESCRIPTION
## Summary

- Move fake-dns off privileged port 53 to unprivileged port 5353 (Service still exposes port 53 externally — consumers are unaffected)
- Remove `anyuid` SCC grant from fake-dns install script (no longer needed)
- Add hardened `securityContext` to both fake-dns and Pebble containers: `runAsNonRoot`, `allowPrivilegeEscalation: false`, drop ALL capabilities, `RuntimeDefault` seccomp profile
- Update stale comments and documentation referencing root/port 53

## Test plan

- [ ] `make lint` passes
- [ ] CI `quick-http-test` passes (validates Pebble with new securityContext)
- [ ] CI `quick-dns-test` passes (validates fake-dns on port 5353 with non-root)

Closes #50
Closes #51