### PR TITLE
Add configurable DEPLOYMENT_READY_TIMEOUT env var

### DIFF
--- a/scripts/ibu/install-minio.sh
+++ b/scripts/ibu/install-minio.sh
@@ -106,7 +106,7 @@ main() {
 		log_info "Verifying existing installation..."
 	else
 		install_minio
-		wait_for_resource "deployment/minio" "$MINIO_NAMESPACE" "300s"
+		wait_for_resource "deployment/minio" "$MINIO_NAMESPACE" "${DEPLOYMENT_READY_TIMEOUT:-300s}"
 		create_velero_bucket
 	fi
 

--- a/scripts/install-cert-manager-helm.sh
+++ b/scripts/install-cert-manager-helm.sh
@@ -38,7 +38,7 @@ main() {
 
 	log_info "Verifying cert-manager installation..."
 	"$KUBE_CLI" get pods -n "$CERT_MANAGER_NAMESPACE"
-	wait_for_resource "deployment/cert-manager-webhook" "$CERT_MANAGER_NAMESPACE" "120s"
+	wait_for_resource "deployment/cert-manager-webhook" "$CERT_MANAGER_NAMESPACE" "${DEPLOYMENT_READY_TIMEOUT:-120s}"
 
 	log_success "cert-manager ${CERT_MANAGER_VERSION} installed via Helm."
 }

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -157,7 +157,7 @@ main() {
 	require_healthy_cluster
 
 	install_fake_dns
-	wait_for_resource "deployment/fake-dns-api" "$FAKEDNS_NAMESPACE" "600s"
+	wait_for_resource "deployment/fake-dns-api" "$FAKEDNS_NAMESPACE" "${DEPLOYMENT_READY_TIMEOUT:-600s}"
 	verify_installation
 	configure_coredns
 	display_next_steps

--- a/scripts/install-local-dns.sh
+++ b/scripts/install-local-dns.sh
@@ -91,7 +91,7 @@ main() {
 	fi
 
 	install_acme_dns
-	wait_for_resource "deployment/acme-dns" "$ACMEDNS_NAMESPACE" "300s"
+	wait_for_resource "deployment/acme-dns" "$ACMEDNS_NAMESPACE" "${DEPLOYMENT_READY_TIMEOUT:-300s}"
 	verify_installation
 	display_next_steps
 }

--- a/scripts/install-pebble.sh
+++ b/scripts/install-pebble.sh
@@ -155,7 +155,7 @@ main() {
 	fi
 
 	install_pebble
-	wait_for_resource "deployment/pebble" "$PEBBLE_NAMESPACE" "600s"
+	wait_for_resource "deployment/pebble" "$PEBBLE_NAMESPACE" "${DEPLOYMENT_READY_TIMEOUT:-600s}"
 	verify_installation
 	display_next_steps
 }


### PR DESCRIPTION
All `wait_for_resource` calls now respect `DEPLOYMENT_READY_TIMEOUT` env var, allowing users to override deployment readiness timeouts. Defaults preserve existing behavior (600s for Pebble/fake-dns, 300s for acme-dns/MinIO, 120s for cert-manager webhook).

Closes #81