### PR TITLE
Add UX improvements: fmt target, delete targets, status in help, recovery hints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BG_BLUE := \033[44m
 # ────────────────────────────────────────────────────────────────────────────────
 # Target Definitions
 # ────────────────────────────────────────────────────────────────────────────────
-.PHONY: all help banner preflight lint install-cert-manager-operator install-cert-manager-helm install-pebble \
+.PHONY: all help banner preflight lint fmt _require-shfmt install-cert-manager-operator install-cert-manager-helm install-pebble \
         install-fake-dns install-all install-monitoring create-issuer create-dns01-issuer \
         create-selfsigned-issuer create-certs create-apiserver-cert verify-apiserver-cert \
         test-all test-dns01 quick-http-test quick-dns-test quick-selfsigned-test \
@@ -39,6 +39,7 @@ BG_BLUE := \033[44m
         troubleshoot check-cert check-cert-renewal check-issuer verify-monitoring check-network check-network-stack check-workload-partitioning \
         diagnose-http01 diagnose-dns01 clean clean-certs clean-pebble clean-fake-dns \
         clean-dns-config clean-issuers clean-selfsigned clean-monitoring clean-temp \
+        delete-certificate delete-issuer \
         clean-acmedns clean-challtestsrv \
         uninstall-cert-manager-operator uninstall-all \
         install-minio install-oadp install-ibu-prereqs capture-cert-state \
@@ -68,7 +69,7 @@ help: banner ## Show this help message
 	@echo "$(BOLD)$(BLUE)Available Commands:$(RESET)"
 	@echo ""
 	@echo "$(YELLOW)Setup & Validation:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(preflight|lint|check-network|check-workload)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(preflight|lint|fmt|check-network|check-workload)"
 	@echo ""
 	@echo "$(YELLOW)Installation:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(install-|register-)"
@@ -79,14 +80,14 @@ help: banner ## Show this help message
 	@echo "$(YELLOW)Quick Tests:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(quick-|test-all|test-dns01|test-cert-renewal|test-ingress)"
 	@echo ""
-	@echo "$(YELLOW)Troubleshooting:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(troubleshoot|diagnose|check-cert|check-issuer|verify-monitoring)"
+	@echo "$(YELLOW)Status & Troubleshooting:$(RESET)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(status|troubleshoot|diagnose|check-cert|check-issuer|verify-monitoring)"
 	@echo ""
 	@echo "$(YELLOW)IBU Testing:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(ibu|minio|oadp|label-cert|validate-cert|validate-post)"
 	@echo ""
 	@echo "$(YELLOW)Cleanup:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(clean|uninstall)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(delete-|clean|uninstall)"
 	@echo ""
 	@echo "$(DIM)Usage: make <command>$(RESET)"
 	@echo ""
@@ -99,7 +100,7 @@ preflight: ## Check all dependencies and prerequisites
 	@./scripts/preflight-check.sh
 	@echo ""
 
-lint: ## Check shell script formatting with shfmt and shellcheck
+lint: _require-shfmt ## Check shell script formatting with shfmt and shellcheck
 	@echo "$(BOLD)$(BLUE)Linting Bash scripts...$(RESET)"
 	@if ! command -v shellcheck >/dev/null 2>&1; then \
 	  echo "$(RED)shellcheck not found. Please install it:$(RESET)"; \
@@ -109,15 +110,22 @@ lint: ## Check shell script formatting with shfmt and shellcheck
 	fi
 	@echo "$(DIM)  Running shellcheck...$(RESET)"
 	@find . -name '*.sh' -type f -not -path './venv/*' | xargs shellcheck -e SC1091,SC2034,SC2329 || (echo "$(RED)shellcheck failed!$(RESET)" && exit 1)
+	@echo "$(DIM)  Running shfmt...$(RESET)"
+	@shfmt -d scripts/ lib/ || (echo "$(RED)shfmt formatting check failed!$(RESET)" && echo "$(YELLOW)To fix: make fmt$(RESET)" && exit 1)
+	@echo "$(GREEN)Bash linting passed!$(RESET)"
+
+fmt: _require-shfmt ## Auto-fix shell script formatting with shfmt
+	@echo "$(BOLD)$(BLUE)Formatting shell scripts...$(RESET)"
+	@shfmt -w scripts/ lib/
+	@echo "$(GREEN)Shell scripts formatted!$(RESET)"
+
+_require-shfmt:
 	@if ! command -v shfmt >/dev/null 2>&1; then \
 	  echo "$(RED)shfmt not found. Please install it:$(RESET)"; \
 	  echo "$(DIM)  macOS: brew install shfmt$(RESET)"; \
 	  echo "$(DIM)  Linux: go install mvdan.cc/sh/v3/cmd/shfmt@latest$(RESET)"; \
 	  exit 1; \
 	fi
-	@echo "$(DIM)  Running shfmt...$(RESET)"
-	@shfmt -d scripts/ lib/ || (echo "$(RED)shfmt formatting check failed!$(RESET)" && echo "$(YELLOW)To fix: shfmt -w scripts/ lib/$(RESET)" && exit 1)
-	@echo "$(GREEN)Bash linting passed!$(RESET)"
 
 check-network: ## Check cluster network configuration (IPv4/IPv6/Dual-stack)
 	@./scripts/check-cluster-network.sh
@@ -227,7 +235,7 @@ verify-cert: ## Verify certificate status
 # Quick Tests
 # ────────────────────────────────────────────────────────────────────────────────
 
-test-all: install-all create-issuer create-certs ## Complete HTTP-01 setup (install + issuer + certs)
+test-all: install-all create-issuer create-certs ## Full HTTP-01 environment setup (install operator, Pebble, issuer, certs)
 	@echo ""
 	@echo "$(BOLD)$(BG_GREEN)$(WHITE)"
 	@echo "  ╔═════════════════════════════════════════════════════════════╗"
@@ -512,6 +520,30 @@ clean-ibu: ## Clean up IBU test resources (MinIO, OADP, backups)
 # ────────────────────────────────────────────────────────────────────────────────
 # Cleanup
 # ────────────────────────────────────────────────────────────────────────────────
+
+delete-certificate: ## Delete a specific certificate (CERT=name NS=namespace)
+	@if [ -z "$(CERT)" ] || [ -z "$(NS)" ]; then \
+	  echo "$(YELLOW)Usage: make delete-certificate CERT=<name> NS=<namespace>$(RESET)"; \
+	  echo "$(DIM)Example: make delete-certificate CERT=test-cert NS=default$(RESET)"; \
+	  exit 1; \
+	fi
+	@echo "$(BOLD)$(YELLOW)Deleting certificate $(CERT) in namespace $(NS)...$(RESET)"
+	@SECRET=$$($(KUBE_CLI) get certificate "$(CERT)" -n "$(NS)" -o jsonpath='{.spec.secretName}' 2>/dev/null || echo ""); \
+	$(KUBE_CLI) delete certificate "$(CERT)" -n "$(NS)" --ignore-not-found=true; \
+	if [ -n "$$SECRET" ]; then \
+	  $(KUBE_CLI) delete secret "$$SECRET" -n "$(NS)" --ignore-not-found=true; \
+	fi
+	@echo "$(GREEN)Certificate $(CERT) deleted.$(RESET)"
+
+delete-issuer: ## Delete a specific ClusterIssuer (ISSUER=name)
+	@if [ -z "$(ISSUER)" ]; then \
+	  echo "$(YELLOW)Usage: make delete-issuer ISSUER=<name>$(RESET)"; \
+	  echo "$(DIM)Example: make delete-issuer ISSUER=pebble-issuer$(RESET)"; \
+	  exit 1; \
+	fi
+	@echo "$(BOLD)$(YELLOW)Deleting ClusterIssuer $(ISSUER)...$(RESET)"
+	@$(KUBE_CLI) delete clusterissuer "$(ISSUER)" --ignore-not-found=true
+	@echo "$(GREEN)ClusterIssuer $(ISSUER) deleted.$(RESET)"
 
 clean-certs: ## Clean up certificates, orders, and challenges
 	@echo "$(BOLD)$(YELLOW)Cleaning up certificates...$(RESET)"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -82,6 +82,10 @@ log_debug() {
 	[[ $LOG_LEVEL -ge 4 ]] && echo -e "${BOLD}[DEBUG]${NC} $*" || true
 }
 
+log_hint() {
+	[[ $LOG_LEVEL -ge 1 ]] && echo -e "  ${YELLOW}→ $*${NC}" >&2 || true
+}
+
 # ============================================================================
 # HELP FLAG HANDLING
 # ============================================================================
@@ -155,14 +159,16 @@ require_cmd() {
 require_cluster() {
 	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
 		if ! oc whoami &>/dev/null 2>&1; then
-			log_error "Not connected to OpenShift cluster. Run 'oc login' first."
+			log_error "Not connected to OpenShift cluster."
+			log_hint "Run 'oc login <cluster-url>' to connect"
 			exit 1
 		fi
 		log_debug "Connected to cluster as: $(oc whoami)"
 		log_debug "Cluster: $(oc whoami --show-server 2>/dev/null || echo 'unknown')"
 	else
 		if ! kubectl cluster-info &>/dev/null 2>&1; then
-			log_error "Not connected to Kubernetes cluster. Check KUBECONFIG."
+			log_error "Not connected to Kubernetes cluster."
+			log_hint "Check KUBECONFIG or run 'kubectl config use-context <context>'"
 			exit 1
 		fi
 		log_debug "Connected to cluster: $(kubectl config current-context 2>/dev/null || echo 'unknown')"
@@ -327,6 +333,7 @@ require_cluster_admin() {
 	require_cluster
 	if ! "$KUBE_CLI" auth can-i '*' '*' --all-namespaces &>/dev/null; then
 		log_error "Cluster-admin privileges required."
+		log_hint "Log in with an admin account or request cluster-admin role binding"
 		exit 1
 	fi
 	log_debug "Cluster-admin privileges confirmed"
@@ -345,6 +352,7 @@ wait_for_resource() {
 		return 0
 	else
 		log_error "$resource failed to become ready within $timeout"
+		log_hint "Run 'make troubleshoot' for diagnostics or 'make check-cert CERT=<name> NS=$namespace'"
 		dump_resource_diagnostics "$namespace" "$resource"
 		return 1
 	fi
@@ -369,7 +377,7 @@ dump_resource_diagnostics() {
 require_cert_manager() {
 	if ! "$KUBE_CLI" get deployment -n cert-manager cert-manager &>/dev/null; then
 		log_error "cert-manager not found."
-		log_info "  Run: make install-cert-manager-operator (OpenShift) or make install-cert-manager-helm (Kubernetes)"
+		log_hint "Run 'make install-cert-manager-operator' (OpenShift) or 'make install-cert-manager-helm' (Kubernetes)"
 		exit 1
 	fi
 
@@ -526,6 +534,7 @@ wait_for_csv() {
 	echo
 
 	log_error "Timeout waiting for CSV to reach Succeeded phase."
+	log_hint "Check operator status: $KUBE_CLI get csv -n $namespace"
 	return 1
 }
 
@@ -566,6 +575,7 @@ wait_for_backup_restore() {
 	done
 
 	log_error "Timeout waiting for $resource_type to complete"
+	log_hint "Check status: oc describe $resource_type $name -n $namespace"
 	return 1
 }
 

--- a/scripts/create-apiserver-certificate.sh
+++ b/scripts/create-apiserver-certificate.sh
@@ -30,7 +30,8 @@ check_prerequisites() {
 
 	# Check if cert-manager is installed
 	if ! oc get deployment -n cert-manager cert-manager &>/dev/null; then
-		log_error "cert-manager not found. Please install cert-manager-operator first."
+		log_error "cert-manager not found."
+		log_hint "Run 'make install-cert-manager-operator' (OpenShift) or 'make install-cert-manager-helm' (Kubernetes)"
 		exit 1
 	fi
 
@@ -105,6 +106,7 @@ EOF
 		log_info "Certificate '$CERT_NAME' created successfully in namespace '$CERT_NAMESPACE'"
 	else
 		log_error "Failed to create certificate '$CERT_NAME'"
+		log_hint "Run 'make troubleshoot' for diagnostics"
 		exit 1
 	fi
 }

--- a/scripts/create-dns01-issuer.sh
+++ b/scripts/create-dns01-issuer.sh
@@ -31,7 +31,8 @@ log_info "Waiting for Pebble ACME server to be available..."
 if wait_for_condition 60 10 check_pebble_responding; then
 	log_info "Pebble ACME server is available."
 else
-	log_error "Pebble ACME server is not available. Install Pebble first: make install-pebble"
+	log_error "Pebble ACME server is not available."
+	log_hint "Run 'make install-pebble' to install the ACME test server"
 	dump_resource_diagnostics "${PEBBLE_NAMESPACE:-pebble}" "deployment/pebble"
 	exit 1
 fi

--- a/scripts/create-test-certificates.sh
+++ b/scripts/create-test-certificates.sh
@@ -28,15 +28,15 @@ check_prerequisites() {
 
 	# Check if cert-manager is installed
 	if ! "$KUBE_CLI" get deployment -n cert-manager cert-manager &>/dev/null; then
-		log_error "cert-manager not found. Please install cert-manager-operator first."
-		log_info "  Run: make install-cert-manager-operator"
+		log_error "cert-manager not found."
+		log_hint "Run 'make install-cert-manager-operator' (OpenShift) or 'make install-cert-manager-helm' (Kubernetes)"
 		exit 1
 	fi
 
 	# Check if issuer exists
 	if ! "$KUBE_CLI" get clusterissuer "$ISSUER_NAME" &>/dev/null; then
 		log_error "ClusterIssuer '$ISSUER_NAME' not found."
-		log_info "  Create an issuer first: make create-issuer"
+		log_hint "Run 'make create-issuer' (HTTP-01) or 'make create-dns01-issuer' (DNS-01)"
 		exit 1
 	fi
 

--- a/scripts/ibu/create-multi-algo-certs.sh
+++ b/scripts/ibu/create-multi-algo-certs.sh
@@ -126,7 +126,7 @@ wait_for_certificates() {
 		log_success "All certificates are ready!"
 	else
 		log_error "Timeout waiting for certificates to become ready."
-		log_info "Check status: oc get certificates -n $TARGET_NAMESPACE -l app=$CERT_LABEL"
+		log_hint "Check status: $KUBE_CLI get certificates -n $TARGET_NAMESPACE -l app=$CERT_LABEL"
 		exit 1
 	fi
 }

--- a/scripts/ibu/install-oadp.sh
+++ b/scripts/ibu/install-oadp.sh
@@ -26,7 +26,8 @@ check_prerequisites() {
 
 	# Check MinIO is running
 	if ! oc get deployment minio -n minio &>/dev/null; then
-		log_error "MinIO is not installed. Run 'make install-minio' first."
+		log_error "MinIO is not installed."
+		log_hint "Run 'make install-minio' first, or 'make install-ibu-prereqs' for full IBU setup"
 		exit 1
 	fi
 
@@ -100,7 +101,7 @@ wait_for_dpa() {
 		log_success "DataProtectionApplication is reconciled!"
 	else
 		log_error "Timeout waiting for DPA to reconcile."
-		log_info "Check status with: oc describe dpa velero -n $OADP_NAMESPACE"
+		log_hint "Check status: $KUBE_CLI describe dpa velero -n $OADP_NAMESPACE"
 		return 1
 	fi
 }

--- a/scripts/ibu/validate-cert-loss.sh
+++ b/scripts/ibu/validate-cert-loss.sh
@@ -55,12 +55,14 @@ check_prerequisites() {
 
 	# Check state files exist
 	if [ ! -f "$STATE_DIR/checksums-before.json" ]; then
-		log_error "Before state not found. Run 'capture-cert-state.sh' with STATE_LABEL=before first."
+		log_error "Before state not found."
+		log_hint "Run 'make capture-cert-state' with STATE_LABEL=before first"
 		exit 1
 	fi
 
 	if [ ! -f "$STATE_DIR/checksums-after.json" ]; then
-		log_error "After state not found. Run 'capture-cert-state.sh' with STATE_LABEL=after first."
+		log_error "After state not found."
+		log_hint "Run 'make capture-cert-state' with STATE_LABEL=after after the IBU simulation"
 		exit 1
 	fi
 

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -58,6 +58,7 @@ configure_coredns() {
 
 	if [ -z "$fake_dns_ip" ]; then
 		log_error "Could not get fake-dns service ClusterIP"
+		log_hint "Check fake-dns deployment: make status"
 		exit 1
 	fi
 

--- a/scripts/install-monitoring.sh
+++ b/scripts/install-monitoring.sh
@@ -130,8 +130,8 @@ main() {
 	require_cluster
 
 	if ! oc get deployment -n "$CERT_MANAGER_NAMESPACE" cert-manager &>/dev/null; then
-		log_error "cert-manager not found. Please install cert-manager-operator first."
-		log_info "  Run: make install-cert-manager-operator"
+		log_error "cert-manager not found."
+		log_hint "Run 'make install-cert-manager-operator' (OpenShift) or 'make install-cert-manager-helm' (Kubernetes)"
 		exit 1
 	fi
 

--- a/scripts/install-pebble-challtestsrv.sh
+++ b/scripts/install-pebble-challtestsrv.sh
@@ -24,7 +24,8 @@ require_cluster
 require_healthy_cluster
 
 if ! oc get namespace "$PEBBLE_NAMESPACE" &>/dev/null; then
-	log_error "Pebble namespace '$PEBBLE_NAMESPACE' not found. Install Pebble first."
+	log_error "Pebble namespace '$PEBBLE_NAMESPACE' not found."
+	log_hint "Run 'make install-pebble' first"
 	exit 1
 fi
 

--- a/scripts/preflight-check.sh
+++ b/scripts/preflight-check.sh
@@ -158,7 +158,6 @@ elif [[ $FAILED -eq 0 ]]; then
 	exit 0
 else
 	log_error "Failed with $FAILED error(s) and $WARNINGS warning(s)"
-	echo ""
-	echo "Please install missing dependencies before proceeding."
+	log_hint "See docs/installation.md for setup instructions"
 	exit 1
 fi

--- a/scripts/register-acmedns-account.sh
+++ b/scripts/register-acmedns-account.sh
@@ -110,7 +110,8 @@ main() {
 	require_cluster
 
 	if ! check_deployment_exists acme-dns "$ACMEDNS_NAMESPACE"; then
-		log_error "acme-dns is not installed. Run 'make install-local-dns' first."
+		log_error "acme-dns is not installed."
+		log_hint "Run 'make install-local-dns' first"
 		exit 1
 	fi
 

--- a/scripts/test-cert-renewal.sh
+++ b/scripts/test-cert-renewal.sh
@@ -76,6 +76,7 @@ wait_for_renewal() {
 	done
 
 	log_error "Timed out waiting for renewal after ${MAX_WAIT}s"
+	log_hint "Run 'make check-cert-renewal' to diagnose renewal status"
 	return 1
 }
 
@@ -122,7 +123,7 @@ main() {
 		log_success "Certificate renewal test passed!"
 	else
 		log_error "Certificate renewal test failed"
-		log_info "Check cert-manager logs: $KUBE_CLI logs -n cert-manager deployment/cert-manager --tail=50"
+		log_hint "Check logs: $KUBE_CLI logs -n cert-manager deployment/cert-manager --tail=50"
 		exit 1
 	fi
 }


### PR DESCRIPTION
## Summary

- Add `make fmt` target for auto-fixing shfmt violations (#137)
- Add `delete-certificate` and `delete-issuer` targets for targeted cleanup (#92)
- Add `status` to `make help` output under Status & Troubleshooting (#138)
- Fix `test-all` help description to accurately describe behavior (#141)
- Add `log_hint()` to `lib/common.sh` for consistent recovery suggestions (#82)
- Add recovery hints to error messages across 12 scripts

Closes #82, closes #92, closes #137, closes #138, closes #141

## Test plan

- [ ] `make help` shows `status`, `fmt`, `delete-certificate`, `delete-issuer` in correct sections
- [ ] `make fmt` formats scripts (requires shfmt installed)
- [ ] `make lint` references `make fmt` on formatting failure
- [ ] `make delete-certificate CERT=x NS=y` prints usage when args missing, deletes cert+secret when valid
- [ ] `make delete-issuer ISSUER=x` prints usage when arg missing, deletes issuer when valid
- [ ] Error messages show `→` recovery hints pointing to the right next step