### PR TITLE
Add kind-based CI for fast portable testing

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -108,6 +108,23 @@ jobs:
             exit 1
           fi
 
+  kind-integration-test:
+    name: Kind Integration Test (CM ${{ matrix.cert-manager-version }})
+    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure]
+    if: |
+      needs.shell-format-check.result == 'success' &&
+      needs.shellcheck.result == 'success' &&
+      needs.workload-partitioning-check.result == 'success' &&
+      needs.verify-structure.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        cert-manager-version: ['v1.19.0', 'v1.20.0']
+    uses: ./.github/workflows/reusable-kind-integration-test.yml
+    with:
+      cert-manager-version: ${{ matrix.cert-manager-version }}
+      checkout-ref: ${{ github.sha }}
+
   integration-test:
     name: Integration Test (OCP ${{ matrix.ocp-version }} / CM ${{ matrix.cert-manager-version }})
     needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure]

--- a/.github/workflows/reusable-kind-integration-test.yml
+++ b/.github/workflows/reusable-kind-integration-test.yml
@@ -1,0 +1,131 @@
+name: Reusable Kind Integration Test
+
+on:
+  workflow_call:
+    inputs:
+      cert-manager-version:
+        required: false
+        type: string
+        default: 'v1.20.0'
+      checkout-ref:
+        required: false
+        type: string
+        default: ''
+
+env:
+  SHELL: /bin/bash
+  CLUSTER_TYPE: kubernetes
+  KUBE_CLI: kubectl
+  PEBBLE_ALWAYS_VALID: '1'
+  SKIP_CONFIRM: '1'
+
+jobs:
+  test:
+    name: kind / cert-manager ${{ inputs.cert-manager-version || 'default' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.checkout-ref || github.sha }}
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: cert-manager-test
+          wait: 120s
+
+      - name: Verify cluster access
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+          kubectl wait --for=condition=Ready nodes --all --timeout=120s
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install cert-manager via Helm
+        run: ./scripts/install-cert-manager-helm.sh
+        env:
+          CERT_MANAGER_VERSION: ${{ inputs.cert-manager-version }}
+
+      - name: Run quick HTTP-01 test
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 2
+          retry_on: error
+          on_retry_command: |
+            echo "=== Pebble diagnostics ==="
+            kubectl get pods -n pebble -o wide 2>/dev/null || true
+            kubectl get events -n pebble --sort-by='.lastTimestamp' 2>/dev/null | tail -15 || true
+            echo "=== cert-manager diagnostics ==="
+            kubectl get pods -n cert-manager 2>/dev/null || true
+          command: make quick-http-test
+
+      - name: Clean up HTTP-01 test resources
+        if: always()
+        timeout-minutes: 2
+        continue-on-error: true
+        run: make clean-certs clean-issuers || true
+
+      - name: Run quick self-signed CA test
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 2
+          retry_on: error
+          on_retry_command: |
+            echo "=== cert-manager diagnostics ==="
+            kubectl get pods -n cert-manager 2>/dev/null || true
+          command: make quick-selfsigned-test
+
+      - name: Clean up self-signed test resources
+        if: always()
+        timeout-minutes: 2
+        continue-on-error: true
+        run: make clean-selfsigned || true
+
+      - name: Run quick DNS-01 test
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 2
+          retry_on: error
+          on_retry_command: |
+            echo "=== Pebble diagnostics ==="
+            kubectl get pods -n pebble -o wide 2>/dev/null || true
+            kubectl get events -n pebble --sort-by='.lastTimestamp' 2>/dev/null | tail -15 || true
+            echo "=== fake-dns diagnostics ==="
+            kubectl get pods -n fake-dns -o wide 2>/dev/null || true
+          command: make quick-dns-test
+
+      - name: Clean up DNS-01 test resources
+        if: always()
+        timeout-minutes: 2
+        continue-on-error: true
+        run: make clean-certs clean-issuers clean-pebble clean-fake-dns || true
+
+      - name: Run multi-algorithm certificate test
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 5
+          max_attempts: 2
+          retry_on: error
+          command: make quick-multi-algo-test
+
+      - name: Display component status
+        if: always()
+        run: |
+          echo "cert-manager pods:"
+          kubectl get pods -n cert-manager || true
+          echo ""
+          echo "Pebble pods:"
+          kubectl get pods -n pebble || true
+          echo ""
+          echo "ClusterIssuer status:"
+          kubectl get clusterissuer -o wide || true
+          echo ""
+          echo "Certificate status:"
+          kubectl get certificate -n default || true

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test-output/
 # Screenshots and binary artifacts
 *.png
 
+.playwright-mcp/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
 # ────────────────────────────────────────────────────────────────────────────────
