### PR TITLE
Add post-restore cluster validation to IBU simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ BG_BLUE := \033[44m
         create-multi-algo-certs verify-key-formats test-ibu-multi-algo clean-multi-algo-certs \
         quick-multi-algo-test \
         install-pebble-challtestsrv install-local-dns \
-        label-cert-resources simulate-ibu validate-cert-loss
+        label-cert-resources simulate-ibu validate-cert-loss validate-post-restore
 
 # Default target
 all: help
@@ -83,7 +83,7 @@ help: banner ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(troubleshoot|diagnose|check-cert|check-issuer)"
 	@echo ""
 	@echo "$(YELLOW)IBU Testing:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(ibu|minio|oadp|label-cert|validate-cert)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(ibu|minio|oadp|label-cert|validate-cert|validate-post)"
 	@echo ""
 	@echo "$(YELLOW)Cleanup:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(clean|uninstall)"
@@ -469,6 +469,9 @@ validate-cert-loss: ## Compare before/after certificate states for IBU validatio
 	@echo "$(BOLD)$(BLUE)Validating certificate state changes...$(RESET)"
 	@./scripts/ibu/validate-cert-loss.sh
 	@echo ""
+
+validate-post-restore: ## Validate cluster health after IBU backup/restore
+	@./scripts/ibu/validate-post-restore.sh
 
 clean-multi-algo-certs: ## Clean up multi-algorithm test certificates
 	@echo "$(BOLD)$(YELLOW)Cleaning up multi-algorithm test certificates...$(RESET)"

--- a/scripts/ibu/simulate-ibu-backup-restore.sh
+++ b/scripts/ibu/simulate-ibu-backup-restore.sh
@@ -140,6 +140,7 @@ main() {
 	delete_namespace_resources
 	restore_from_backup
 	wait_for_cert_manager_reconcile
+	"$(dirname "${BASH_SOURCE[0]}")/validate-post-restore.sh"
 
 	print_simulation_summary
 	log_success "IBU simulation complete!"

--- a/scripts/ibu/validate-post-restore.sh
+++ b/scripts/ibu/validate-post-restore.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+################################################################################
+# Script: validate-post-restore.sh
+# Description: Validate cluster health after IBU backup/restore simulation
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../../lib/common.sh"
+
+CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
+
+pass_count=0
+fail_count=0
+
+record_pass() {
+	log_success "$1"
+	pass_count=$((pass_count + 1))
+}
+
+record_fail() {
+	log_error "$1"
+	fail_count=$((fail_count + 1))
+}
+
+check_node_readiness() {
+	local nodes_json
+	nodes_json=$("$KUBE_CLI" get nodes -o json 2>/dev/null) || {
+		record_fail "Cannot retrieve node status"
+		return
+	}
+
+	local not_ready
+	not_ready=$(echo "$nodes_json" | jq -r \
+		'.items[] | select(.status.conditions[] | select(.type=="Ready" and .status!="True")) | .metadata.name' 2>/dev/null || echo "")
+
+	if [ -z "$not_ready" ]; then
+		local node_count
+		node_count=$(echo "$nodes_json" | jq '.items | length')
+		record_pass "All $node_count node(s) are Ready"
+	else
+		record_fail "Not-ready nodes: $not_ready"
+	fi
+}
+
+check_cert_manager() {
+	if check_deployment_exists cert-manager "$CERT_MANAGER_NAMESPACE"; then
+		record_pass "cert-manager controller is running"
+	else
+		record_fail "cert-manager controller is not running"
+	fi
+
+	if check_deployment_exists cert-manager-webhook "$CERT_MANAGER_NAMESPACE"; then
+		record_pass "cert-manager webhook is running"
+	else
+		record_fail "cert-manager webhook is not running"
+	fi
+}
+
+check_system_pods() {
+	if [[ "${CLUSTER_TYPE:-}" != "openshift" ]]; then
+		return
+	fi
+
+	local checks=(
+		"openshift-apiserver:app=openshift-apiserver:OpenShift API server"
+		"openshift-controller-manager:app=controller-manager:OpenShift controller manager"
+	)
+
+	for check in "${checks[@]}"; do
+		local namespace label description
+		IFS=: read -r namespace label description <<<"$check"
+		local pod_count
+		pod_count=$("$KUBE_CLI" get pods -n "$namespace" -l "$label" \
+			--field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l | xargs)
+		if [ "$pod_count" -gt 0 ]; then
+			record_pass "$description pods running ($pod_count)"
+		else
+			record_fail "$description pods not running"
+		fi
+	done
+}
+
+check_cluster_operators() {
+	if [[ "${CLUSTER_TYPE:-}" != "openshift" ]]; then
+		return
+	fi
+
+	local degraded
+	degraded=$("$KUBE_CLI" get clusteroperators -o json 2>/dev/null |
+		jq -r '.items[] | select(.status.conditions[]? | select(.type=="Degraded" and .status=="True")) | .metadata.name' 2>/dev/null || echo "")
+
+	if [ -z "$degraded" ]; then
+		record_pass "No degraded ClusterOperators"
+	else
+		record_fail "Degraded ClusterOperators: $degraded"
+	fi
+}
+
+require_cmd jq
+require_cluster
+
+print_header "Post-Restore Cluster Validation"
+echo
+
+check_node_readiness
+check_cert_manager
+check_system_pods
+check_cluster_operators
+
+echo
+print_summary \
+	"Passed" "$pass_count" \
+	"Failed" "$fail_count" \
+	"Total" "$((pass_count + fail_count))"
+
+if [ "$fail_count" -gt 0 ]; then
+	echo
+	log_warn "Some post-restore checks failed. The cluster may need manual intervention."
+	exit 1
+else
+	echo
+	log_success "Cluster is healthy after restore."
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/ibu/validate-post-restore.sh` that validates cluster health after IBU backup/restore simulation
- Checks: node readiness (single API call), cert-manager controller/webhook deployments via `check_deployment_exists`, OpenShift system pods (API server, controller manager), and ClusterOperator degraded status
- Integrates into `simulate-ibu-backup-restore.sh` — automatically runs after cert-manager reconciliation
- Add `validate-post-restore` Makefile target in the IBU Testing section

Closes #91