### PR TITLE
Add OCP 4.22 to CI integration test matrix

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -137,7 +137,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocp-version: ['4.20', '4.21']
+        ocp-version: ['4.20', '4.21', '4.22']
         cert-manager-version: ['v1.19.0', 'v1.20.0']
     uses: ./.github/workflows/reusable-integration-test.yml
     with:


### PR DESCRIPTION
## Summary

- Add OCP 4.22 to the integration test matrix in `pre-main.yml`
- Expands the CI matrix from 4 jobs (2 OCP x 2 CM) to 6 jobs (3 OCP x 2 CM)
- OCP 4.22 is now available in quick-ocp

## Test plan

- [ ] `make lint` passes
- [ ] OCP 4.22 integration test jobs run successfully