+# CLI Detection
+# ────────────────────────────────────────────────────────────────────────────────
+KUBE_CLI ?= $(shell command -v oc >/dev/null 2>&1 && echo oc || echo kubectl)
+CLUSTER_TYPE ?= $(shell command -v oc >/dev/null 2>&1 && oc whoami >/dev/null 2>&1 && echo openshift || echo kubernetes)
+export KUBE_CLI CLUSTER_TYPE
+
+# ────────────────────────────────────────────────────────────────────────────────
 # Color Definitions
 # ────────────────────────────────────────────────────────────────────────────────
 RESET := \033[0m
@@ -23,7 +30,7 @@ BG_BLUE := \033[44m
 # ────────────────────────────────────────────────────────────────────────────────
 # Target Definitions
 # ────────────────────────────────────────────────────────────────────────────────
-.PHONY: all help banner preflight lint install-cert-manager-operator install-pebble \
+.PHONY: all help banner preflight lint install-cert-manager-operator install-cert-manager-helm install-pebble \
         install-fake-dns install-all install-monitoring create-issuer create-dns01-issuer \
         create-selfsigned-issuer create-certs create-apiserver-cert verify-apiserver-cert \
         test-all test-dns01 quick-http-test quick-dns-test quick-selfsigned-test \
@@ -97,7 +104,7 @@ lint: ## Check shell script formatting with shfmt and shellcheck
 	  exit 1; \
 	fi
 	@echo "$(DIM)  Running shellcheck...$(RESET)"
-	@find . -name '*.sh' -type f -not -path './venv/*' | xargs shellcheck -e SC1091,SC2034 || (echo "$(RED)shellcheck failed!$(RESET)" && exit 1)
+	@find . -name '*.sh' -type f -not -path './venv/*' | xargs shellcheck -e SC1091,SC2034,SC2329 || (echo "$(RED)shellcheck failed!$(RESET)" && exit 1)
 	@if ! command -v shfmt >/dev/null 2>&1; then \
 	  echo "$(RED)shfmt not found. Please install it:$(RESET)"; \
 	  echo "$(DIM)  macOS: brew install shfmt$(RESET)"; \
@@ -125,6 +132,12 @@ install-cert-manager-operator: ## Install cert-manager Operator for Red Hat Open
 	@echo "$(BOLD)$(BLUE)Installing cert-manager Operator...$(RESET)"
 	@./scripts/install-cert-manager-operator.sh
 	@echo "$(GREEN)cert-manager Operator installation completed!$(RESET)"
+	@echo ""
+
+install-cert-manager-helm: ## Install cert-manager via Helm (vanilla Kubernetes)
+	@echo "$(BOLD)$(BLUE)Installing cert-manager via Helm...$(RESET)"
+	@./scripts/install-cert-manager-helm.sh
+	@echo "$(GREEN)cert-manager Helm installation completed!$(RESET)"
 	@echo ""
 
 install-pebble: ## Install Pebble ACME test server
@@ -172,22 +185,22 @@ verify-apiserver-cert: ## Verify API server certificate
 
 test-cert: ## Create a test wildcard certificate (DNS-01)
 	@echo "Creating test wildcard certificate..."
-	@printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: wildcard-test\n  namespace: default\nspec:\n  secretName: wildcard-test-tls\n  issuerRef:\n    name: pebble-dns01-issuer\n    kind: ClusterIssuer\n  dnsNames:\n  - "*.example.com"\n  - "example.com"\n' | oc apply -f -
+	@printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: wildcard-test\n  namespace: default\nspec:\n  secretName: wildcard-test-tls\n  issuerRef:\n    name: pebble-dns01-issuer\n    kind: ClusterIssuer\n  dnsNames:\n  - "*.example.com"\n  - "example.com"\n' | $(KUBE_CLI) apply -f -
 	@echo "Certificate created. Run 'make verify-cert' to check status."
 
 verify-cert: ## Verify certificate status
 	@echo ""
 	@echo "$(BOLD)Certificate Status$(RESET)"
 	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	@oc get certificate wildcard-test -n default 2>/dev/null || echo "Certificate not found"
+	@$(KUBE_CLI) get certificate wildcard-test -n default 2>/dev/null || echo "Certificate not found"
 	@echo ""
 	@echo "Orders:"
-	@oc get order -n default 2>/dev/null || echo "No orders found"
+	@$(KUBE_CLI) get order -n default 2>/dev/null || echo "No orders found"
 	@echo ""
 	@echo "Challenges:"
-	@oc get challenge -n default 2>/dev/null || echo "No challenges found"
+	@$(KUBE_CLI) get challenge -n default 2>/dev/null || echo "No challenges found"
 	@echo ""
-	@if oc get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+	@if $(KUBE_CLI) get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
 		echo "$(GREEN)Certificate is READY!$(RESET)"; \
 	else \
 		echo "$(YELLOW)Certificate is still being issued...$(RESET)"; \
@@ -222,19 +235,20 @@ test-dns01: install-fake-dns ## Complete DNS-01 setup (air-gapped)
 	@echo "Test with: make test-cert"
 	@echo "Monitor progress: watch oc get certificate -n default"
 
-quick-http-test: install-cert-manager-operator ## Quick end-to-end HTTP-01 test
+quick-http-test: ## Quick end-to-end HTTP-01 test
 	@echo ""
 	@echo "$(BOLD)$(BLUE)Quick HTTP-01 Test Running...$(RESET)"
 	@echo ""
+	@if [ "$(CLUSTER_TYPE)" = "openshift" ]; then $(MAKE) install-cert-manager-operator; else $(MAKE) install-cert-manager-helm; fi
 	@PEBBLE_ALWAYS_VALID=1 $(MAKE) install-pebble || true
 	@$(MAKE) create-issuer || true
-	@CLUSTER_DOMAIN=$$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "apps-crc.testing"); \
-	printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: test-cert-http01\n  namespace: default\nspec:\n  secretName: test-cert-http01-tls\n  issuerRef:\n    name: pebble-issuer\n    kind: ClusterIssuer\n  dnsNames:\n  - test.'"$$CLUSTER_DOMAIN"'\n' | oc apply -f -
+	@CLUSTER_DOMAIN=$$($(KUBE_CLI) get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "example.com"); \
+	printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: test-cert-http01\n  namespace: default\nspec:\n  secretName: test-cert-http01-tls\n  issuerRef:\n    name: pebble-issuer\n    kind: ClusterIssuer\n  dnsNames:\n  - test.'"$$CLUSTER_DOMAIN"'\n' | $(KUBE_CLI) apply -f -
 	@echo ""
 	@echo "Waiting for certificate (timeout: 3 minutes)..."
 	@timeout=180; elapsed=0; \
 	while [ $$elapsed -lt $$timeout ]; do \
-		if oc get certificate test-cert-http01 -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+		if $(KUBE_CLI) get certificate test-cert-http01 -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
 			echo "$(GREEN)Certificate issued successfully!$(RESET)"; \
 			break; \
 		fi; \
@@ -244,18 +258,18 @@ quick-http-test: install-cert-manager-operator ## Quick end-to-end HTTP-01 test
 	@echo ""
 	@echo "Quick HTTP-01 test complete! Run 'make clean' to clean up."
 
-quick-selfsigned-test: install-cert-manager-operator create-selfsigned-issuer ## Quick end-to-end self-signed CA test
+quick-selfsigned-test: create-selfsigned-issuer ## Quick end-to-end self-signed CA test
 	@echo ""
 	@echo "$(BOLD)$(BLUE)Quick Self-Signed CA Test Running...$(RESET)"
 	@echo ""
-	@CLUSTER_DOMAIN=$$(oc get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "apps-crc.testing"); \
+	@CLUSTER_DOMAIN=$$($(KUBE_CLI) get ingresses.config/cluster -o jsonpath='{.spec.domain}' 2>/dev/null || echo "example.com"); \
 	ISSUER_NAME=$$(echo "$${CA_ISSUER_NAME:-selfsigned-ca-issuer}"); \
-	printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: test-cert-selfsigned\n  namespace: default\nspec:\n  secretName: test-cert-selfsigned-tls\n  issuerRef:\n    name: '"$$ISSUER_NAME"'\n    kind: ClusterIssuer\n  dnsNames:\n  - test.'"$$CLUSTER_DOMAIN"'\n  - "*.'"$$CLUSTER_DOMAIN"'"\n' | oc apply -f -
+	printf 'apiVersion: cert-manager.io/v1\nkind: Certificate\nmetadata:\n  name: test-cert-selfsigned\n  namespace: default\nspec:\n  secretName: test-cert-selfsigned-tls\n  issuerRef:\n    name: '"$$ISSUER_NAME"'\n    kind: ClusterIssuer\n  dnsNames:\n  - test.'"$$CLUSTER_DOMAIN"'\n  - "*.'"$$CLUSTER_DOMAIN"'"\n' | $(KUBE_CLI) apply -f -
 	@echo ""
 	@echo "Waiting for certificate (timeout: 2 minutes)..."
 	@timeout=120; elapsed=0; \
 	while [ $$elapsed -lt $$timeout ]; do \
-		if oc get certificate test-cert-selfsigned -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+		if $(KUBE_CLI) get certificate test-cert-selfsigned -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
 			echo "$(GREEN)Certificate issued successfully!$(RESET)"; \
 			break; \
 		fi; \
@@ -272,7 +286,7 @@ quick-dns-test: test-dns01 test-cert ## Quick end-to-end DNS-01 test
 	@echo "Waiting for certificate (timeout: 5 minutes)..."
 	@timeout=300; elapsed=0; \
 	while [ $$elapsed -lt $$timeout ]; do \
-		if oc get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
+		if $(KUBE_CLI) get certificate wildcard-test -n default -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -q "True"; then \
 			echo "$(GREEN)Certificate issued successfully!$(RESET)"; \
 			break; \
 		fi; \
@@ -283,7 +297,7 @@ quick-dns-test: test-dns01 test-cert ## Quick end-to-end DNS-01 test
 	@echo ""
 	@echo "Quick DNS-01 test complete! Run 'make clean' to clean up."
 
-quick-multi-algo-test: install-cert-manager-operator create-multi-algo-certs ## Quick multi-algorithm certificate test (ECDSA, RSA, Ed25519)
+quick-multi-algo-test: create-multi-algo-certs ## Quick multi-algorithm certificate test (ECDSA, RSA, Ed25519)
 	@echo ""
 	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
 	@echo "  ╔═════════════════════════════════════════════════════════════╗"
@@ -394,8 +408,8 @@ test-ibu-multi-algo: ## Run IBU cert loss test with all key algorithms
 
 clean-multi-algo-certs: ## Clean up multi-algorithm test certificates
 	@echo "$(BOLD)$(YELLOW)Cleaning up multi-algorithm test certificates...$(RESET)"
-	@oc delete certificate -n default -l app=ibu-multi-algo-test --ignore-not-found=true 2>/dev/null || true
-	@oc delete secret -n default ibu-cert-ecdsa-p256-tls ibu-cert-ecdsa-p384-tls ibu-cert-rsa-2048-tls ibu-cert-rsa-4096-tls ibu-cert-ed25519-tls --ignore-not-found=true 2>/dev/null || true
+	@$(KUBE_CLI) delete certificate -n default -l app=ibu-multi-algo-test --ignore-not-found=true 2>/dev/null || true
+	@$(KUBE_CLI) delete secret -n default ibu-cert-ecdsa-p256-tls ibu-cert-ecdsa-p384-tls ibu-cert-rsa-2048-tls ibu-cert-rsa-4096-tls ibu-cert-ed25519-tls --ignore-not-found=true 2>/dev/null || true
 	@echo "$(GREEN)Multi-algorithm test certificates cleaned.$(RESET)"
 
 clean-ibu: ## Clean up IBU test resources (MinIO, OADP, backups)
@@ -419,47 +433,49 @@ clean-ibu: ## Clean up IBU test resources (MinIO, OADP, backups)
 
 clean-certs: ## Clean up certificates, orders, and challenges
 	@echo "$(BOLD)$(YELLOW)Cleaning up certificates...$(RESET)"
-	@oc delete certificates --all -n default --ignore-not-found=true
-	@oc delete certificaterequests --all -n default --ignore-not-found=true
-	@oc delete orders --all -n default --ignore-not-found=true
-	@oc delete challenges --all -n default --ignore-not-found=true
-	@oc delete secrets wildcard-test-tls test-cert-simple-tls test-cert-app-tls test-cert-api-tls test-cert-http01-tls -n default --ignore-not-found=true
+	@$(KUBE_CLI) delete certificates --all -n default --ignore-not-found=true
+	@$(KUBE_CLI) delete certificaterequests --all -n default --ignore-not-found=true
+	@$(KUBE_CLI) delete orders --all -n default --ignore-not-found=true
+	@$(KUBE_CLI) delete challenges --all -n default --ignore-not-found=true
+	@$(KUBE_CLI) delete secrets wildcard-test-tls test-cert-simple-tls test-cert-app-tls test-cert-api-tls test-cert-http01-tls -n default --ignore-not-found=true
 	@echo "$(GREEN)Certificates cleaned.$(RESET)"
 
 clean-pebble: ## Clean up Pebble ACME test server
 	@echo "$(BOLD)$(YELLOW)Cleaning up Pebble...$(RESET)"
-	@oc delete namespace pebble --ignore-not-found=true --timeout=60s --wait=false
-	@oc delete secret pebble-dns01-issuer-account-key pebble-issuer-account-key -n cert-manager --ignore-not-found=true
+	@$(KUBE_CLI) delete namespace pebble --ignore-not-found=true --timeout=60s --wait=false
+	@$(KUBE_CLI) delete secret pebble-dns01-issuer-account-key pebble-issuer-account-key -n cert-manager --ignore-not-found=true
 	@echo "$(GREEN)Pebble cleaned.$(RESET)"
 
 clean-fake-dns: ## Clean up fake DNS API
 	@echo "$(BOLD)$(YELLOW)Cleaning up fake DNS...$(RESET)"
-	@oc delete namespace fake-dns --ignore-not-found=true --timeout=60s --wait=false
+	@$(KUBE_CLI) delete namespace fake-dns --ignore-not-found=true --timeout=60s --wait=false
 	@echo "$(GREEN)Fake DNS cleaned.$(RESET)"
 
 clean-dns-config: ## Restore DNS configuration
 	@echo "Restoring DNS configuration..."
-	@oc patch dns.operator.openshift.io/default --type=json -p='[{"op": "remove", "path": "/spec/servers"}]' 2>/dev/null || true
+	@if [ "$(CLUSTER_TYPE)" = "openshift" ]; then \
+		$(KUBE_CLI) patch dns.operator.openshift.io/default --type=json -p='[{"op": "remove", "path": "/spec/servers"}]' 2>/dev/null || true; \
+	fi
 	@echo "DNS configuration restored."
 
 clean-issuers: ## Clean up ClusterIssuers (ACME/Pebble)
 	@echo "$(BOLD)$(YELLOW)Cleaning up ClusterIssuers...$(RESET)"
-	@oc delete clusterissuer pebble-issuer pebble-dns01-issuer --ignore-not-found=true
-	@oc delete secret rfc2136-credentials -n default --ignore-not-found=true
+	@$(KUBE_CLI) delete clusterissuer pebble-issuer pebble-dns01-issuer --ignore-not-found=true
+	@$(KUBE_CLI) delete secret rfc2136-credentials -n default --ignore-not-found=true
 	@echo "$(GREEN)ClusterIssuers cleaned.$(RESET)"
 
 clean-selfsigned: ## Clean up self-signed CA chain
 	@echo "$(BOLD)$(YELLOW)Cleaning up self-signed CA resources...$(RESET)"
-	@oc delete certificate test-cert-selfsigned -n default --ignore-not-found=true
-	@oc delete secret test-cert-selfsigned-tls -n default --ignore-not-found=true
-	@oc delete clusterissuer selfsigned-ca-issuer selfsigned-issuer --ignore-not-found=true
-	@oc delete certificate root-ca -n cert-manager --ignore-not-found=true
-	@oc delete secret root-ca-secret -n cert-manager --ignore-not-found=true
+	@$(KUBE_CLI) delete certificate test-cert-selfsigned -n default --ignore-not-found=true
+	@$(KUBE_CLI) delete secret test-cert-selfsigned-tls -n default --ignore-not-found=true
+	@$(KUBE_CLI) delete clusterissuer selfsigned-ca-issuer selfsigned-issuer --ignore-not-found=true
+	@$(KUBE_CLI) delete certificate root-ca -n cert-manager --ignore-not-found=true
+	@$(KUBE_CLI) delete secret root-ca-secret -n cert-manager --ignore-not-found=true
 	@echo "$(GREEN)Self-signed CA resources cleaned.$(RESET)"
 
 clean-monitoring: ## Clean up cert-manager monitoring resources
 	@echo "$(BOLD)$(YELLOW)Cleaning up monitoring resources...$(RESET)"
-	@oc delete servicemonitor/cert-manager prometheusrule/cert-manager-alerts -n cert-manager --ignore-not-found=true
+	@$(KUBE_CLI) delete servicemonitor/cert-manager prometheusrule/cert-manager-alerts -n cert-manager --ignore-not-found=true
 	@echo "$(GREEN)Monitoring resources cleaned.$(RESET)"
 
 clean-temp: ## Clean up temporary files

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -83,6 +83,33 @@ log_debug() {
 }
 
 # ============================================================================
+# CLUSTER TYPE DETECTION
+# ============================================================================
+detect_cluster_type() {
+	if command -v oc &>/dev/null && oc whoami &>/dev/null 2>&1; then
+		CLUSTER_TYPE="openshift"
+		KUBE_CLI="oc"
+	elif command -v kubectl &>/dev/null && kubectl config current-context &>/dev/null 2>&1; then
+		CLUSTER_TYPE="kubernetes"
+		KUBE_CLI="kubectl"
+	elif command -v oc &>/dev/null; then
+		CLUSTER_TYPE="openshift"
+		KUBE_CLI="oc"
+	elif command -v kubectl &>/dev/null; then
+		CLUSTER_TYPE="kubernetes"
+		KUBE_CLI="kubectl"
+	else
+		CLUSTER_TYPE="unknown"
+		KUBE_CLI="kubectl"
+	fi
+	export CLUSTER_TYPE KUBE_CLI
+}
+
+if [[ -z "${CLUSTER_TYPE:-}" ]]; then
+	detect_cluster_type
+fi
+
+# ============================================================================
 # DEPENDENCY CHECKING
 # ============================================================================
 # Check if required commands are available
@@ -108,18 +135,20 @@ require_cmd() {
 # Verify cluster connectivity
 # Usage: require_cluster
 require_cluster() {
-	if ! command -v oc &>/dev/null; then
-		log_error "OpenShift CLI (oc) not found."
-		exit 1
+	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+		if ! oc whoami &>/dev/null 2>&1; then
+			log_error "Not connected to OpenShift cluster. Run 'oc login' first."
+			exit 1
+		fi
+		log_debug "Connected to cluster as: $(oc whoami)"
+		log_debug "Cluster: $(oc whoami --show-server 2>/dev/null || echo 'unknown')"
+	else
+		if ! kubectl cluster-info &>/dev/null 2>&1; then
+			log_error "Not connected to Kubernetes cluster. Check KUBECONFIG."
+			exit 1
+		fi
+		log_debug "Connected to cluster: $(kubectl config current-context 2>/dev/null || echo 'unknown')"
 	fi
-
-	if ! oc whoami &>/dev/null 2>&1; then
-		log_error "Not connected to OpenShift cluster. Run 'oc login' first."
-		exit 1
-	fi
-
-	log_debug "Connected to cluster as: $(oc whoami)"
-	log_debug "Cluster: $(oc whoami --show-server 2>/dev/null || echo 'unknown')"
 }
 
 # ============================================================================
@@ -278,44 +307,11 @@ confirm() {
 # Check if running with cluster-admin privileges
 require_cluster_admin() {
 	require_cluster
-	if ! oc auth can-i '*' '*' --all-namespaces &>/dev/null; then
+	if ! "$KUBE_CLI" auth can-i '*' '*' --all-namespaces &>/dev/null; then
 		log_error "Cluster-admin privileges required."
 		exit 1
 	fi
 	log_debug "Cluster-admin privileges confirmed"
-}
-
-# Wait for critical cluster operators to be healthy before deploying workloads.
-# Checks dns, network, and ingress operators — degraded state in any of these
-# prevents pods from scheduling, pulling images, or receiving traffic.
-# Usage: require_healthy_cluster [max_attempts] [interval]
-require_healthy_cluster() {
-	local max_attempts="${1:-30}"
-	local interval="${2:-10}"
-
-	check_critical_operators() {
-		local unhealthy
-		unhealthy=$(oc get clusteroperator dns network ingress \
-			-o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' 2>/dev/null |
-			grep -cve '^True$' || true)
-		[ "$unhealthy" -eq 0 ]
-	}
-
-	log_info "Checking critical cluster operators (dns, network, ingress)..."
-	if check_critical_operators; then
-		log_info "Critical cluster operators are healthy."
-		return 0
-	fi
-
-	log_warn "Critical cluster operators not yet healthy. Waiting up to $((max_attempts * interval))s..."
-	if wait_for_condition "$max_attempts" "$interval" check_critical_operators; then
-		log_success "Critical cluster operators are healthy."
-	else
-		log_error "Critical cluster operators still unhealthy after $((max_attempts * interval))s."
-		log_error "Operator status:"
-		oc get clusteroperator dns network ingress 2>/dev/null || true
-		return 1
-	fi
 }
 
 # Wait for a resource to be ready
@@ -326,7 +322,7 @@ wait_for_resource() {
 	local timeout="${3:-300s}"
 
 	log_info "Waiting for $resource to be ready..."
-	if oc wait --for=condition=available --timeout="$timeout" "$resource" -n "$namespace"; then
+	if "$KUBE_CLI" wait --for=condition=available --timeout="$timeout" "$resource" -n "$namespace"; then
 		log_success "$resource is ready"
 		return 0
 	else
@@ -343,29 +339,74 @@ dump_resource_diagnostics() {
 	local resource="${2:-}"
 
 	log_warn "--- Diagnostics for namespace '$namespace' ---"
-	oc get pods -n "$namespace" -o wide 2>/dev/null || true
+	"$KUBE_CLI" get pods -n "$namespace" -o wide 2>/dev/null || true
 	if [[ -n "$resource" ]]; then
-		oc describe "$resource" -n "$namespace" 2>/dev/null | tail -30 || true
+		"$KUBE_CLI" describe "$resource" -n "$namespace" 2>/dev/null | tail -30 || true
 	fi
-	oc get events -n "$namespace" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+	"$KUBE_CLI" get events -n "$namespace" --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
 	log_warn "--- End diagnostics ---"
 }
 
 # Verify cert-manager is installed and webhook is ready
 require_cert_manager() {
-	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
-		log_error "cert-manager not found. Please install cert-manager-operator first."
-		log_info "  Run: make install-cert-manager-operator"
+	if ! "$KUBE_CLI" get deployment -n cert-manager cert-manager &>/dev/null; then
+		log_error "cert-manager not found."
+		log_info "  Run: make install-cert-manager-operator (OpenShift) or make install-cert-manager-helm (Kubernetes)"
 		exit 1
 	fi
 
 	log_info "Waiting for cert-manager webhook to be ready..."
-	if ! oc wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager; then
+	if ! $KUBE_CLI wait --for=condition=available --timeout=120s deployment/cert-manager-webhook -n cert-manager; then
 		log_error "Timeout waiting for cert-manager webhook to be ready."
-		log_info "  Check webhook status: oc get deployment cert-manager-webhook -n cert-manager"
 		exit 1
 	fi
 	log_info "cert-manager webhook is ready."
+}
+
+# Wait for cluster health (OpenShift: cluster operators, Kubernetes: node readiness)
+# Usage: require_healthy_cluster [max_attempts] [interval]
+require_healthy_cluster() {
+	local max_attempts="${1:-30}"
+	local interval="${2:-10}"
+
+	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+		check_critical_operators() {
+			local unhealthy
+			unhealthy=$("$KUBE_CLI" get clusteroperator dns network ingress \
+				-o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Available")].status}{"\n"}{end}' 2>/dev/null |
+				grep -cve '^True' || true)
+			[ "$unhealthy" -eq 0 ]
+		}
+
+		if check_critical_operators; then
+			log_info "Critical cluster operators are healthy."
+			return 0
+		fi
+
+		log_info "Waiting for critical cluster operators (dns, network, ingress)..."
+		if wait_for_condition "$max_attempts" "$interval" check_critical_operators; then
+			log_success "Critical cluster operators are healthy."
+		else
+			log_error "Critical cluster operators not healthy after $((max_attempts * interval))s."
+			"$KUBE_CLI" get clusteroperator dns network ingress 2>/dev/null || true
+			return 1
+		fi
+	else
+		check_nodes_ready() {
+			local not_ready
+			not_ready=$("$KUBE_CLI" get nodes --no-headers 2>/dev/null | grep -cve '\sReady\s' || true)
+			[ "$not_ready" -eq 0 ]
+		}
+
+		log_info "Checking node readiness..."
+		if wait_for_condition "$max_attempts" "$interval" check_nodes_ready; then
+			log_success "All nodes are ready."
+		else
+			log_error "Nodes not ready after $((max_attempts * interval))s."
+			"$KUBE_CLI" get nodes 2>/dev/null || true
+			return 1
+		fi
+	fi
 }
 
 # Print a formatted section header
@@ -391,7 +432,7 @@ apply_yaml_template() {
 	fi
 
 	log_info "Applying $resource_type from $(basename "$yaml_file")..."
-	envsubst <"$yaml_file" | oc apply -f -
+	envsubst <"$yaml_file" | "$KUBE_CLI" apply -f -
 }
 
 # Create a namespace if it doesn't exist
@@ -399,11 +440,11 @@ apply_yaml_template() {
 ensure_namespace() {
 	local namespace="$1"
 
-	if oc get namespace "$namespace" &>/dev/null; then
+	if "$KUBE_CLI" get namespace "$namespace" &>/dev/null; then
 		log_info "Namespace '$namespace' already exists."
 	else
 		log_info "Creating namespace '$namespace'..."
-		oc create namespace "$namespace"
+		"$KUBE_CLI" create namespace "$namespace"
 		log_info "Namespace '$namespace' created successfully."
 	fi
 }
@@ -415,20 +456,12 @@ check_deployment_exists() {
 	local deployment="$1"
 	local namespace="$2"
 
-	if ! oc get namespace "$namespace" &>/dev/null; then
-		return 1
-	fi
+	local info
+	info=$("$KUBE_CLI" get deployment "$deployment" -n "$namespace" \
+		-o jsonpath='{.spec.replicas},{.status.readyReplicas}' 2>/dev/null) || return 1
 
-	if ! oc get deployment "$deployment" -n "$namespace" &>/dev/null; then
-		return 1
-	fi
-
-	local ready_replicas
-	ready_replicas=$(oc get deployment "$deployment" -n "$namespace" \
-		-o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
-	local desired_replicas
-	desired_replicas=$(oc get deployment "$deployment" -n "$namespace" \
-		-o jsonpath='{.spec.replicas}' 2>/dev/null || echo "1")
+	local desired_replicas="${info%%,*}"
+	local ready_replicas="${info##*,}"
 
 	if [[ "$ready_replicas" = "$desired_replicas" ]] && [[ "$ready_replicas" != "0" ]]; then
 		return 0

--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -22,7 +22,7 @@ print_header "Create DNS-01 ClusterIssuer"
 require_cluster
 
 check_pebble_responding() {
-	oc get deployment pebble -n "${PEBBLE_NAMESPACE:-pebble}" -o jsonpath='{.status.availableReplicas}' 2>/dev/null | grep -q '^[1-9]'
+	"$KUBE_CLI" get deployment pebble -n "${PEBBLE_NAMESPACE:-pebble}" -o jsonpath='{.status.availableReplicas}' 2>/dev/null | grep -q '^[1-9]'
 }
 
 log_info "Waiting for Pebble ACME server to be available..."
@@ -35,18 +35,18 @@ else
 fi
 
 log_info "Creating dummy RFC2136 secret in cert-manager namespace..."
-oc create secret generic rfc2136-credentials \
+"$KUBE_CLI" create secret generic rfc2136-credentials \
 	--from-literal=tsig-secret="$(echo -n "dummy-secret-key" | base64)" \
 	--namespace cert-manager \
-	--dry-run=client -o yaml | oc apply -f -
+	--dry-run=client -o yaml | "$KUBE_CLI" apply -f -
 
 apply_yaml_template "$YAML_DIR/pebble-dns01-simple-clusterissuer.yaml" "DNS-01 ClusterIssuer"
 
 log_info "Waiting for ClusterIssuer to be ready..."
-retry 5 10 oc wait --for=condition=Ready clusterissuer/"$ISSUER_NAME" --timeout=30s 2>/dev/null
+retry 5 10 "$KUBE_CLI" wait --for=condition=Ready clusterissuer/"$ISSUER_NAME" --timeout=30s 2>/dev/null
 
-if oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
-	oc get clusterissuer "$ISSUER_NAME"
+if "$KUBE_CLI" get clusterissuer "$ISSUER_NAME" &>/dev/null; then
+	"$KUBE_CLI" get clusterissuer "$ISSUER_NAME"
 	echo
 	log_info "DNS-01 ClusterIssuer created!"
 	echo

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -15,12 +15,16 @@ YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"
 export ISSUER_NAME="${ISSUER_NAME:-pebble-issuer}"
 export ACME_SERVER_URL="${ACME_SERVER_URL:-https://pebble.pebble.svc.cluster.local:14000/dir}"
 export ACME_EMAIL="${ACME_EMAIL:-test@example.com}"
-export INGRESS_CLASS="${INGRESS_CLASS:-openshift-default}"
+if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+	export INGRESS_CLASS="${INGRESS_CLASS:-openshift-default}"
+else
+	export INGRESS_CLASS="${INGRESS_CLASS:-}"
+fi
 
 check_pebble() {
 	log_info "Checking if Pebble is available..."
 
-	if ! oc get deployment -n pebble pebble &>/dev/null; then
+	if ! "$KUBE_CLI" get deployment -n pebble pebble &>/dev/null; then
 		log_warn "Pebble ACME server not found."
 		log_info "This issuer will point to: $ACME_SERVER_URL"
 		log_warn "If using Pebble, install it first: make install-pebble"
@@ -33,7 +37,7 @@ check_pebble() {
 		log_info "Pebble ACME server is available."
 
 		local ready_replicas
-		ready_replicas=$(oc get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+		ready_replicas=$("$KUBE_CLI" get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 		if [ "$ready_replicas" = "0" ]; then
 			log_warn "Pebble deployment exists but no replicas are ready."
 		else
@@ -45,11 +49,11 @@ check_pebble() {
 check_existing_issuer() {
 	log_info "Checking for existing ClusterIssuer '$ISSUER_NAME'..."
 
-	if oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
+	if "$KUBE_CLI" get clusterissuer "$ISSUER_NAME" &>/dev/null; then
 		log_warn "ClusterIssuer '$ISSUER_NAME' already exists."
 
 		local current_server
-		current_server=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.server}' 2>/dev/null || echo "unknown")
+		current_server=$("$KUBE_CLI" get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.server}' 2>/dev/null || echo "unknown")
 		log_debug "Current ACME server: $current_server"
 
 		echo
@@ -76,7 +80,7 @@ create_issuer() {
 
 check_issuer_ready() {
 	local ready
-	ready=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+	ready=$("$KUBE_CLI" get clusterissuer "$ISSUER_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
 	[ "$ready" = "True" ]
 }
 
@@ -92,7 +96,7 @@ verify_issuer() {
 
 	echo
 	log_info "ClusterIssuer status:"
-	oc get clusterissuer "$ISSUER_NAME"
+	"$KUBE_CLI" get clusterissuer "$ISSUER_NAME"
 }
 
 # Function to display next steps
@@ -141,7 +145,7 @@ display_next_steps() {
 main() {
 	print_header "Create cert-manager ClusterIssuer"
 
-	require_cmd oc envsubst
+	require_cmd "$KUBE_CLI" envsubst
 	require_cluster
 	require_cert_manager
 

--- a/scripts/create-selfsigned-issuer.sh
+++ b/scripts/create-selfsigned-issuer.sh
@@ -32,17 +32,17 @@ check_existing_issuer() {
 
 	local exists=false
 
-	if oc get clusterissuer "$SELFSIGNED_ISSUER_NAME" &>/dev/null; then
+	if $KUBE_CLI get clusterissuer "$SELFSIGNED_ISSUER_NAME" &>/dev/null; then
 		log_warn "ClusterIssuer '$SELFSIGNED_ISSUER_NAME' already exists."
 		exists=true
 	fi
 
-	if oc get clusterissuer "$CA_ISSUER_NAME" &>/dev/null; then
+	if $KUBE_CLI get clusterissuer "$CA_ISSUER_NAME" &>/dev/null; then
 		log_warn "ClusterIssuer '$CA_ISSUER_NAME' already exists."
 		exists=true
 	fi
 
-	if oc get certificate "$ROOT_CA_NAME" -n "$ROOT_CA_NAMESPACE" &>/dev/null; then
+	if $KUBE_CLI get certificate "$ROOT_CA_NAME" -n "$ROOT_CA_NAMESPACE" &>/dev/null; then
 		log_warn "Root CA Certificate '$ROOT_CA_NAME' already exists in namespace '$ROOT_CA_NAMESPACE'."
 		exists=true
 	fi
@@ -74,7 +74,7 @@ create_selfsigned_issuer() {
 	apply_yaml_template "$YAML_DIR/selfsigned-clusterissuer.yaml" "SelfSigned ClusterIssuer"
 
 	log_info "Waiting for SelfSigned ClusterIssuer to be ready..."
-	retry 10 2 oc wait --for=condition=Ready clusterissuer/"$SELFSIGNED_ISSUER_NAME" --timeout=30s
+	retry 10 2 "$KUBE_CLI" wait --for=condition=Ready clusterissuer/"$SELFSIGNED_ISSUER_NAME" --timeout=30s
 	log_success "SelfSigned ClusterIssuer is ready."
 }
 
@@ -83,7 +83,7 @@ create_root_ca() {
 	apply_yaml_template "$YAML_DIR/root-ca-certificate.yaml" "Root CA Certificate"
 
 	log_info "Waiting for Root CA Certificate to be issued..."
-	retry 15 2 oc wait --for=condition=Ready certificate/"$ROOT_CA_NAME" -n "$ROOT_CA_NAMESPACE" --timeout=30s
+	retry 15 2 "$KUBE_CLI" wait --for=condition=Ready certificate/"$ROOT_CA_NAME" -n "$ROOT_CA_NAMESPACE" --timeout=30s
 	log_success "Root CA Certificate is ready."
 }
 
@@ -92,7 +92,7 @@ create_ca_issuer() {
 	apply_yaml_template "$YAML_DIR/ca-clusterissuer.yaml" "CA ClusterIssuer"
 
 	log_info "Waiting for CA ClusterIssuer to be ready..."
-	retry 10 2 oc wait --for=condition=Ready clusterissuer/"$CA_ISSUER_NAME" --timeout=30s
+	retry 10 2 "$KUBE_CLI" wait --for=condition=Ready clusterissuer/"$CA_ISSUER_NAME" --timeout=30s
 	log_success "CA ClusterIssuer is ready."
 }
 
@@ -132,7 +132,7 @@ display_next_steps() {
 main() {
 	print_header "Create Self-Signed CA Chain"
 
-	require_cmd oc envsubst
+	require_cmd "$KUBE_CLI" envsubst
 	require_cluster
 	require_cert_manager
 

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -21,28 +21,28 @@ export CERT_NAMESPACE="${CERT_NAMESPACE:-default}"
 check_prerequisites() {
 	log_info "Checking prerequisites..."
 
-	require_cmd oc envsubst
+	require_cmd "$KUBE_CLI" envsubst
 	require_cluster
 
 	# Check if cert-manager is installed
-	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
+	if ! "$KUBE_CLI" get deployment -n cert-manager cert-manager &>/dev/null; then
 		log_error "cert-manager not found. Please install cert-manager-operator first."
 		log_info "  Run: make install-cert-manager-operator"
 		exit 1
 	fi
 
 	# Check if issuer exists
-	if ! oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
+	if ! "$KUBE_CLI" get clusterissuer "$ISSUER_NAME" &>/dev/null; then
 		log_error "ClusterIssuer '$ISSUER_NAME' not found."
 		log_info "  Create an issuer first: make create-issuer"
 		exit 1
 	fi
 
 	# Check if namespace exists
-	if ! oc get namespace "$CERT_NAMESPACE" &>/dev/null; then
+	if ! "$KUBE_CLI" get namespace "$CERT_NAMESPACE" &>/dev/null; then
 		log_warn "Namespace '$CERT_NAMESPACE' does not exist."
 		if confirm "Create namespace '$CERT_NAMESPACE'?"; then
-			oc create namespace "$CERT_NAMESPACE"
+			"$KUBE_CLI" create namespace "$CERT_NAMESPACE"
 			log_info "Namespace '$CERT_NAMESPACE' created."
 		else
 			log_error "Cannot create certificates without target namespace."
@@ -67,7 +67,7 @@ create_certificate() {
 	log_info "Creating certificate: $cert_name ($description)..."
 
 	# Check if certificate already exists
-	if oc get certificate "$cert_name" -n "$CERT_NAMESPACE" &>/dev/null; then
+	if "$KUBE_CLI" get certificate "$cert_name" -n "$CERT_NAMESPACE" &>/dev/null; then
 		log_warn "Certificate '$cert_name' already exists in namespace '$CERT_NAMESPACE'."
 		return 0
 	fi
@@ -115,9 +115,9 @@ show_http01_flow() {
 
 check_test_certs_ready() {
 	for cert in test-cert-simple test-cert-app test-cert-api; do
-		if oc get certificate "$cert" -n "$CERT_NAMESPACE" &>/dev/null; then
+		if "$KUBE_CLI" get certificate "$cert" -n "$CERT_NAMESPACE" &>/dev/null; then
 			local ready
-			ready=$(oc get certificate "$cert" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' || echo "False")
+			ready=$("$KUBE_CLI" get certificate "$cert" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' || echo "False")
 			[ "$ready" != "True" ] && return 1
 		fi
 	done
@@ -142,19 +142,19 @@ display_certificate_status() {
 	print_header "Certificate Status"
 
 	log_info "Certificates:"
-	oc get certificate -n "$CERT_NAMESPACE" 2>/dev/null || echo "No certificates found"
+	"$KUBE_CLI" get certificate -n "$CERT_NAMESPACE" 2>/dev/null || echo "No certificates found"
 
 	echo
 	log_info "Certificate Requests:"
-	oc get certificaterequest -n "$CERT_NAMESPACE" 2>/dev/null || echo "No certificate requests found"
+	"$KUBE_CLI" get certificaterequest -n "$CERT_NAMESPACE" 2>/dev/null || echo "No certificate requests found"
 
 	echo
 	log_info "ACME Orders:"
-	oc get order -n "$CERT_NAMESPACE" 2>/dev/null || echo "No orders found"
+	"$KUBE_CLI" get order -n "$CERT_NAMESPACE" 2>/dev/null || echo "No orders found"
 
 	echo
 	log_info "ACME Challenges:"
-	oc get challenge -n "$CERT_NAMESPACE" 2>/dev/null || echo "No challenges found"
+	"$KUBE_CLI" get challenge -n "$CERT_NAMESPACE" 2>/dev/null || echo "No challenges found"
 }
 
 # Function to display next steps
@@ -178,7 +178,7 @@ display_next_steps() {
 
 	# Check if certificates failed
 	local failed_certs
-	failed_certs=$(oc get certificate -n "$CERT_NAMESPACE" -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="False")) | .metadata.name' | wc -l | tr -d ' ')
+	failed_certs=$("$KUBE_CLI" get certificate -n "$CERT_NAMESPACE" -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="False")) | .metadata.name' | wc -l | tr -d ' ')
 
 	if [ "$failed_certs" -gt 0 ]; then
 		echo

--- a/scripts/ibu/create-multi-algo-certs.sh
+++ b/scripts/ibu/create-multi-algo-certs.sh
@@ -29,20 +29,20 @@ ALGO_SPECS=(
 
 check_prerequisites() {
 	log_info "Checking prerequisites..."
-	require_cmd oc jq
+	require_cmd "$KUBE_CLI" jq
 	require_cluster
 	require_cert_manager
 	log_success "Prerequisites met."
 }
 
 ensure_selfsigned_issuer() {
-	if oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
+	if "$KUBE_CLI" get clusterissuer "$ISSUER_NAME" &>/dev/null; then
 		log_info "ClusterIssuer '$ISSUER_NAME' already exists."
 		return 0
 	fi
 
 	log_info "Creating selfsigned ClusterIssuer..."
-	cat <<EOF | oc apply -f -
+	cat <<EOF | "$KUBE_CLI" apply -f -
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -60,7 +60,7 @@ create_algo_certificate() {
 	local cert_name="ibu-cert-${name_suffix}"
 	local secret_name="${cert_name}-tls"
 
-	if oc get certificate "$cert_name" -n "$TARGET_NAMESPACE" &>/dev/null; then
+	if "$KUBE_CLI" get certificate "$cert_name" -n "$TARGET_NAMESPACE" &>/dev/null; then
 		log_warn "Certificate '$cert_name' already exists, skipping."
 		return 0
 	fi
@@ -77,7 +77,7 @@ create_algo_certificate() {
     algorithm: $algorithm"
 	fi
 
-	cat <<EOF | oc apply -f -
+	cat <<EOF | "$KUBE_CLI" apply -f -
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -112,7 +112,7 @@ create_all_certificates() {
 
 check_all_certs_ready() {
 	local not_ready
-	not_ready=$(oc get certificates -n "$TARGET_NAMESPACE" -l app="$CERT_LABEL" -o json |
+	not_ready=$("$KUBE_CLI" get certificates -n "$TARGET_NAMESPACE" -l app="$CERT_LABEL" -o json |
 		jq '[.items[] | select((.status.conditions // [] | map(select(.type=="Ready" and .status=="True")) | length) == 0)] | length')
 	[ "$not_ready" -eq 0 ]
 }
@@ -136,7 +136,7 @@ verify_key_formats() {
 	local fail_count=0
 
 	local secrets_json
-	secrets_json=$(oc get secrets -n "$TARGET_NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
+	secrets_json=$("$KUBE_CLI" get secrets -n "$TARGET_NAMESPACE" -o json 2>/dev/null || echo '{"items":[]}')
 
 	printf "  %-22s %-18s %-18s %s\n" "CERTIFICATE" "EXPECTED" "ACTUAL" "STATUS"
 	printf "  %-22s %-18s %-18s %s\n" "───────────" "────────" "──────" "──────"

--- a/scripts/ibu/verify-key-formats.sh
+++ b/scripts/ibu/verify-key-formats.sh
@@ -18,7 +18,7 @@ TARGET_NAMESPACE="${TARGET_NAMESPACE:-default}"
 
 check_prerequisites() {
 	log_info "Checking prerequisites..."
-	require_cmd oc jq
+	require_cmd "$KUBE_CLI" jq
 	require_cluster
 	log_success "Prerequisites met."
 }

--- a/scripts/install-cert-manager-helm.sh
+++ b/scripts/install-cert-manager-helm.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+################################################################################
+# Script: install-cert-manager-helm.sh
+# Description: Install cert-manager via Helm for vanilla Kubernetes clusters
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+
+export CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
+export CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.20.0}"
+
+main() {
+	print_header "Install cert-manager via Helm"
+
+	require_cmd "$KUBE_CLI" helm envsubst
+	require_cluster
+
+	if check_deployment_exists cert-manager "$CERT_MANAGER_NAMESPACE"; then
+		log_info "cert-manager is already installed."
+		return 0
+	fi
+
+	log_info "Adding Jetstack Helm repository..."
+	helm repo add jetstack https://charts.jetstack.io --force-update
+	helm repo update jetstack
+
+	log_info "Installing cert-manager ${CERT_MANAGER_VERSION}..."
+	helm upgrade --install cert-manager jetstack/cert-manager \
+		--namespace "$CERT_MANAGER_NAMESPACE" \
+		--create-namespace \
+		--version "${CERT_MANAGER_VERSION#v}" \
+		--set crds.enabled=true \
+		--wait --timeout 300s
+
+	log_info "Verifying cert-manager installation..."
+	"$KUBE_CLI" get pods -n "$CERT_MANAGER_NAMESPACE"
+	wait_for_resource "deployment/cert-manager-webhook" "$CERT_MANAGER_NAMESPACE" "120s"
+
+	log_success "cert-manager ${CERT_MANAGER_VERSION} installed via Helm."
+}
+
+main

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -29,9 +29,9 @@ install_fake_dns() {
 verify_installation() {
 	log_info "Verifying fake-dns-api installation..."
 
-	oc get pods -n "$FAKEDNS_NAMESPACE"
+	"$KUBE_CLI" get pods -n "$FAKEDNS_NAMESPACE"
 	echo
-	oc get service fake-dns-api -n "$FAKEDNS_NAMESPACE"
+	"$KUBE_CLI" get service fake-dns-api -n "$FAKEDNS_NAMESPACE"
 	echo
 }
 
@@ -39,7 +39,7 @@ configure_coredns() {
 	log_info "Configuring CoreDNS to delegate example.com to fake DNS server..."
 
 	local fake_dns_ip
-	fake_dns_ip=$(oc get service fake-dns-api -n "$FAKEDNS_NAMESPACE" -o jsonpath='{.spec.clusterIP}')
+	fake_dns_ip=$("$KUBE_CLI" get service fake-dns-api -n "$FAKEDNS_NAMESPACE" -o jsonpath='{.spec.clusterIP}')
 
 	if [ -z "$fake_dns_ip" ]; then
 		log_error "Could not get fake-dns service ClusterIP"
@@ -48,26 +48,37 @@ configure_coredns() {
 
 	log_info "Fake DNS server IP: $fake_dns_ip"
 
-	if ! oc get configmap dns-default -n openshift-dns &>/dev/null; then
+	local dns_namespace dns_configmap dns_rollout_target
+	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+		dns_namespace="openshift-dns"
+		dns_configmap="dns-default"
+		dns_rollout_target="daemonset/dns-default"
+	else
+		dns_namespace="kube-system"
+		dns_configmap="coredns"
+		dns_rollout_target="deployment/coredns"
+	fi
+
+	if ! "$KUBE_CLI" get configmap "$dns_configmap" -n "$dns_namespace" &>/dev/null; then
 		log_warn "CoreDNS configmap not found, skipping CoreDNS configuration"
 		log_warn "You may need to manually configure DNS forwarding for example.com"
 		return
 	fi
 
 	local corefile
-	corefile=$(oc get configmap dns-default -n openshift-dns -o jsonpath='{.data.Corefile}')
+	corefile=$("$KUBE_CLI" get configmap "$dns_configmap" -n "$dns_namespace" -o jsonpath='{.data.Corefile}')
 
 	if echo "$corefile" | grep -q "example.com:53"; then
 		log_info "CoreDNS already configured for example.com"
 	else
 		log_info "Adding example.com zone to CoreDNS..."
 
-		cat <<EOF | oc apply -f -
+		cat <<EOF | "$KUBE_CLI" apply -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dns-default
-  namespace: openshift-dns
+  name: $dns_configmap
+  namespace: $dns_namespace
 data:
   Corefile: |
     example.com:53 {
@@ -91,7 +102,7 @@ data:
 EOF
 
 		log_info "CoreDNS configured. Waiting for DNS pods to restart..."
-		oc rollout status daemonset/dns-default -n openshift-dns --timeout=60s 2>/dev/null || log_warn "DNS rollout may still be in progress"
+		"$KUBE_CLI" rollout status "$dns_rollout_target" -n "$dns_namespace" --timeout=60s 2>/dev/null || log_warn "DNS rollout may still be in progress"
 	fi
 }
 
@@ -140,7 +151,7 @@ display_next_steps() {
 main() {
 	print_header "Install Fake DNS API (Air-gapped)"
 
-	require_cmd oc envsubst
+	require_cmd "$KUBE_CLI" envsubst
 	require_cluster
 	require_healthy_cluster
 

--- a/scripts/install-pebble.sh
+++ b/scripts/install-pebble.sh
@@ -24,7 +24,11 @@ install_pebble() {
 	apply_yaml_template "$YAML_DIR/configmap.yaml" "ConfigMap"
 	apply_yaml_template "$YAML_DIR/deployment.yaml" "Deployment"
 	apply_yaml_template "$YAML_DIR/service.yaml" "Service"
-	apply_yaml_template "$YAML_DIR/route.yaml" "Route"
+	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+		apply_yaml_template "$YAML_DIR/route.yaml" "Route"
+	else
+		log_info "Skipping Route (not on OpenShift)."
+	fi
 
 	log_info "Resources applied. Waiting for Pebble to be ready..."
 }
@@ -33,22 +37,24 @@ verify_installation() {
 	log_info "Verifying Pebble installation..."
 
 	log_info "Checking pod status..."
-	oc get pods -n "$PEBBLE_NAMESPACE"
+	"$KUBE_CLI" get pods -n "$PEBBLE_NAMESPACE"
 	echo
 
 	log_info "Checking service..."
-	oc get service pebble -n "$PEBBLE_NAMESPACE"
+	"$KUBE_CLI" get service pebble -n "$PEBBLE_NAMESPACE"
 	echo
 
-	log_info "Checking route..."
-	oc get route pebble-acme -n "$PEBBLE_NAMESPACE"
-	echo
+	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+		log_info "Checking route..."
+		"$KUBE_CLI" get route pebble-acme -n "$PEBBLE_NAMESPACE"
+		echo
 
-	local route_host
-	route_host=$(oc get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+		local route_host
+		route_host=$("$KUBE_CLI" get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 
-	if [ -n "$route_host" ]; then
-		log_info "Pebble ACME directory URL: https://${route_host}/dir"
+		if [ -n "$route_host" ]; then
+			log_info "Pebble ACME directory URL: https://${route_host}/dir"
+		fi
 	fi
 
 	local service_url="https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:14000/dir"
@@ -75,8 +81,10 @@ display_configuration() {
 }
 
 display_next_steps() {
-	local route_host
-	route_host=$(oc get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+	local route_host=""
+	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+		route_host=$("$KUBE_CLI" get route pebble-acme -n "$PEBBLE_NAMESPACE" -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+	fi
 	local service_url="https://pebble.${PEBBLE_NAMESPACE}.svc.cluster.local:14000/dir"
 
 	print_header "Installation Complete!"
@@ -127,7 +135,7 @@ display_next_steps() {
 main() {
 	print_header "Pebble ACME Test Server Installation"
 
-	require_cmd oc envsubst
+	require_cmd "$KUBE_CLI" envsubst
 	require_cluster
 
 	if [ ! -d "$YAML_DIR" ]; then

--- a/yaml/issuers/pebble-dns01-simple-clusterissuer.yaml
+++ b/yaml/issuers/pebble-dns01-simple-clusterissuer.yaml
@@ -34,6 +34,4 @@ spec:
           tsigSecretSecretRef:
             name: rfc2136-credentials
             key: tsig-secret
-            # For ClusterIssuer, secret must be in cert-manager namespace
-            namespace: cert-manager
 


### PR DESCRIPTION
## Summary

- Add `CLUSTER_TYPE`/`KUBE_CLI` auto-detection to `lib/common.sh` — scripts work on both OpenShift (`oc`) and vanilla Kubernetes (`kubectl`)
- Add `install-cert-manager-helm.sh` for Helm-based cert-manager installation on vanilla k8s
- Update all portable scripts to use `$KUBE_CLI` instead of hardcoded `oc`
- Add new kind-based CI workflow that runs HTTP-01, self-signed, DNS-01, and multi-algo tests in ~5 min (vs 30-45 min on CRC)
- Kind CI runs for all PRs (including Dependabot) — no pull secret required
- Existing CRC/OCP workflow unchanged — runs in parallel for OCP-specific tests

## Test plan

- [ ] Kind CI workflow passes (HTTP-01, self-signed, DNS-01, multi-algo)
- [ ] CRC/OCP workflow still passes (no regression from `$KUBE_CLI` changes)
- [ ] `make lint` passes
- [ ] OCP-only scripts (`install-cert-manager-operator.sh`, IBU, apiserver-cert) still use `oc`

Closes #55