### PR TITLE
Make MinIO credentials configurable via environment variables

### DIFF
--- a/scripts/ibu/install-minio.sh
+++ b/scripts/ibu/install-minio.sh
@@ -16,6 +16,8 @@ setup_cleanup
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/minio"
 MINIO_NAMESPACE="${MINIO_NAMESPACE:-minio}"
 export MINIO_VERSION="${MINIO_VERSION:-RELEASE.2025-09-07T16-13-09Z}"
+export MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minio}"
+export MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minio123}"
 
 check_prerequisites() {
 	log_info "Checking prerequisites..."
@@ -67,7 +69,7 @@ create_velero_bucket() {
 		--image=quay.io/minio/mc:latest \
 		-n "$MINIO_NAMESPACE" \
 		--command -- /bin/sh -c "
-			mc alias set myminio http://minio.minio.svc.cluster.local:9000 minio minio123 && \
+			mc alias set myminio http://minio.minio.svc.cluster.local:9000 ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} && \
 			mc mb --ignore-existing myminio/velero && \
 			echo 'Bucket created successfully'
 		" 2>/dev/null || {
@@ -92,7 +94,7 @@ verify_installation() {
 
 	if [ -n "$route_host" ]; then
 		log_info "MinIO Console URL: https://${route_host}"
-		log_info "Login with: minio / minio123"
+		log_info "Login with: ${MINIO_ACCESS_KEY} / ${MINIO_SECRET_KEY}"
 	fi
 	echo
 

--- a/scripts/ibu/install-oadp.sh
+++ b/scripts/ibu/install-oadp.sh
@@ -15,6 +15,8 @@ setup_cleanup
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/ibu/oadp"
 OADP_NAMESPACE="${OADP_NAMESPACE:-openshift-adp}"
+export MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minio}"
+export MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-minio123}"
 
 check_prerequisites() {
 	log_info "Checking prerequisites..."

--- a/yaml/ibu/minio/secret.yaml
+++ b/yaml/ibu/minio/secret.yaml
@@ -9,5 +9,5 @@ metadata:
   namespace: minio
 type: Opaque
 stringData:
-  accessKeyID: minio
-  secretAccessKey: minio123
+  accessKeyID: ${MINIO_ACCESS_KEY}
+  secretAccessKey: ${MINIO_SECRET_KEY}

--- a/yaml/ibu/oadp/cloud-credentials-secret.yaml
+++ b/yaml/ibu/oadp/cloud-credentials-secret.yaml
@@ -11,5 +11,5 @@ type: Opaque
 stringData:
   cloud: |
     [default]
-    aws_access_key_id=minio
-    aws_secret_access_key=minio123
+    aws_access_key_id=${MINIO_ACCESS_KEY}
+    aws_secret_access_key=${MINIO_SECRET_KEY}


### PR DESCRIPTION
Replace hardcoded `minio/minio123` credentials with `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` env vars processed by envsubst. Defaults preserve existing behavior.

## Changes
- `yaml/ibu/minio/secret.yaml` — use envsubst variables
- `yaml/ibu/oadp/cloud-credentials-secret.yaml` — use envsubst variables
- `scripts/ibu/install-minio.sh` — export vars with defaults, use in mc alias and login hint
- `scripts/ibu/install-oadp.sh` — export vars with defaults for cloud-credentials

Closes #74