### PR TITLE
Add automated acme-dns account registration helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ BG_BLUE := \033[44m
         test-ibu-certs test-ibu-preserved test-ibu-both quick-ibu-test clean-ibu \
         create-multi-algo-certs verify-key-formats test-ibu-multi-algo clean-multi-algo-certs \
         quick-multi-algo-test \
-        install-pebble-challtestsrv install-local-dns \
+        install-pebble-challtestsrv install-local-dns register-acmedns \
         label-cert-resources simulate-ibu validate-cert-loss validate-post-restore
 
 # Default target
@@ -71,7 +71,7 @@ help: banner ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(preflight|lint|check-network|check-workload)"
 	@echo ""
 	@echo "$(YELLOW)Installation:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(install-)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(install-|register-)"
 	@echo ""
 	@echo "$(YELLOW)Issuers & Certificates:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(create-|test-cert|verify-)"
@@ -166,6 +166,9 @@ install-local-dns: ## Install acme-dns local DNS server
 	@echo "$(BOLD)$(BLUE)Installing acme-dns local DNS server...$(RESET)"
 	@./scripts/install-local-dns.sh
 	@echo ""
+
+register-acmedns: ## Register acme-dns account and create credentials secret
+	@./scripts/register-acmedns-account.sh
 
 install-all: install-cert-manager-operator install-pebble ## Install cert-manager-operator and Pebble
 	@echo ""

--- a/scripts/register-acmedns-account.sh
+++ b/scripts/register-acmedns-account.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+################################################################################
+# Script: register-acmedns-account.sh
+# Description: Register an acme-dns account and create cert-manager credentials
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
+load_env
+
+ACMEDNS_NAMESPACE="${ACMEDNS_NAMESPACE:-acme-dns}"
+CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
+ACMEDNS_SECRET_NAME="${ACMEDNS_SECRET_NAME:-acme-dns-credentials}"
+ACMEDNS_DOMAIN="${ACMEDNS_DOMAIN:-example.com}"
+
+register_account() {
+	log_info "Registering new acme-dns account..."
+
+	local acmedns_pod
+	acmedns_pod=$("$KUBE_CLI" get pods -n "$ACMEDNS_NAMESPACE" -l app=acme-dns \
+		-o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+	if [ -z "$acmedns_pod" ]; then
+		log_error "Could not find acme-dns pod"
+		exit 1
+	fi
+
+	local response
+	response=$("$KUBE_CLI" exec "$acmedns_pod" -n "$ACMEDNS_NAMESPACE" -- \
+		sh -c 'if command -v wget >/dev/null 2>&1; then wget -qO- --post-data="" http://localhost:8080/register; else curl -sf -X POST http://localhost:8080/register; fi' || echo "")
+
+	if [ -z "$response" ]; then
+		log_error "Failed to register acme-dns account"
+		log_info "Check that acme-dns is running: $KUBE_CLI get pods -n $ACMEDNS_NAMESPACE"
+		exit 1
+	fi
+
+	if ! echo "$response" | jq -e '.username' &>/dev/null; then
+		log_error "Unexpected registration response: $response"
+		exit 1
+	fi
+
+	read -r ACMEDNS_USERNAME ACMEDNS_PASSWORD ACMEDNS_FULLDOMAIN ACMEDNS_SUBDOMAIN \
+		< <(echo "$response" | jq -r '[.username, .password, .fulldomain, .subdomain] | @tsv')
+
+	log_success "Account registered successfully"
+}
+
+create_credentials_secret() {
+	log_info "Creating credentials secret in $CERT_MANAGER_NAMESPACE..."
+
+	local credentials_json
+	credentials_json=$(jq -n \
+		--arg domain "$ACMEDNS_DOMAIN" \
+		--arg username "$ACMEDNS_USERNAME" \
+		--arg password "$ACMEDNS_PASSWORD" \
+		--arg fulldomain "$ACMEDNS_FULLDOMAIN" \
+		--arg subdomain "$ACMEDNS_SUBDOMAIN" \
+		'{($domain): {"username": $username, "password": $password, "fulldomain": $fulldomain, "subdomain": $subdomain}}')
+
+	"$KUBE_CLI" create secret generic "$ACMEDNS_SECRET_NAME" \
+		-n "$CERT_MANAGER_NAMESPACE" \
+		--from-literal=acmedns.json="$credentials_json" \
+		--dry-run=client -o yaml | "$KUBE_CLI" apply -f -
+
+	log_success "Secret '$ACMEDNS_SECRET_NAME' created in namespace '$CERT_MANAGER_NAMESPACE'"
+}
+
+display_results() {
+	print_header "acme-dns Registration Complete"
+
+	print_summary \
+		"Username" "$ACMEDNS_USERNAME" \
+		"Subdomain" "$ACMEDNS_SUBDOMAIN" \
+		"Full Domain" "$ACMEDNS_FULLDOMAIN" \
+		"Secret" "$CERT_MANAGER_NAMESPACE/$ACMEDNS_SECRET_NAME" \
+		"Domain" "$ACMEDNS_DOMAIN"
+
+	echo
+	echo "Next steps:"
+	echo
+	echo "1. Create a CNAME record pointing to acme-dns:"
+	echo "   _acme-challenge.${ACMEDNS_DOMAIN}. CNAME ${ACMEDNS_FULLDOMAIN}."
+	echo
+	echo "2. Create a DNS-01 ClusterIssuer referencing the secret:"
+	echo "   apiVersion: cert-manager.io/v1"
+	echo "   kind: ClusterIssuer"
+	echo "   metadata:"
+	echo "     name: acmedns-issuer"
+	echo "   spec:"
+	echo "     acme:"
+	echo "       solvers:"
+	echo "       - dns01:"
+	echo "           acmeDNS:"
+	echo "             host: http://acme-dns.${ACMEDNS_NAMESPACE}.svc.cluster.local:8080"
+	echo "             accountSecretRef:"
+	echo "               name: ${ACMEDNS_SECRET_NAME}"
+	echo "               key: acmedns.json"
+	echo
+}
+
+main() {
+	print_header "Register acme-dns Account"
+
+	require_cmd jq
+	require_cluster
+
+	if ! check_deployment_exists acme-dns "$ACMEDNS_NAMESPACE"; then
+		log_error "acme-dns is not installed. Run 'make install-local-dns' first."
+		exit 1
+	fi
+
+	ensure_namespace "$CERT_MANAGER_NAMESPACE"
+
+	register_account
+	create_credentials_secret
+	display_results
+}
+
+main


### PR DESCRIPTION
## Summary
- Add `scripts/register-acmedns-account.sh` that automates the manual acme-dns registration flow
- Registers an account via POST to the acme-dns API inside the pod, parses credentials from the JSON response, and creates a Kubernetes secret in the cert-manager namespace
- Uses `command -v` for tool selection (wget vs curl) to avoid masking HTTP errors
- Single `jq` call with `@tsv` to parse all fields efficiently
- Prints next steps for CNAME setup and ClusterIssuer configuration
- Add `register-acmedns` Makefile target in the Installation section

Closes #88