### PR TITLE
Add load_env to all scripts so .env overrides work everywhere

### DIFF
--- a/scripts/check-cluster-network.sh
+++ b/scripts/check-cluster-network.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 # CYAN color not defined in common.sh, add locally
 CYAN='\033[0;36m'

--- a/scripts/create-apiserver-certificate.sh
+++ b/scripts/create-apiserver-certificate.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 # Configuration
 ISSUER_NAME="${ISSUER_NAME:-pebble-issuer}"

--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"
 

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"
 

--- a/scripts/create-selfsigned-issuer.sh
+++ b/scripts/create-selfsigned-issuer.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"
 

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/certificates"
 

--- a/scripts/ibu/capture-cert-state.sh
+++ b/scripts/ibu/capture-cert-state.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 setup_cleanup
 
 # Configuration

--- a/scripts/ibu/create-multi-algo-certs.sh
+++ b/scripts/ibu/create-multi-algo-certs.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 setup_cleanup
 
 # Configuration

--- a/scripts/ibu/install-minio.sh
+++ b/scripts/ibu/install-minio.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/minio"

--- a/scripts/ibu/install-oadp.sh
+++ b/scripts/ibu/install-oadp.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/oadp"

--- a/scripts/ibu/label-cert-resources.sh
+++ b/scripts/ibu/label-cert-resources.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 setup_cleanup
 
 # Configuration

--- a/scripts/ibu/run-ibu-preserved-test.sh
+++ b/scripts/ibu/run-ibu-preserved-test.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
+load_env
 setup_cleanup
 
 # Configuration

--- a/scripts/ibu/run-ibu-test.sh
+++ b/scripts/ibu/run-ibu-test.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
+load_env
 setup_cleanup
 
 # Configuration

--- a/scripts/ibu/simulate-ibu-backup-restore.sh
+++ b/scripts/ibu/simulate-ibu-backup-restore.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/backup"

--- a/scripts/ibu/simulate-ibu-preserved.sh
+++ b/scripts/ibu/simulate-ibu-preserved.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/backup"

--- a/scripts/ibu/verify-key-formats.sh
+++ b/scripts/ibu/verify-key-formats.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 setup_cleanup
 
 # Configuration

--- a/scripts/import-acmedns-image.sh
+++ b/scripts/import-acmedns-image.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 print_header "Import acme-dns Image"
 

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/fake-dns-api"
 

--- a/scripts/install-local-dns.sh
+++ b/scripts/install-local-dns.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/acme-dns"
 

--- a/scripts/install-monitoring.sh
+++ b/scripts/install-monitoring.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/monitoring"
 

--- a/scripts/install-pebble-challtestsrv.sh
+++ b/scripts/install-pebble-challtestsrv.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/pebble-challtestsrv"
 

--- a/scripts/install-pebble.sh
+++ b/scripts/install-pebble.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/pebble"
 

--- a/scripts/troubleshooting/verify-apiserver-certificate.sh
+++ b/scripts/troubleshooting/verify-apiserver-certificate.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
+load_env
 
 # Configuration
 CERT_NAMESPACE="${CERT_NAMESPACE:-openshift-config}"


### PR DESCRIPTION
## Summary

- Add `load_env` call to 23 scripts that use `${VAR:-default}` environment variable patterns
- Previously only `install-cert-manager-operator.sh` loaded `.env` — all other scripts silently ignored `.env` overrides
- Users can now set `PEBBLE_NAMESPACE`, `DNS_SERVER`, `CERT_MANAGER_VERSION`, etc. in a single `.env` file and have it apply consistently across all scripts

## Test plan

- [x] `make lint` passes
- [ ] CI integration tests pass

Closes #53