### PR TITLE
Add UX improvements: status health, wait progress, monitoring uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BG_BLUE := \033[44m
         clean-dns-config clean-issuers clean-selfsigned clean-monitoring clean-temp \
         delete-certificate delete-issuer \
         clean-acmedns clean-challtestsrv \
-        uninstall-cert-manager-operator uninstall-all \
+        uninstall-cert-manager-operator uninstall-monitoring uninstall-all \
         install-minio install-oadp install-ibu-prereqs capture-cert-state \
         test-ibu-certs test-ibu-preserved test-ibu-both quick-ibu-test clean-ibu \
         create-multi-algo-certs verify-key-formats test-ibu-multi-algo clean-multi-algo-certs \
@@ -343,35 +343,7 @@ test-ingress-tls: ## End-to-end TLS integration test via Route/Ingress
 # ────────────────────────────────────────────────────────────────────────────────
 
 status: ## Show installed components and their status
-	@echo ""
-	@echo "$(BOLD)$(BLUE)Component Status Dashboard$(RESET)"
-	@echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-	@echo ""
-	@printf "  $(BOLD)%-25s %s$(RESET)\n" "Component" "Status"
-	@echo "  ─────────────────────── ──────────────────────────"
-	@printf "  %-25s " "cert-manager"; \
-		if $(KUBE_CLI) get deployment cert-manager -n cert-manager &>/dev/null 2>&1; then echo "$(GREEN)Installed$(RESET)"; else echo "$(DIM)Not installed$(RESET)"; fi
-	@printf "  %-25s " "cert-manager-webhook"; \
-		if $(KUBE_CLI) get deployment cert-manager-webhook -n cert-manager &>/dev/null 2>&1; then echo "$(GREEN)Installed$(RESET)"; else echo "$(DIM)Not installed$(RESET)"; fi
-	@printf "  %-25s " "Pebble ACME server"; \
-		if $(KUBE_CLI) get deployment pebble -n pebble &>/dev/null 2>&1; then echo "$(GREEN)Installed$(RESET)"; else echo "$(DIM)Not installed$(RESET)"; fi
-	@printf "  %-25s " "Fake DNS API"; \
-		if $(KUBE_CLI) get deployment fake-dns-api -n fake-dns &>/dev/null 2>&1; then echo "$(GREEN)Installed$(RESET)"; else echo "$(DIM)Not installed$(RESET)"; fi
-	@printf "  %-25s " "acme-dns"; \
-		if $(KUBE_CLI) get deployment acme-dns -n acme-dns &>/dev/null 2>&1; then echo "$(GREEN)Installed$(RESET)"; else echo "$(DIM)Not installed$(RESET)"; fi
-	@printf "  %-25s " "pebble-challtestsrv"; \
-		if $(KUBE_CLI) get deployment pebble-challtestsrv -n pebble &>/dev/null 2>&1; then echo "$(GREEN)Installed$(RESET)"; else echo "$(DIM)Not installed$(RESET)"; fi
-	@printf "  %-25s " "MinIO"; \
-		if $(KUBE_CLI) get deployment minio -n minio &>/dev/null 2>&1; then echo "$(GREEN)Installed$(RESET)"; else echo "$(DIM)Not installed$(RESET)"; fi
-	@printf "  %-25s " "OADP"; \
-		if $(KUBE_CLI) get deployment -n openshift-adp -l app.kubernetes.io/name=velero &>/dev/null 2>&1; then echo "$(GREEN)Installed$(RESET)"; else echo "$(DIM)Not installed$(RESET)"; fi
-	@echo ""
-	@echo "  $(BOLD)Issuers:$(RESET)"
-	@$(KUBE_CLI) get clusterissuer -o wide 2>/dev/null || echo "  $(DIM)No ClusterIssuers found$(RESET)"
-	@echo ""
-	@echo "  $(BOLD)Certificates:$(RESET)"
-	@$(KUBE_CLI) get certificate --all-namespaces 2>/dev/null || echo "  $(DIM)No Certificates found$(RESET)"
-	@echo ""
+	@./scripts/status.sh
 
 # ────────────────────────────────────────────────────────────────────────────────
 # Troubleshooting
@@ -610,10 +582,12 @@ clean-ingress-test: ## Clean up ingress TLS test resources
 	@$(KUBE_CLI) delete namespace ingress-tls-test --ignore-not-found=true --timeout=60s --wait=false
 	@echo "$(GREEN)Ingress TLS test resources cleaned.$(RESET)"
 
-clean-monitoring: ## Clean up cert-manager monitoring resources
+clean-monitoring: ## Clean up cert-manager monitoring resources (alias: uninstall-monitoring)
 	@echo "$(BOLD)$(YELLOW)Cleaning up monitoring resources...$(RESET)"
 	@$(KUBE_CLI) delete servicemonitor/cert-manager prometheusrule/cert-manager-alerts -n cert-manager --ignore-not-found=true
 	@echo "$(GREEN)Monitoring resources cleaned.$(RESET)"
+
+uninstall-monitoring: clean-monitoring ## Uninstall cert-manager ServiceMonitor and PrometheusRule (alias of clean-monitoring)
 
 clean-temp: ## Clean up temporary files
 	@echo "Cleaning temporary files..."

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -339,6 +339,30 @@ require_cluster_admin() {
 	log_debug "Cluster-admin privileges confirmed"
 }
 
+# Parse a duration string into seconds.
+# Accepts a bare integer, or a number with suffix s/m/h (e.g. 300s, 5m, 1h).
+# Returns 1 for unknown formats so callers can fall back.
+_parse_duration_seconds() {
+	local value="$1"
+	if [[ "$value" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$value"
+		return 0
+	fi
+	if [[ "$value" =~ ^([0-9]+)s$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	if [[ "$value" =~ ^([0-9]+)m$ ]]; then
+		printf '%s\n' "$((BASH_REMATCH[1] * 60))"
+		return 0
+	fi
+	if [[ "$value" =~ ^([0-9]+)h$ ]]; then
+		printf '%s\n' "$((BASH_REMATCH[1] * 3600))"
+		return 0
+	fi
+	return 1
+}
+
 # Wait for a resource to be ready
 # Usage: wait_for_resource <type/name> <namespace> <timeout>
 wait_for_resource() {
@@ -346,16 +370,52 @@ wait_for_resource() {
 	local namespace="${2:-default}"
 	local timeout="${3:-300s}"
 
-	log_info "Waiting for $resource to be ready..."
-	if "$KUBE_CLI" wait --for=condition=available --timeout="$timeout" "$resource" -n "$namespace"; then
-		log_success "$resource is ready"
-		return 0
-	else
+	local timeout_sec
+	if ! timeout_sec=$(_parse_duration_seconds "$timeout"); then
+		log_info "Waiting for $resource to be ready..."
+		if "$KUBE_CLI" wait --for=condition=available --timeout="$timeout" "$resource" -n "$namespace"; then
+			log_success "$resource is ready"
+			return 0
+		fi
 		log_error "$resource failed to become ready within $timeout"
 		log_hint "Run 'make troubleshoot' for diagnostics or 'make check-cert CERT=<name> NS=$namespace'"
 		dump_resource_diagnostics "$namespace" "$resource"
 		return 1
 	fi
+
+	log_info "Waiting for $resource to be ready..."
+	local start elapsed last_progress tick_start tick_elapsed
+	local tick=5
+	local heartbeat=15
+	start=$(date +%s)
+	last_progress=0
+
+	while true; do
+		tick_start=$(date +%s)
+		if "$KUBE_CLI" wait --for=condition=available --timeout="${tick}s" "$resource" -n "$namespace" &>/dev/null; then
+			log_success "$resource is ready"
+			return 0
+		fi
+
+		elapsed=$(($(date +%s) - start))
+		if [[ $elapsed -ge $((last_progress + heartbeat)) ]]; then
+			log_info "Still waiting... (${elapsed}s/${timeout_sec}s)"
+			last_progress=$elapsed
+		fi
+
+		if [[ $elapsed -ge $timeout_sec ]]; then
+			log_error "$resource failed to become ready within $timeout"
+			log_hint "Run 'make troubleshoot' for diagnostics or 'make check-cert CERT=<name> NS=$namespace'"
+			dump_resource_diagnostics "$namespace" "$resource"
+			return 1
+		fi
+
+		# kubectl wait may return immediately (missing resource); consume the rest of the tick
+		tick_elapsed=$(($(date +%s) - tick_start))
+		if [[ $tick_elapsed -lt $tick ]]; then
+			sleep $((tick - tick_elapsed))
+		fi
+	done
 }
 
 # Dump diagnostic info for a namespace and optional resource

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+################################################################################
+# Script: status.sh
+# Description: Show installed components with deployment health and replica readiness
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
+check_help "$@" && exit 0
+load_env
+
+# Dim text for "Not installed" (common.sh has no DIM)
+DIM=''
+if [[ -n "$GREEN" ]]; then
+	DIM='\033[2m'
+fi
+
+# Print Ready/Degraded from "desired ready" replica counts.
+# Empty readyReplicas is treated as 0.
+print_ready_status() {
+	local info="$1"
+	local desired ready
+	read -r desired ready <<<"$info"
+	desired="${desired:-0}"
+	ready="${ready:-0}"
+
+	if [[ "$ready" == "$desired" ]] && [[ "$ready" != "0" ]]; then
+		echo -e "${GREEN}Ready ${ready}/${desired}${NC}"
+	else
+		echo -e "${YELLOW}Degraded ${ready}/${desired}${NC}"
+	fi
+}
+
+# Print one table row for a named deployment.
+show_deployment_status() {
+	local label="$1"
+	local name="$2"
+	local namespace="$3"
+
+	printf "  %-25s " "$label"
+
+	local info
+	if ! info=$("$KUBE_CLI" get deployment "$name" -n "$namespace" \
+		-o jsonpath='{.spec.replicas}{" "}{.status.readyReplicas}' 2>/dev/null) ||
+		[[ -z "${info// /}" ]]; then
+		echo -e "${DIM}Not installed${NC}"
+		return 0
+	fi
+
+	print_ready_status "$info"
+}
+
+# OADP uses deployment/velero when present, otherwise the velero label selector.
+show_oadp_status() {
+	printf "  %-25s " "OADP"
+
+	local info
+	if info=$("$KUBE_CLI" get deployment velero -n openshift-adp \
+		-o jsonpath='{.spec.replicas}{" "}{.status.readyReplicas}' 2>/dev/null) &&
+		[[ -n "${info// /}" ]]; then
+		print_ready_status "$info"
+		return 0
+	fi
+
+	info=$("$KUBE_CLI" get deployment -n openshift-adp -l app.kubernetes.io/name=velero \
+		-o jsonpath='{.items[0].spec.replicas}{" "}{.items[0].status.readyReplicas}' 2>/dev/null || true)
+
+	if [[ -z "${info// /}" ]]; then
+		echo -e "${DIM}Not installed${NC}"
+		return 0
+	fi
+
+	print_ready_status "$info"
+}
+
+print_header "Component Status Dashboard"
+
+printf "  %b%-25s %s%b\n" "$BOLD" "Component" "Status" "$NC"
+echo "  ─────────────────────── ──────────────────────────"
+
+show_deployment_status "cert-manager" "cert-manager" "cert-manager"
+show_deployment_status "cert-manager-webhook" "cert-manager-webhook" "cert-manager"
+show_deployment_status "Pebble ACME server" "pebble" "pebble"
+show_deployment_status "Fake DNS API" "fake-dns-api" "fake-dns"
+show_deployment_status "acme-dns" "acme-dns" "acme-dns"
+show_deployment_status "pebble-challtestsrv" "pebble-challtestsrv" "pebble"
+show_deployment_status "MinIO" "minio" "minio"
+show_oadp_status
+
+echo
+echo -e "  ${BOLD}Issuers:${NC}"
+"$KUBE_CLI" get clusterissuer -o wide 2>/dev/null || echo -e "  ${DIM}No ClusterIssuers found${NC}"
+echo
+echo -e "  ${BOLD}Certificates:${NC}"
+"$KUBE_CLI" get certificate --all-namespaces 2>/dev/null || echo -e "  ${DIM}No Certificates found${NC}"
+echo


### PR DESCRIPTION
## Summary

- Show replica readiness in `make status` (`Ready 1/1` / `Degraded 0/1`) instead of only Installed/Not installed (#149)
- Print `Still waiting... (elapsed/timeout)` progress during long `wait_for_resource` polls (#147)
- Add `make uninstall-monitoring` as an alias of `clean-monitoring` so install-monitoring has a matching teardown (#150)

Closes #147, closes #149, closes #150

## Test plan

- [ ] `make lint` passes
- [ ] `make help | grep uninstall-monitoring` lists the new target
- [ ] `make -n uninstall-monitoring` runs the same deletes as `clean-monitoring`
- [ ] `make status` on a cluster with nothing installed shows `Not installed` for every component
- [ ] `make status` on a cluster with Pebble up shows `Pebble ACME server    Ready 1/1`
- [ ] A deployment with 0 ready replicas shows `Degraded`, not `Installed`
- [ ] `wait_for_resource deployment/does-not-exist default 15s` prints at least one `Still waiting...` line, then failure diagnostics


Made with [Cursor](https://cursor.com)