### PR TITLE
Add --help/-h support to scripts

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -83,6 +83,23 @@ log_debug() {
 }
 
 # ============================================================================
+# HELP FLAG HANDLING
+# ============================================================================
+# Parse --help/-h from the calling script's header comment block
+# Usage: check_help "$@" (call before any other logic)
+check_help() {
+	for arg in "$@"; do
+		case "$arg" in
+		-h | --help)
+			local caller="${BASH_SOURCE[1]:-$0}"
+			sed -n '/^#\{2,\}/,/^#\{2,\}/{/^#\{2,\}/d; s/^# \?//p}' "$caller"
+			return 0
+			;;
+		esac
+	done
+}
+
+# ============================================================================
 # CLUSTER TYPE DETECTION
 # ============================================================================
 detect_cluster_type() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -86,7 +86,7 @@ log_debug() {
 # HELP FLAG HANDLING
 # ============================================================================
 # Parse --help/-h from the calling script's header comment block
-# Usage: check_help "$@" (call before any other logic)
+# Usage: check_help "$@" && exit 0
 check_help() {
 	for arg in "$@"; do
 		case "$arg" in
@@ -97,6 +97,7 @@ check_help() {
 			;;
 		esac
 	done
+	return 1
 }
 
 # ============================================================================

--- a/scripts/check-cluster-network.sh
+++ b/scripts/check-cluster-network.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 # CYAN color not defined in common.sh, add locally

--- a/scripts/create-apiserver-certificate.sh
+++ b/scripts/create-apiserver-certificate.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 # Source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 # Configuration

--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"

--- a/scripts/create-issuer.sh
+++ b/scripts/create-issuer.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"

--- a/scripts/create-selfsigned-issuer.sh
+++ b/scripts/create-selfsigned-issuer.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/issuers"

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/certificates"

--- a/scripts/ibu/create-multi-algo-certs.sh
+++ b/scripts/ibu/create-multi-algo-certs.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 setup_cleanup
 

--- a/scripts/ibu/install-minio.sh
+++ b/scripts/ibu/install-minio.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 setup_cleanup
 

--- a/scripts/ibu/install-oadp.sh
+++ b/scripts/ibu/install-oadp.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 # Get script directory and source common library
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 setup_cleanup
 

--- a/scripts/install-cert-manager-helm.sh
+++ b/scripts/install-cert-manager-helm.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 
 export CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
 export CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.20.0}"

--- a/scripts/install-cert-manager-operator.sh
+++ b/scripts/install-cert-manager-operator.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
+check_help "$@" && exit 0
 load_env
 setup_cleanup
 

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/fake-dns-api"

--- a/scripts/install-local-dns.sh
+++ b/scripts/install-local-dns.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/acme-dns"

--- a/scripts/install-monitoring.sh
+++ b/scripts/install-monitoring.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/monitoring"

--- a/scripts/install-pebble-challtestsrv.sh
+++ b/scripts/install-pebble-challtestsrv.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/pebble-challtestsrv"

--- a/scripts/install-pebble.sh
+++ b/scripts/install-pebble.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
 load_env
 
 YAML_DIR="${SCRIPT_DIR}/../yaml/pebble"

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../lib/common.sh
 source "$SCRIPT_DIR/lib/common.sh"
+check_help "$@" && exit 0
 
 print_header "CERT-MANAGER SCRIPTS - PREFLIGHT CHECK"
 


### PR DESCRIPTION
Adds `check_help()` to `lib/common.sh` that parses the calling script's header comment block. Added `check_help "$@"` to 17 scripts so `./scripts/install-pebble.sh --help` shows the description.

Closes #73