### PR TITLE
Add certificate renewal/rotation testing workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BG_BLUE := \033[44m
         install-fake-dns install-all install-monitoring create-issuer create-dns01-issuer \
         create-selfsigned-issuer create-certs create-apiserver-cert verify-apiserver-cert \
         test-all test-dns01 quick-http-test quick-dns-test quick-selfsigned-test \
-        test-cert verify-cert \
+        test-cert verify-cert test-cert-renewal clean-cert-renewal \
         status \
         troubleshoot check-cert check-issuer check-network check-network-stack check-workload-partitioning \
         diagnose-http01 diagnose-dns01 clean clean-certs clean-pebble clean-fake-dns \
@@ -77,7 +77,7 @@ help: banner ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(create-|test-cert|verify-)"
 	@echo ""
 	@echo "$(YELLOW)Quick Tests:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(quick-|test-all|test-dns01)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(quick-|test-all|test-dns01|test-cert-renewal)"
 	@echo ""
 	@echo "$(YELLOW)Troubleshooting:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(troubleshoot|diagnose|check-cert|check-issuer)"
@@ -321,6 +321,9 @@ quick-multi-algo-test: create-multi-algo-certs ## Quick multi-algorithm certific
 	@echo ""
 	@echo "Run 'make clean-multi-algo-certs' to clean up."
 
+test-cert-renewal: ## Test automatic certificate renewal with a short-lived cert
+	@./scripts/test-cert-renewal.sh
+
 # ────────────────────────────────────────────────────────────────────────────────
 # Status
 # ────────────────────────────────────────────────────────────────────────────────
@@ -548,6 +551,12 @@ clean-selfsigned: ## Clean up self-signed CA chain
 	@$(KUBE_CLI) delete certificate root-ca -n cert-manager --ignore-not-found=true
 	@$(KUBE_CLI) delete secret root-ca-secret -n cert-manager --ignore-not-found=true
 	@echo "$(GREEN)Self-signed CA resources cleaned.$(RESET)"
+
+clean-cert-renewal: ## Clean up renewal test certificate
+	@echo "$(BOLD)$(YELLOW)Cleaning up renewal test resources...$(RESET)"
+	@$(KUBE_CLI) delete certificate -l app=cert-renewal-test --all-namespaces --ignore-not-found=true
+	@$(KUBE_CLI) delete secret renewal-test-tls -n $${CERT_NAMESPACE:-default} --ignore-not-found=true
+	@echo "$(GREEN)Renewal test resources cleaned.$(RESET)"
 
 clean-monitoring: ## Clean up cert-manager monitoring resources
 	@echo "$(BOLD)$(YELLOW)Cleaning up monitoring resources...$(RESET)"

--- a/scripts/test-cert-renewal.sh
+++ b/scripts/test-cert-renewal.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+################################################################################
+# Script: test-cert-renewal.sh
+# Description: Test certificate automatic renewal by creating a short-lived cert
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
+load_env
+setup_cleanup
+
+YAML_DIR="${SCRIPT_DIR}/../yaml/certificates"
+
+export CERT_NAME="${CERT_NAME:-renewal-test}"
+export CERT_NAMESPACE="${CERT_NAMESPACE:-default}"
+export CERT_SECRET_NAME="${CERT_SECRET_NAME:-renewal-test-tls}"
+export ISSUER_NAME="${ISSUER_NAME:-selfsigned-ca-issuer}"
+export CERT_DNS_NAME="${CERT_DNS_NAME:-renewal-test.example.com}"
+export CERT_DURATION="${CERT_DURATION:-6m}"
+export CERT_RENEW_BEFORE="${CERT_RENEW_BEFORE:-3m}"
+
+POLL_INTERVAL=15
+MAX_WAIT=600
+
+get_cert_serial() {
+	"$KUBE_CLI" get secret "$CERT_SECRET_NAME" -n "$CERT_NAMESPACE" \
+		-o jsonpath='{.data.tls\.crt}' 2>/dev/null |
+		base64 -d 2>/dev/null |
+		openssl x509 -noout -serial 2>/dev/null |
+		cut -d= -f2 || echo ""
+}
+
+create_short_lived_cert() {
+	log_info "Creating short-lived certificate..."
+	log_info "  Duration: $CERT_DURATION, Renew Before: $CERT_RENEW_BEFORE"
+	log_info "  Issuer: $ISSUER_NAME"
+
+	apply_yaml_template "$YAML_DIR/short-lived-certificate.yaml" "Certificate"
+}
+
+wait_for_initial_issuance() {
+	log_info "Waiting for initial certificate issuance..."
+
+	retry 24 5 "$KUBE_CLI" wait --for=condition=Ready \
+		"certificate/$CERT_NAME" -n "$CERT_NAMESPACE" --timeout=5s
+
+	log_success "Certificate issued successfully"
+}
+
+wait_for_renewal() {
+	local initial_serial="$1"
+	log_info "Waiting for automatic renewal (polling every ${POLL_INTERVAL}s, max ${MAX_WAIT}s)..."
+	log_info "Initial serial: $initial_serial"
+
+	local elapsed=0
+	while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+		local current_serial
+		current_serial=$(get_cert_serial)
+
+		if [ -n "$current_serial" ] && [ "$current_serial" != "$initial_serial" ]; then
+			log_success "Certificate renewed!"
+			log_info "New serial: $current_serial"
+			return 0
+		fi
+
+		local remaining=$((MAX_WAIT - elapsed))
+		if [ $((elapsed % 60)) -eq 0 ]; then
+			log_info "Still waiting... (${elapsed}s elapsed, ${remaining}s remaining)"
+		fi
+		sleep "$POLL_INTERVAL"
+		elapsed=$((elapsed + POLL_INTERVAL))
+	done
+
+	log_error "Timed out waiting for renewal after ${MAX_WAIT}s"
+	return 1
+}
+
+verify_renewed_cert() {
+	local initial_serial="$1"
+
+	local cert_data
+	cert_data=$("$KUBE_CLI" get secret "$CERT_SECRET_NAME" -n "$CERT_NAMESPACE" \
+		-o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d 2>/dev/null)
+
+	local renewed_serial not_before not_after
+	renewed_serial=$(echo "$cert_data" | openssl x509 -noout -serial 2>/dev/null | cut -d= -f2 || echo "unknown")
+	not_before=$(echo "$cert_data" | openssl x509 -noout -startdate 2>/dev/null | cut -d= -f2 || echo "unknown")
+	not_after=$(echo "$cert_data" | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2 || echo "unknown")
+
+	print_summary \
+		"Initial Serial" "$initial_serial" \
+		"Renewed Serial" "$renewed_serial" \
+		"Not Before" "$not_before" \
+		"Not After" "$not_after" \
+		"Result" "RENEWED"
+}
+
+main() {
+	print_header "Certificate Renewal Test"
+
+	require_cmd openssl envsubst
+	require_cluster
+	require_cert_manager
+
+	create_short_lived_cert
+	wait_for_initial_issuance
+
+	local initial_serial
+	initial_serial=$(get_cert_serial)
+
+	if [ -z "$initial_serial" ]; then
+		log_error "Could not read certificate serial from secret $CERT_SECRET_NAME"
+		exit 1
+	fi
+
+	if wait_for_renewal "$initial_serial"; then
+		verify_renewed_cert "$initial_serial"
+		log_success "Certificate renewal test passed!"
+	else
+		log_error "Certificate renewal test failed"
+		log_info "Check cert-manager logs: $KUBE_CLI logs -n cert-manager deployment/cert-manager --tail=50"
+		exit 1
+	fi
+}
+
+main

--- a/yaml/certificates/short-lived-certificate.yaml
+++ b/yaml/certificates/short-lived-certificate.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${CERT_NAME}
+  namespace: ${CERT_NAMESPACE}
+  labels:
+    app: cert-renewal-test
+spec:
+  secretName: ${CERT_SECRET_NAME}
+  duration: ${CERT_DURATION}
+  renewBefore: ${CERT_RENEW_BEFORE}
+  issuerRef:
+    name: ${ISSUER_NAME}
+    kind: ClusterIssuer
+    group: cert-manager.io
+  dnsNames:
+  - ${CERT_DNS_NAME}


### PR DESCRIPTION
## Summary
- Add `scripts/test-cert-renewal.sh` that tests automatic certificate renewal end-to-end
- Creates a short-lived cert (default 6m duration, 3m renewBefore), waits for issuance, then polls for serial number change in the TLS secret to detect renewal
- Validates renewed cert and prints initial/renewed serial, validity dates
- Uses self-signed CA issuer by default (configurable via `ISSUER_NAME`)
- Add `yaml/certificates/short-lived-certificate.yaml` template with configurable duration/renewBefore
- Add `test-cert-renewal` and `clean-cert-renewal` Makefile targets

Closes #61