### PR TITLE
Add monitoring setup verification script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ BG_BLUE := \033[44m
         test-all test-dns01 quick-http-test quick-dns-test quick-selfsigned-test \
         test-cert verify-cert \
         status \
-        troubleshoot check-cert check-issuer check-network check-network-stack check-workload-partitioning \
+        troubleshoot check-cert check-issuer verify-monitoring check-network check-network-stack check-workload-partitioning \
         diagnose-http01 diagnose-dns01 clean clean-certs clean-pebble clean-fake-dns \
         clean-dns-config clean-issuers clean-selfsigned clean-monitoring clean-temp \
         clean-acmedns clean-challtestsrv \
@@ -80,7 +80,7 @@ help: banner ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(quick-|test-all|test-dns01)"
 	@echo ""
 	@echo "$(YELLOW)Troubleshooting:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(troubleshoot|diagnose|check-cert|check-issuer)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(troubleshoot|diagnose|check-cert|check-issuer|verify-monitoring)"
 	@echo ""
 	@echo "$(YELLOW)IBU Testing:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(ibu|minio|oadp|label-cert|validate-cert)"
@@ -384,6 +384,9 @@ diagnose-http01: ## Diagnose HTTP-01 challenge issues
 
 diagnose-dns01: ## Diagnose DNS-01 challenge issues
 	@./scripts/troubleshooting/diagnose-dns01.sh
+
+verify-monitoring: ## Verify cert-manager Prometheus monitoring setup
+	@./scripts/troubleshooting/verify-monitoring.sh
 
 # ────────────────────────────────────────────────────────────────────────────────
 # IBU Testing

--- a/scripts/troubleshooting/verify-monitoring.sh
+++ b/scripts/troubleshooting/verify-monitoring.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+################################################################################
+# Script: verify-monitoring.sh
+# Description: Verify cert-manager Prometheus monitoring and alert configuration
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
+
+CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
+METRICS_PORT="${METRICS_PORT:-9402}"
+EXPECTED_ALERTS="CertManagerAbsent CertManagerCertExpirySoon CertManagerCertNotReady CertManagerACMEClientErrors"
+
+pass_count=0
+fail_count=0
+
+record_pass() {
+	log_success "$1"
+	pass_count=$((pass_count + 1))
+}
+
+record_fail() {
+	log_error "$1"
+	fail_count=$((fail_count + 1))
+}
+
+check_service_monitor() {
+	if "$KUBE_CLI" get servicemonitor cert-manager -n "$CERT_MANAGER_NAMESPACE" &>/dev/null; then
+		record_pass "ServiceMonitor 'cert-manager' exists"
+	else
+		record_fail "ServiceMonitor 'cert-manager' not found"
+	fi
+}
+
+check_prometheus_rule() {
+	local rule_json
+	if ! rule_json=$("$KUBE_CLI" get prometheusrule cert-manager-alerts -n "$CERT_MANAGER_NAMESPACE" -o json 2>/dev/null); then
+		record_fail "PrometheusRule 'cert-manager-alerts' not found"
+		return
+	fi
+	record_pass "PrometheusRule 'cert-manager-alerts' exists"
+
+	for alert in $EXPECTED_ALERTS; do
+		if echo "$rule_json" | jq -e ".spec.groups[].rules[] | select(.alert==\"$alert\")" &>/dev/null; then
+			record_pass "Alert rule '$alert' configured"
+		else
+			record_fail "Alert rule '$alert' missing"
+		fi
+	done
+}
+
+check_metrics_endpoint() {
+	local cm_pod
+	cm_pod=$("$KUBE_CLI" get pods -n "$CERT_MANAGER_NAMESPACE" -l app=cert-manager \
+		-o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+	if [ -z "$cm_pod" ]; then
+		record_fail "cert-manager controller pod not found"
+		return
+	fi
+
+	if "$KUBE_CLI" exec "$cm_pod" -n "$CERT_MANAGER_NAMESPACE" -- \
+		sh -c "wget -qO- http://localhost:${METRICS_PORT}/metrics 2>/dev/null | head -1" &>/dev/null; then
+		record_pass "Metrics endpoint (port $METRICS_PORT) is reachable"
+	else
+		record_fail "Metrics endpoint (port $METRICS_PORT) is not reachable"
+	fi
+}
+
+check_metrics_service() {
+	if "$KUBE_CLI" get service cert-manager -n "$CERT_MANAGER_NAMESPACE" -o jsonpath='{.spec.ports}' 2>/dev/null |
+		grep -q "$METRICS_PORT"; then
+		record_pass "cert-manager service exposes metrics port $METRICS_PORT"
+	else
+		record_fail "cert-manager service does not expose metrics port $METRICS_PORT"
+	fi
+}
+
+require_cmd jq
+require_cluster
+
+print_header "Verify cert-manager Monitoring"
+log_info "Namespace: $CERT_MANAGER_NAMESPACE"
+echo
+
+if ! check_deployment_exists cert-manager "$CERT_MANAGER_NAMESPACE"; then
+	log_error "cert-manager not found in namespace $CERT_MANAGER_NAMESPACE"
+	log_info "Install cert-manager first: make install-cert-manager-operator"
+	exit 1
+fi
+
+check_service_monitor
+check_prometheus_rule
+check_metrics_service
+check_metrics_endpoint
+
+echo
+print_summary \
+	"Passed" "$pass_count" \
+	"Failed" "$fail_count" \
+	"Total" "$((pass_count + fail_count))"
+
+if [ "$fail_count" -gt 0 ]; then
+	echo
+	log_warn "Some checks failed. Run 'make install-monitoring' to set up monitoring."
+	exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/troubleshooting/verify-monitoring.sh` to validate cert-manager Prometheus monitoring is correctly configured
- Checks: ServiceMonitor existence, PrometheusRule with all 4 expected alerts (CertManagerAbsent, CertManagerCertExpirySoon, CertManagerCertNotReady, CertManagerACMEClientErrors), metrics service port exposure, and metrics endpoint reachability
- Uses single JSON fetch for PrometheusRule (no N+1), `check_deployment_exists` from common.sh, configurable `METRICS_PORT`
- Prints pass/fail summary; exits non-zero if any check fails
- Add `verify-monitoring` Makefile target in Troubleshooting section

Closes #90