### PR TITLE
Fix version-check workflows for parameterized YAML templates

### DIFF
--- a/.github/workflows/check-acme-dns-version.yml
+++ b/.github/workflows/check-acme-dns-version.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get current pinned version
         id: current
         run: |
-          current=$(grep 'joohoi/acme-dns:' yaml/acme-dns/deployment.yaml | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+          current=$(grep 'ACMEDNS_VERSION:-' scripts/install-local-dns.sh | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
           echo "version=$current" >> "$GITHUB_OUTPUT"
           echo "Current pinned version: $current"
 

--- a/.github/workflows/check-minio-version.yml
+++ b/.github/workflows/check-minio-version.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get current pinned version
         id: current
         run: |
-          current=$(grep 'quay.io/minio/minio:' yaml/ibu/minio/deployment.yaml | grep -oE 'RELEASE\.[0-9T-]+Z')
+          current=$(grep 'MINIO_VERSION:-' scripts/ibu/install-minio.sh | grep -oE 'RELEASE\.[0-9T-]+Z')
           echo "version=$current" >> "$GITHUB_OUTPUT"
           echo "Current pinned version: $current"
 

--- a/.github/workflows/check-pebble-version.yml
+++ b/.github/workflows/check-pebble-version.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get current pinned version
         id: current
         run: |
-          current=$(grep 'ghcr.io/letsencrypt/pebble:' yaml/pebble/deployment.yaml | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+          current=$(grep 'PEBBLE_VERSION:-' scripts/install-pebble.sh | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           echo "version=$current" >> "$GITHUB_OUTPUT"
           echo "Current pinned version: $current"
 

--- a/.github/workflows/check-ubi9-python-version.yml
+++ b/.github/workflows/check-ubi9-python-version.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get current pinned version
         id: current
         run: |
-          current=$(grep 'ubi9/python-39:' yaml/fake-dns-api/deployment.yaml | grep -oE '[0-9]+\.[0-9]+')
+          current=$(grep 'UBI9_PYTHON_VERSION:-' scripts/install-fake-dns.sh | grep -oE '[0-9]+\.[0-9]+')
           echo "version=$current" >> "$GITHUB_OUTPUT"
           echo "Current pinned version: $current"
 

--- a/scripts/workflows/query-version.sh
+++ b/scripts/workflows/query-version.sh
@@ -30,6 +30,7 @@ query_github_latest() {
 case "$component" in
 pebble)
 	query_github_latest "letsencrypt/pebble" "Pebble"
+	latest="${latest#v}"
 	;;
 
 acme-dns)

--- a/scripts/workflows/update-version.sh
+++ b/scripts/workflows/update-version.sh
@@ -20,16 +20,16 @@ fi
 
 case "$component" in
 pebble)
-	sed -i "s|ghcr.io/letsencrypt/pebble:${current}|ghcr.io/letsencrypt/pebble:${latest}|" \
-		yaml/pebble/deployment.yaml
-	sed -i "s|ghcr.io/letsencrypt/pebble-challtestsrv:${current}|ghcr.io/letsencrypt/pebble-challtestsrv:${latest}|" \
-		yaml/pebble-challtestsrv/deployment.yaml
-	echo "Updated Pebble from $current to $latest in both deployment files"
+	sed -i "s|PEBBLE_VERSION:-${current}|PEBBLE_VERSION:-${latest}|" \
+		scripts/install-pebble.sh
+	sed -i "s|PEBBLE_CHALLTESTSRV_VERSION:-v${current}|PEBBLE_CHALLTESTSRV_VERSION:-v${latest}|" \
+		scripts/install-pebble-challtestsrv.sh
+	echo "Updated Pebble from $current to $latest in both install scripts"
 	;;
 
 acme-dns)
-	sed -i "s|joohoi/acme-dns:${current}|joohoi/acme-dns:${latest}|" \
-		yaml/acme-dns/deployment.yaml
+	sed -i "s|ACMEDNS_VERSION:-${current}|ACMEDNS_VERSION:-${latest}|" \
+		scripts/install-local-dns.sh
 	echo "Updated acme-dns from $current to $latest"
 	;;
 
@@ -45,14 +45,14 @@ operator)
 	;;
 
 minio)
-	sed -i "s|quay.io/minio/minio:${current}|quay.io/minio/minio:${latest}|" \
-		yaml/ibu/minio/deployment.yaml
+	sed -i "s|MINIO_VERSION:-${current}|MINIO_VERSION:-${latest}|" \
+		scripts/ibu/install-minio.sh
 	echo "Updated MinIO from $current to $latest"
 	;;
 
 ubi9-python)
-	sed -i "s|ubi9/python-39:${current}|ubi9/python-39:${latest}|" \
-		yaml/fake-dns-api/deployment.yaml
+	sed -i "s|UBI9_PYTHON_VERSION:-${current}|UBI9_PYTHON_VERSION:-${latest}|" \
+		scripts/install-fake-dns.sh
 	echo "Updated UBI9 Python 3.9 from $current to $latest"
 	;;
 


### PR DESCRIPTION
## Summary

- All 4 version-check workflows (pebble, acme-dns, minio, ubi9-python) were broken because YAML deployment files now use envsubst variables instead of hardcoded image tags
- Updated workflows to extract current versions from install scripts (where the defaults live) instead of YAML templates
- Updated `update-version.sh` to modify the script defaults instead of YAML files
- Fixed Pebble version query to strip `v` prefix since ghcr.io image tags use bare versions

## Test plan

- [ ] `check-ubi9-python-version.yml` workflow dispatch succeeds
- [ ] `check-pebble-version.yml` workflow dispatch succeeds
- [ ] `check-minio-version.yml` workflow dispatch succeeds
- [ ] `check-acme-dns-version.yml` workflow dispatch succeeds