### PR TITLE
Fix stale docs: broken links, mismatched examples, and CI descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ make uninstall-cert-manager-operator   # Remove operator (interactive confirm)
 
 ### Fix Formatting
 ```bash
-shfmt -w scripts/ lib/    # Auto-fix shell formatting
+make fmt    # Auto-fix shell formatting (shfmt -w scripts/ lib/)
 ```
 
 ## Architecture
@@ -128,7 +128,7 @@ Key functions:
 - **Cluster**: `require_healthy_cluster [max_attempts] [interval]` — waits for dns, network, ingress operators to be Available
 - **Environment**: `load_env` — loads `.env` from script or parent directory
 - **Retry**: `retry <max_attempts> <delay> <command...>` — exponential backoff
-- **Wait**: `wait_for_resource <type/name> <namespace> <timeout>` — uses `oc wait --for=condition=available`
+- **Wait**: `wait_for_resource <type/name> <namespace> <timeout>` — polls until ready and logs progress every 15s
 - **Cleanup**: `setup_cleanup` + `register_temp_file` — trap-based cleanup with duration tracking
 - **Output**: `print_summary "Key1" "Val1" "Key2" "Val2"` — formatted summary table
 - **Headers**: `print_header "Title"` — formatted section header box
@@ -161,18 +161,20 @@ The LCA (Lifecycle Agent) apply-label format is `<apiGroup>/<version>/<resourceT
 - Scripts resolve their own location with `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` (varies by depth — see sourcing patterns above)
 - Use shared functions: `require_cmd`/`require_cluster` instead of inline prerequisite checks, `apply_yaml_template` instead of inline envsubst, `print_header` instead of inline echo headers, `wait_for_resource` instead of custom polling loops
 - `shfmt` formatting: 2-space indentation (tabs in Makefile), binary operators at line start, switch cases indented
-- `shellcheck` with severity=error; excluded codes: SC1091, SC2034
+- `shellcheck` with severity=error. Local `make lint` also excludes SC1091, SC2034, SC2329
 - Cleanup operations use `--ignore-not-found=true` for idempotency
 - New Makefile targets need a `## Description` comment suffix for `make help` integration
 
 ## CI Pipeline
 
 CI runs on PRs to main (`.github/workflows/pre-main.yml`):
-1. **shell-format-check** — `shfmt -d .`
-2. **shellcheck** — severity=error on `scripts/`
-3. **workload-partitioning-check** — validates script existence, executability, syntax
-4. **verify-structure** — directory layout and key files
-5. **integration-test** — deploys OCP 4.20/4.21 CRC cluster (matrix), runs `make quick-http-test`, API server cert creation/verification, workload partitioning check, network stack detection
+1. **shell-format-check** — `shfmt -d scripts/ lib/`
+2. **shellcheck** — severity=error on `scripts/` and `lib/`
+3. **workload-partitioning-check** — script exists, is executable, syntax + Makefile/docs mentions
+4. **verify-structure** — directory layout, key files, script references
+5. **version-query-check** — version query scripts for pebble, acme-dns, operator, minio, ubi9-python
+6. **kind-integration-test** — Kind cluster, cert-manager v1.19.0 / v1.20.0
+7. **integration-test** — OCP 4.20/4.21/4.22 × cert-manager v1.19.0/v1.20.0 CRC matrix (skipped for dependabot); `make quick-http-test`, API server cert, workload partitioning, network stack detection
 
 ## Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,14 +35,14 @@ Thank you for contributing to cert-manager-scripts! This guide will help you get
 All shell scripts must follow consistent formatting using `shfmt`:
 
 ```bash
-# Check formatting (what CI runs)
-shfmt -d .
+# Check formatting + shellcheck (what you should run locally)
+make lint
 
-# Auto-format all scripts
-shfmt -w .
+# Auto-format scripts
+make fmt
 
-# Format specific file
-shfmt -w script-name.sh
+# Format a specific file
+shfmt -w scripts/your-script.sh
 ```
 
 **Formatting rules:**
@@ -54,13 +54,9 @@ shfmt -w script-name.sh
 
 Before submitting a pull request:
 
-1. **Format check:**
+1. **Format and lint check:**
    ```bash
-   # Using Make (recommended)
    make lint
-   
-   # Or directly with shfmt
-   shfmt -d scripts/
    ```
 
 2. **Test on a real cluster:**
@@ -109,12 +105,12 @@ Before submitting a pull request:
 4. **Open a Pull Request** on GitHub
 
 5. **Ensure CI passes:**
-   - Shell format check must pass
-   - Integration tests must pass (requires `CRC_PULL_SECRET` secret)
+   - `make lint` (shfmt + shellcheck)
+   - Integration tests (Kind always; OCP needs `CRC_PULL_SECRET`)
 
 ### Pull Request Checklist
 
-- [ ] Code follows shell script formatting (shfmt)
+- [ ] `make lint` passes (shfmt + shellcheck)
 - [ ] Tested on a real OpenShift cluster
 - [ ] Scripts are idempotent (can run multiple times safely)
 - [ ] Documentation updated (README.md or relevant .md files)
@@ -129,25 +125,17 @@ This repository uses GitHub Actions to automatically test changes.
 
 ### Workflow: `pre-main.yml`
 
-The CI pipeline runs on every push and pull request with two jobs:
+Runs on every push and pull request to `main`:
 
-#### 1. Shell Format Check
-- Validates all shell scripts with `shfmt`
-- Ensures consistent formatting across the codebase
-- **Must pass** before integration tests run
+1. **Shell format check** — `shfmt -d scripts/ lib/`
+2. **ShellCheck** — `shellcheck --severity=error` on `scripts/` and `lib/`
+3. **Workload partitioning check** — script present, executable, valid syntax
+4. **Structure check** — directory layout, key files, script references
+5. **Version query check** — pebble, acme-dns, operator, minio, ubi9-python
+6. **Kind integration test** — cert-manager v1.19.0 and v1.20.0
+7. **OCP integration test** — CRC via [quick-ocp](https://github.com/palmsoftware/quick-ocp), matrix of OCP 4.20/4.21/4.22 × cert-manager v1.19.0/v1.20.0. Runs `make quick-http-test` (HTTP-01, not DNS-01), API server cert verification, workload partitioning, and network stack detection. Skipped for dependabot.
 
-#### 2. Integration Test (OCP 4.20/4.21 + cert-manager)
-- Deploys a real OpenShift cluster using [quick-ocp](https://github.com/palmsoftware/quick-ocp)
-- Installs cert-manager-operator
-- Runs the complete `make quick-http-test` workflow:
-  - Installs fake DNS for air-gapped testing
-  - Installs Pebble ACME server
-  - Creates DNS-01 ClusterIssuer
-  - Requests wildcard certificate
-  - Validates certificate issuance
-- Displays detailed results and logs on failure
-
-**Note:** Integration tests require the `CRC_PULL_SECRET` GitHub secret for deploying the OCP cluster. This is only available in the upstream repository.
+OCP integration tests need the `CRC_PULL_SECRET` GitHub secret (upstream only). See [CI cluster health](docs/CRC-CLUSTER-HEALTH-IMPROVEMENTS.md) for the CRC health-check flow.
 
 ### Running CI Tests Locally
 
@@ -166,9 +154,8 @@ make quick-http-test
 
 If CI fails:
 
-1. **Format check failure:**
-   - Run `shfmt -w scripts/` to auto-format all scripts
-   - Or check what needs fixing with `make lint`
+1. **Format or ShellCheck failure:**
+   - Run `make fmt` then `make lint`
    - Commit the formatting changes
 
 2. **Integration test failure:**
@@ -189,14 +176,16 @@ Update documentation when you:
 
 ### Documentation Files
 
-- **README.md** - Overview, quick start, and key links
-- **[docs/installation.md](docs/installation.md)** - Detailed installation instructions
-- **[docs/troubleshooting.md](docs/troubleshooting.md)** - Common issues and solutions
-- **[docs/pebble-usage.md](docs/pebble-usage.md)** - Pebble-specific usage and examples
-- **[docs/network-support.md](docs/network-support.md)** - IPv4/IPv6/dual-stack testing
-- **[docs/dns01-setup.md](docs/dns01-setup.md)** - DNS-01 challenge configuration
-- **[docs/ibu-testing.md](docs/ibu-testing.md)** - Image-Based Upgrade certificate loss validation
-- **CONTRIBUTING.md** - This file
+- **README.md** — overview and quick start
+- **[docs/README.md](docs/README.md)** — documentation index
+- **[docs/getting-started.md](docs/getting-started.md)** — first-time walkthrough
+- **[docs/installation.md](docs/installation.md)** — component install
+- **[docs/troubleshooting.md](docs/troubleshooting.md)** — diagnostics
+- **[docs/pebble-usage.md](docs/pebble-usage.md)** — Pebble
+- **[docs/dns01-setup.md](docs/dns01-setup.md)** — DNS-01
+- **[docs/network-support.md](docs/network-support.md)** — IPv4/IPv6/dual-stack
+- **[docs/ibu-testing.md](docs/ibu-testing.md)** — IBU certificate validation
+- **CONTRIBUTING.md** — this file
 
 ### Documentation Style
 
@@ -255,9 +244,8 @@ When adding a new script:
 
 ## Getting Help
 
-- **Issues:** Open an issue for bugs or feature requests
-- **Discussions:** Use GitHub Discussions for questions
-- **Pull Requests:** Reference related issues in your PR description
+- **Issues:** bugs and feature requests
+- **Pull Requests:** reference related issues in the description
 
 ## Code of Conduct
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Brandon Palm and contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ For DNS-01 with air-gapped fake DNS, use `make quick-dns-test` instead.
 
 ## Guides
 
+See [docs/README.md](docs/README.md) for the full index.
+
 | Guide | Description |
 |-------|-------------|
-| [Installation](docs/installation.md) | Step-by-step setup for cert-manager and Pebble |
-| [Pebble Usage](docs/pebble-usage.md) | Working with the local ACME test server |
-| [DNS-01 Setup](docs/dns01-setup.md) | Air-gapped DNS-01 challenge configuration |
-| [Network Support](docs/network-support.md) | IPv4/IPv6/dual-stack cluster testing |
+| [Getting Started](docs/getting-started.md) | Walkthrough from prerequisites to HTTP-01 and DNS-01 tests |
+| [Installation](docs/installation.md) | Component-by-component install |
+| [Pebble Usage](docs/pebble-usage.md) | Local ACME test server |
+| [DNS-01 Setup](docs/dns01-setup.md) | Air-gapped DNS-01 (fake DNS or acme-dns) |
+| [Network Support](docs/network-support.md) | IPv4/IPv6/dual-stack |
 | [IBU Testing](docs/ibu-testing.md) | Image-Based Upgrade certificate validation |
-| [Troubleshooting](docs/troubleshooting.md) | Common issues and diagnostic commands |
-| [Getting Started](docs/getting-started.md) | Step-by-step walkthrough from prerequisites to testing |
+| [Troubleshooting](docs/troubleshooting.md) | Diagnostics and common failures |
 | [Contributing](CONTRIBUTING.md) | Development setup and pull request process |
 
 ## Prerequisites
@@ -57,8 +59,9 @@ cp .env.example .env
 make help       # Show all available targets
 make preflight  # Check tool dependencies and cluster prerequisites
 make lint       # Run shellcheck + shfmt (CI gate)
+make fmt        # Auto-fix shell formatting
 ```
 
 ## License
 
-Apache 2.0
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/docs/CRC-CLUSTER-HEALTH-IMPROVEMENTS.md
+++ b/docs/CRC-CLUSTER-HEALTH-IMPROVEMENTS.md
@@ -1,147 +1,17 @@
-# CRC Cluster Health Check Improvements
+# CI Cluster Health Checks
 
-## Overview
+Integration tests deploy a CRC cluster. These scripts catch DNS/API instability before it looks like a cert-manager failure.
 
-Enhanced CI workflow reliability by adding comprehensive cluster health checks and recovery mechanisms to detect and handle CRC cluster instability issues before they cause test failures.
+| Script | Role |
+|--------|------|
+| `scripts/workflows/verify-cluster-access.sh` | DNS, kubeconfig, auth, API reachability, node readiness, operator health |
+| `scripts/workflows/recover-cluster.sh` | Retry DNS/auth/API after a transient failure |
+| `scripts/workflows/display-component-status.sh` | Component status that degrades cleanly if the cluster is down |
+| `scripts/workflows/wait-for-cluster-operators.sh` | Wait for cluster operators after CRC comes up |
 
-## Problem
+Used from `.github/workflows/reusable-integration-test.yml`:
 
-Integration tests were failing with:
-```
-Unable to connect to the server: dial tcp: lookup api.crc.testing: no such host
-```
-
-This indicates CRC cluster DNS resolution failures or cluster crashes mid-test, which are common in CI environments due to:
-- Resource constraints
-- DNS propagation delays
-- Cluster instability after heavy operations
-- API server responsiveness issues
-
-## Solution
-
-### 1. Enhanced Cluster Verification Script
-
-**File:** `scripts/workflows/verify-cluster-access.sh`
-
-Comprehensive health checks that verify:
-- ✅ oc CLI availability
-- ✅ DNS resolution for API server (catches the `no such host` error early)
-- ✅ KUBECONFIG validity
-- ✅ Cluster authentication
-- ✅ API server reachability
-- ✅ Node presence and readiness
-- ✅ Cluster operator health
-- ✅ API responsiveness timing
-
-**Benefits:**
-- Catches DNS failures before tests start
-- Validates cluster is stable enough for testing
-- Provides detailed diagnostic output
-- Exits early if cluster is unhealthy
-
-### 2. New Cluster Recovery Script
-
-**File:** `scripts/workflows/recover-cluster.sh`
-
-Attempts to recover from common failure states:
-- DNS resolution failures (with refresh attempts)
-- Authentication issues (token refresh)
-- API server unresponsiveness (with retries)
-
-**Benefits:**
-- Automatic recovery from transient issues
-- Reduces false-positive test failures
-- Extends cluster stability window
-
-### 3. Improved Component Status Display
-
-**File:** `scripts/workflows/display-component-status.sh`
-
-Enhanced to:
-- Check cluster accessibility before attempting status queries
-- Provide clear error messages when cluster is down
-- Gracefully handle individual component query failures
-- Give actionable diagnostic information
-
-**Benefits:**
-- Prevents confusing error logs when cluster is down
-- Helps diagnose whether issue is cluster-wide or component-specific
-
-### 4. Enhanced CI Workflow
-
-**File:** `.github/workflows/pre-main.yml`
-
-Improvements:
-1. **Initial Health Check** (after CRC deployment)
-   - 5 retry attempts with 30s wait between retries
-   - Ensures cluster is fully stable before starting tests
-
-2. **Cluster Stabilization Wait**
-   - 30-second wait after initial verification
-   - Allows DNS and operators to fully stabilize
-
-3. **Pre-Test Health Checks**
-   - Added before HTTP-01 tests (with 3 retries)
-   - Added before API server cert tests (with 3 retries)
-
-4. **Cluster Recovery on Retry**
-   - Automatic recovery attempt when tests fail
-   - Runs `recover-cluster.sh` before retrying failed tests
-
-5. **Final Health Check**
-   - Runs after all tests complete (even on failure)
-   - Helps diagnose if cluster became unstable during testing
-
-## Workflow Changes Summary
-
-```yaml
-Before:
-- Deploy CRC
-- Run tests (no health checks)
-- Test fails with "no such host"
-
-After:
-- Deploy CRC
-- Initial health check (5 retries, 30s between)
-- Wait 30s for stabilization
-- Health check before each major test phase (3 retries)
-- Auto-recovery on test failure
-- Run tests
-- Final health check
-```
-
-## Expected Impact
-
-### Reduced False Positives
-- Early detection of cluster issues prevents misleading test failures
-- Recovery mechanisms handle transient failures automatically
-
-### Better Diagnostics
-- Clear indication of whether issue is cluster or test-related
-- Detailed health information in logs
-- Easier troubleshooting when real issues occur
-
-### Improved Reliability
-- Multiple retry points with increasing wait times
-- Cluster stabilization periods
-- Recovery attempts between retries
-
-## Testing Recommendations
-
-1. Monitor next few CI runs to validate improvements
-2. Check for reduced "no such host" failures
-3. Verify recovery mechanisms are working
-4. Adjust retry counts/timeouts if needed
-
-## Maintenance Notes
-
-- Health check thresholds may need tuning based on observed behavior
-- Recovery script can be extended with additional recovery strategies
-- Consider adding metrics/telemetry for cluster health patterns
-
-## Related Issues
-
-- Addresses GitHub Actions integration test failures due to CRC instability
-- Prevents DNS resolution failures from causing test failures
-- Improves overall CI reliability for cert-manager testing
-
+1. After CRC deploy: wait for operators, then health-check with retries.
+2. Before HTTP-01 and API-server cert tests: health-check again.
+3. On test failure: run `recover-cluster.sh` before retry.
+4. Always: final health-check and component status (including on failure).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@
 | [Getting Started](getting-started.md) | Step-by-step walkthrough from prerequisites to testing |
 | [Installation](installation.md) | Detailed installation for each component |
 | [Pebble Usage](pebble-usage.md) | Working with the local ACME test server |
-| [DNS-01 Setup](dns01-setup.md) | Air-gapped DNS-01 challenge configuration |
+| [DNS-01 Setup](dns01-setup.md) | Air-gapped DNS-01 (fake DNS or acme-dns) |
 | [Network Support](network-support.md) | IPv4/IPv6/dual-stack cluster testing |
 | [IBU Testing](ibu-testing.md) | Image-Based Upgrade certificate validation |
 | [Troubleshooting](troubleshooting.md) | Common issues and diagnostic commands |
@@ -17,7 +17,7 @@
 | Document | Description |
 |----------|-------------|
 | [IBU-FAQ](IBU-FAQ.md) | Frequently asked questions about IBU certificate testing |
-| [CRC Cluster Health](CRC-CLUSTER-HEALTH-IMPROVEMENTS.md) | CI workflow health check enhancements |
+| [CI Cluster Health](CRC-CLUSTER-HEALTH-IMPROVEMENTS.md) | CRC health checks used by OCP integration tests |
 | [Contributing](../CONTRIBUTING.md) | Development setup and pull request process |
 
 ## Choosing a Challenge Type

--- a/docs/dns01-setup.md
+++ b/docs/dns01-setup.md
@@ -1,111 +1,44 @@
 # DNS-01 Challenge Setup Guide
 
-This guide shows you how to set up **fully local DNS-01 challenge testing** on your OpenShift cluster without any external dependencies.
+DNS-01 is required for wildcard certificates (`*.example.com`). This repo supports two fully local paths:
 
-## What You'll Get
+| Path | Use when |
+|------|----------|
+| **fake DNS** (recommended) | Air-gapped / CI testing. RFC2136 nameserver inside the cluster. |
+| **acme-dns** | You want a closer ACME-DNS workflow. cert-manager uses the native `acmeDNS` solver. |
 
-✅ Local DNS server (acme-dns) for ACME challenges  
-✅ Pebble ACME server using your local DNS  
-✅ cert-manager configured for DNS-01  
-✅ Ability to test wildcard certificates  
-✅ **No external DNS provider needed**  
-✅ **No real DNS records needed**
+Neither path needs a public DNS provider or internet connectivity.
 
-## Quick Start
-
-### Step 1: Install Local DNS Server
+## Recommended: fake DNS
 
 ```bash
-./install-local-dns.sh
+make install-cert-manager-operator
+make install-fake-dns
+DNS_SERVER=fake-dns-api.fake-dns.svc.cluster.local:53 make install-pebble
+make create-dns01-issuer
+make test-cert
+make verify-cert
 ```
 
-This installs **acme-dns** - a lightweight DNS server with an API designed specifically for ACME challenges.
+Or run the whole flow with `make quick-dns-test`.
 
-### Step 2: Reinstall Pebble to Use Local DNS
+`create-dns01-issuer` applies `yaml/issuers/pebble-dns01-simple-clusterissuer.yaml` (RFC2136 pointing at `DNS_SERVER`). For smoke tests, install Pebble with `PEBBLE_ALWAYS_VALID=1` so challenges succeed without a real TXT lookup.
+
+See [Fake DNS API](../yaml/fake-dns-api/README.md) for manifests.
+
+## Alternative: acme-dns
+
+[acme-dns](https://github.com/acme-dns/acme-dns) exposes DNS (port 53) and an HTTP API (port 8080). cert-manager talks to it with the native [`acmeDNS` solver](https://cert-manager.io/docs/configuration/acme/dns01/acme-dns/) — no webhook install is required.
 
 ```bash
-# Delete existing Pebble
-oc delete namespace pebble
-
-# Reinstall pointing to acme-dns
-DNS_SERVER=acme-dns.acme-dns.svc.cluster.local:53 PEBBLE_ALWAYS_VALID=1 ./install-pebble.sh
+make install-local-dns
+DNS_SERVER=acme-dns.acme-dns.svc.cluster.local:53 PEBBLE_ALWAYS_VALID=1 make install-pebble
+make register-acmedns
 ```
 
-Now Pebble will query your local acme-dns server for DNS validation!
+`register-acmedns` registers an account and creates a credentials Secret in the `cert-manager` namespace. Point a ClusterIssuer at that secret:
 
-### Step 3: Install cert-manager Webhook for acme-dns
-
-The cert-manager webhook allows cert-manager to create DNS records in acme-dns.
-
-```bash
-# Install the acme-dns webhook
-helm repo add cert-manager-webhook-acmedns https://k3rnelpan1c-dev.github.io/cert-manager-webhook-acmedns
-helm repo update
-
-helm install cert-manager-webhook-acmedns \
-  cert-manager-webhook-acmedns/cert-manager-webhook-acmedns \
-  -n cert-manager \
-  --set groupName=acme.mycompany.com
-```
-
-Or manually deploy:
-```bash
-kubectl apply -f https://raw.githubusercontent.com/k3rnelpan1c-dev/cert-manager-webhook-acmedns/master/deploy/manifests.yaml
-```
-
-### Step 4: Register with acme-dns
-
-Create an account in acme-dns for each domain you want to test:
-
-```bash
-# Register a domain
-oc run --rm -i acmedns-register --image=curlimages/curl --restart=Never -- \
-  curl -X POST http://acme-dns.acme-dns.svc.cluster.local:8080/register
-
-# Save the output - you'll need the credentials
-```
-
-Example output:
-```json
-{
-  "username": "eabcdb41-d89f-4580-bb05-cd43c5d53b79",
-  "password": "pbAXVjlIOE01xbut7YnAbkhMQIkcwoHO0ek2j4Q0",
-  "fulldomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf.acme-dns.local",
-  "subdomain": "d420c923-bbd7-4056-ab64-c3ca54c9b3cf",
-  "allowfrom": []
-}
-```
-
-### Step 5: Create DNS-01 ClusterIssuer
-
-Create a secret with your acme-dns credentials:
-
-```bash
-cat <<EOF | oc apply -f -
-apiVersion: v1
-kind: Secret
-metadata:
-  name: acmedns-credentials
-  namespace: cert-manager
-type: Opaque
-stringData:
-  acmedns.json: |
-    {
-      "*.example.com": {
-        "username": "YOUR_USERNAME",
-        "password": "YOUR_PASSWORD",
-        "fulldomain": "YOUR_FULLDOMAIN",
-        "subdomain": "YOUR_SUBDOMAIN",
-        "serverurl": "http://acme-dns.acme-dns.svc.cluster.local:8080"
-      }
-    }
-EOF
-```
-
-Create the ClusterIssuer:
-
-```bash
-cat <<EOF | oc apply -f -
+```yaml
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
@@ -122,141 +55,43 @@ spec:
         acmeDNS:
           host: http://acme-dns.acme-dns.svc.cluster.local:8080
           accountSecretRef:
-            name: acmedns-credentials
+            name: acme-dns-credentials
             key: acmedns.json
-EOF
 ```
 
-### Step 6: Test with a Wildcard Certificate
+Then:
 
 ```bash
-cat <<EOF | oc apply -f -
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: wildcard-cert-test
-  namespace: default
-spec:
-  secretName: wildcard-cert-tls
-  issuerRef:
-    name: pebble-dns01-issuer
-    kind: ClusterIssuer
-  dnsNames:
-  - "*.example.com"
-  - "example.com"
-EOF
+make test-cert
+make verify-cert
 ```
 
-### Step 7: Verify
-
-```bash
-# Watch certificate status
-watch oc get certificate -n default
-
-# Check if cert is ready
-oc get certificate wildcard-cert-test -n default
-
-# View the certificate
-oc get secret wildcard-cert-tls -n default -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
-```
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────┐
-│                   Your OCP Cluster                       │
-│                                                          │
-│  ┌──────────────┐      ┌─────────────┐                 │
-│  │ cert-manager │─────→│  acme-dns   │                 │
-│  │              │      │  (DNS API)  │                 │
-│  └──────┬───────┘      └──────┬──────┘                 │
-│         │                      │                         │
-│         │  ACME                │  DNS                    │
-│         │  Protocol            │  Queries                │
-│         │                      │                         │
-│         ↓                      ↓                         │
-│  ┌──────────────┐      ┌─────────────┐                 │
-│  │   Pebble     │─────→│  acme-dns   │                 │
-│  │ (ACME Server)│      │ (DNS Server)│                 │
-│  └──────────────┘      └─────────────┘                 │
-│                                                          │
-│  Everything runs locally - no external dependencies!    │
-└─────────────────────────────────────────────────────────┘
-```
-
-## How It Works
-
-1. **cert-manager** requests a certificate from **Pebble**
-2. **Pebble** says "prove ownership with DNS-01 challenge"
-3. **cert-manager** creates a TXT record in **acme-dns** via API
-4. **Pebble** queries **acme-dns** to verify the TXT record
-5. With `PEBBLE_ALWAYS_VALID=1`, validation auto-succeeds
-6. **Pebble** issues the certificate
-7. **cert-manager** stores it in a Secret
-
-## Benefits of This Setup
-
-✅ **Completely Local** - Everything runs in your cluster  
-✅ **No External Dependencies** - No Route53, CloudFlare, etc needed  
-✅ **Test Wildcard Certs** - DNS-01 is required for wildcards  
-✅ **Fast** - No waiting for DNS propagation  
-✅ **Repeatable** - Same setup works on any OCP cluster  
-✅ **Safe** - No rate limits, no real certificates  
-
-## Troubleshooting
-
-### acme-dns Not Starting
+### acme-dns troubleshooting
 
 ```bash
 oc logs -n acme-dns deployment/acme-dns
 oc describe pod -n acme-dns
-```
 
-### Pebble Can't Reach acme-dns
-
-```bash
-# Test DNS resolution from Pebble
+# DNS resolution from the Pebble namespace
 oc run --rm -i dns-test --image=busybox --restart=Never -n pebble -- \
   nslookup acme-dns.acme-dns.svc.cluster.local
-```
 
-### Certificate Stuck in Pending
-
-```bash
-# Check challenge status
 oc describe challenge -n default
-
-# Check cert-manager logs
 oc logs -n cert-manager deployment/cert-manager -f
-
-# Check Pebble logs
-oc logs -n pebble deployment/pebble -f
 ```
 
-### Webhook Not Working
+## How validation works
 
-```bash
-# Check webhook deployment
-oc get pods -n cert-manager | grep webhook
-
-# Check webhook logs
-oc logs -n cert-manager deployment/cert-manager-webhook-acmedns
-```
-
-## Alternative: Simpler Setup with Always-Valid
-
-If you just want to test the mechanics without full DNS setup:
-
-1. Keep `PEBBLE_ALWAYS_VALID=1`
-2. Use a dummy DNS-01 solver configuration
-3. Pebble will auto-validate without checking DNS
-
-This is less realistic but useful for testing cert-manager functionality.
+1. cert-manager requests a certificate from Pebble.
+2. Pebble asks for a DNS-01 proof (TXT record).
+3. cert-manager publishes the TXT record via fake DNS (RFC2136) or the acme-dns API.
+4. Pebble queries that local DNS server.
+5. With `PEBBLE_ALWAYS_VALID=1`, Pebble accepts the challenge without checking DNS.
+6. Pebble issues the certificate and cert-manager stores it in a Secret.
 
 ## References
 
-- [acme-dns GitHub](https://github.com/joohoi/acme-dns)
-- [cert-manager acme-dns webhook](https://github.com/k3rnelpan1c-dev/cert-manager-webhook-acmedns)
-- [Pebble Documentation](https://github.com/letsencrypt/pebble)
+- [acme-dns](https://github.com/acme-dns/acme-dns)
+- [cert-manager ACMEDNS solver](https://cert-manager.io/docs/configuration/acme/dns01/acme-dns/)
 - [cert-manager DNS-01 Guide](https://cert-manager.io/docs/configuration/acme/dns01/)
-
+- [Pebble](https://github.com/letsencrypt/pebble)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,7 @@ Before you begin, ensure you have:
 - OpenShift cluster (4.20+)
 - `oc` CLI installed and configured with cluster-admin privileges
 - `openssl` for certificate inspection
+- `jq` (`brew install jq` or `dnf install jq`)
 - `envsubst` (`brew install gettext` on macOS, `dnf install gettext` on RHEL/Fedora)
 
 Verify cluster access:
@@ -106,7 +107,7 @@ Press `Ctrl+C` once the certificate shows `READY: True`.
 ### Inspect the Certificate
 
 ```bash
-oc get secret test-cert-http01-tls -n default -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+oc get secret test-cert-simple-tls -n default -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
 ```
 
 ## Step 3b: DNS-01 Wildcard Certificates

--- a/docs/ibu-testing.md
+++ b/docs/ibu-testing.md
@@ -30,7 +30,7 @@ Since IBU requires specific operators (Lifecycle Agent, TALM) and seed images, t
 
 ## Prerequisites
 
-- OpenShift 4.12+ cluster with default StorageClass
+- OpenShift 4.20+ cluster with default StorageClass
 - `oc` CLI with cluster-admin privileges
 - `jq` command-line JSON processor
 - `envsubst` command (`brew install gettext` on macOS)
@@ -185,6 +185,7 @@ metadata:
 | `make test-ibu-preserved` | Run Scenario 2: Certificate preservation test |
 | `make test-ibu-both` | Run both scenarios sequentially |
 | `make quick-ibu-test` | End-to-end test (prereqs + Scenario 1) |
+| `make test-ibu-multi-algo` | Scenario 1 with ECDSA, RSA, and Ed25519 certs |
 | `make clean-ibu` | Clean up all IBU test resources |
 
 ## Understanding Results
@@ -256,7 +257,7 @@ MinIO provides S3-compatible object storage for Velero backups:
 OADP installs Velero for backup/restore operations:
 
 - **Namespace**: `openshift-adp`
-- **Operator**: Red Hat OADP Operator (stable-1.4)
+- **Operator**: Red Hat OADP Operator (`stable` channel)
 - **Backup Location**: MinIO S3 bucket `velero`
 
 ## State Files
@@ -329,9 +330,7 @@ This removes:
 
 ## References
 
-- [Red Hat OADP Documentation](https://docs.openshift.com/container-platform/latest/backup_and_restore/application_backup_and_restore/oadp-intro.html)
-- [Image-Based Upgrade for SNO](https://docs.openshift.com/container-platform/latest/edge_computing/image_based_upgrade/cnf-about-image-based-upgrade.html)
-- [cert-manager on OpenShift](https://docs.openshift.com/container-platform/latest/security/cert_manager_operator/index.html)
-- [Creating ConfigMap objects for IBU](https://docs.openshift.com/container-platform/4.17/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-prep-resources.html)
-- [IBU with GitOps ZTP](https://docs.openshift.com/container-platform/4.17/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/ztp-image-based-upgrade-prep-resources.html)
+- [Red Hat OADP Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/backup_and_restore/oadp-application-backup-and-restore)
+- [Image-Based Upgrade for SNO](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/edge_computing/image-based-upgrade-for-single-node-openshift-clusters)
+- [cert-manager Operator for Red Hat OpenShift](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift)
 - [Red Hat Article 7057298](https://access.redhat.com/articles/7057298)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,14 +6,14 @@ Detailed installation instructions for cert-manager-scripts components.
 
 Before running any scripts, ensure you have:
 
-- **OpenShift cluster** (4.20+ recommended)
-- **`oc` CLI** installed and configured
-- **`openssl`** for certificate inspection (pre-installed on most systems)
-- **`envsubst`** command (part of gettext package)
+- **OpenShift cluster** (4.20+)
+- **`oc` CLI** installed and configured with cluster-admin privileges
+- **`openssl`** for certificate inspection
+- **`jq`** (`brew install jq` or `dnf install jq`)
+- **`envsubst`** (gettext package)
   - macOS: `brew install gettext`
   - RHEL/Fedora: `dnf install gettext`
-- **Cluster-admin privileges**
-- **Bash shell** (for shell scripts)
+- **Bash**
 
 ## Quick Installation
 
@@ -27,9 +27,13 @@ make test-all
 
 This will:
 - Install cert-manager-operator
-- Install Pebble with auto-validation enabled
-- Create a ClusterIssuer pointing to Pebble
-- Create test certificates
+- Install Pebble (default: real challenge validation, `PEBBLE_ALWAYS_VALID=0`)
+- Create an HTTP-01 ClusterIssuer pointing to Pebble
+- Create test certificates (`test-cert-simple`, `test-cert-app`, `test-cert-api`)
+
+For a smoke test that skips real ACME validation, use `make quick-http-test` instead (`PEBBLE_ALWAYS_VALID=1`).
+
+On vanilla Kubernetes (no OLM), install cert-manager with `make install-cert-manager-helm` instead of the operator target.
 
 ### Option 2: Step-by-Step Installation
 
@@ -254,7 +258,7 @@ After installing cert-manager-operator and Pebble, you can:
    - Verify HTTP-01 challenge handling
 
 2. **Test production-like scenarios:**
-   - Test apiServer certificate replacement
+   - Test API server certificate replacement
    - Test ingress certificate management
    - Test certificate renewal workflows
 

--- a/docs/network-support.md
+++ b/docs/network-support.md
@@ -76,7 +76,7 @@ Pebble (the ACME test server) also supports all network stacks:
 - ✅ DNS-01 challenges (DNS provider must be reachable via IPv4)
 - ✅ Certificate issuance for domains with A records
 - ✅ Wildcard certificates
-- ✅ apiServer certificates
+- ✅ API server certificates
 - ✅ Ingress/Route certificates
 
 **Limitations:**
@@ -90,7 +90,7 @@ Pebble (the ACME test server) also supports all network stacks:
 - ✅ DNS-01 challenges (DNS provider must be reachable via IPv6)
 - ✅ Certificate issuance for domains with AAAA records
 - ✅ Wildcard certificates
-- ✅ apiServer certificates
+- ✅ API server certificates
 - ✅ Ingress/Route certificates
 
 **Considerations:**
@@ -305,7 +305,7 @@ This will detect and display:
 
 ## References
 
-- [OpenShift Dual-Stack Documentation](https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html)
+- [OpenShift Dual-Stack Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ovn-kubernetes_network_plugin/converting-to-dual-stack)
 - [cert-manager Documentation](https://cert-manager.io/docs/)
 - [Kubernetes IPv6 Documentation](https://kubernetes.io/docs/concepts/services-networking/dual-stack/)
 

--- a/docs/pebble-usage.md
+++ b/docs/pebble-usage.md
@@ -77,23 +77,25 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: pebble-dns-issuer
+  name: pebble-dns01-issuer
 spec:
   acme:
     server: https://pebble.pebble.svc.cluster.local:14000/dir
     skipTLSVerify: true
     privateKeySecretRef:
-      name: pebble-dns-account-key
+      name: pebble-dns01-account-key
     solvers:
     - dns01:
-        # Example: Using Route53
-        route53:
-          region: us-east-1
-          accessKeyID: YOUR_ACCESS_KEY_ID
-          secretAccessKeySecretRef:
-            name: route53-credentials
-            key: secret-access-key
+        rfc2136:
+          nameserver: fake-dns-api.fake-dns.svc.cluster.local:53
+          tsigKeyName: dummy-key
+          tsigAlgorithm: HMACSHA256
+          tsigSecretSecretRef:
+            name: rfc2136-credentials
+            key: tsig-secret
 ```
+
+Prefer `make create-dns01-issuer` over applying this by hand. See [DNS-01 Setup](dns01-setup.md).
 
 ## Testing Certificate Issuance
 
@@ -125,7 +127,7 @@ metadata:
 spec:
   secretName: wildcard-tls
   issuerRef:
-    name: pebble-dns-issuer
+    name: pebble-dns01-issuer
     kind: ClusterIssuer
   dnsNames:
   - "*.apps.example.com"
@@ -253,7 +255,7 @@ oc rollout restart deployment/pebble -n pebble
 
 ## Pebble Challenge Test Server (pebble-challtestsrv)
 
-Pebble ships with a companion service called `pebble-challtestsrv` — a mock DNS/HTTP server that provides configurable responses for ACME challenge validation. It is deployed automatically alongside Pebble by `make install-pebble`.
+Pebble ships with a companion service called `pebble-challtestsrv` — a mock DNS/HTTP server that provides configurable responses for ACME challenge validation. Install it separately with `make install-pebble-challtestsrv` (it is **not** started by `make install-pebble`).
 
 ### When to Use challtestsrv vs PEBBLE_ALWAYS_VALID
 
@@ -266,12 +268,12 @@ For most users, `PEBBLE_ALWAYS_VALID=1` is sufficient. Use `pebble-challtestsrv`
 
 ### challtestsrv Ports
 
-| Port | Protocol | Purpose |
-|------|----------|---------|
-| 8053 | UDP/TCP | DNS queries |
-| 5002 | TCP | HTTP-01 challenge responses |
-| 5001 | TCP | TLS-ALPN-01/HTTPS challenges |
-| 8055 | TCP | Management API |
+| Port | Protocol | Purpose | Exposed by Service |
+|------|----------|---------|--------------------|
+| 8053 | UDP/TCP | DNS queries | yes |
+| 8055 | TCP | Management API | yes |
+| 5002 | TCP | HTTP-01 challenge responses | container only |
+| 5001 | TCP | TLS-ALPN-01/HTTPS challenges | container only |
 
 ### Management API
 
@@ -351,7 +353,7 @@ make install-cert-manager-operator
 PEBBLE_ALWAYS_VALID=1 make install-pebble
 
 # 3. Create ClusterIssuer
-oc apply -f your-pebble-issuer.yaml
+make create-issuer
 
 # 4. Create test Certificate
 oc apply -f your-test-certificate.yaml
@@ -377,5 +379,5 @@ oc delete clusterissuer pebble-issuer
 
 - [Pebble GitHub Repository](https://github.com/letsencrypt/pebble)
 - [cert-manager Documentation](https://cert-manager.io/docs/)
-- [ACME Protocol (RFC 8555)](https://tools.ietf.org/html/rfc8555)
+- [ACME Protocol (RFC 8555)](https://datatracker.ietf.org/doc/html/rfc8555)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,13 +4,13 @@ Common issues and solutions for cert-manager-scripts.
 
 ## Quick Test Issues
 
-The `quick-http-test` (or `quick-dns-test`) runs a complete end-to-end workflow and may fail for several reasons.
+The `quick-http-test` waits up to **3 minutes** for `test-cert-http01`. The `quick-dns-test` waits up to **5 minutes** for `wildcard-test`. Either can fail for several reasons.
 
 ### Common Issues
 
 #### 1. Timeout waiting for certificate (5 minutes)
 
-The test waits up to 5 minutes for the certificate to be issued.
+The test waits up to 3 minutes (HTTP-01) or 5 minutes (DNS-01) for the certificate to be issued.
 
 **Symptoms:**
 - Test hangs at "Waiting for certificate to be issued"
@@ -30,7 +30,10 @@ oc get order -n default
 # Verify Pebble is running
 oc get pods -n pebble
 
-# Check certificate details
+# Check certificate details (HTTP-01)
+oc describe certificate test-cert-http01 -n default
+
+# Check certificate details (DNS-01)
 oc describe certificate wildcard-test -n default
 ```
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -10,13 +10,15 @@ Shared shell library functions for cert-manager-scripts.
 
 ## Usage
 
-Source `common.sh` at the top of your scripts:
+Source `common.sh` at the top of scripts in `scripts/`:
 
 ```bash
 #!/bin/bash
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-source "$SCRIPT_DIR/lib/common.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
 ```
+
+Scripts in `scripts/troubleshooting/` and `scripts/workflows/` use `source "$SCRIPT_DIR/../../lib/common.sh"`. Most `scripts/ibu/` files set `SCRIPT_DIR` to the parent `scripts/` directory and then `source "$SCRIPT_DIR/../lib/common.sh"`.
 
 ## Available Functions
 
@@ -56,7 +58,9 @@ source "$SCRIPT_DIR/lib/common.sh"
 | Function | Description |
 |----------|-------------|
 | `retry 3 5 cmd args...` | Retry command with exponential backoff |
-| `wait_for_resource type/name ns timeout` | Wait for resource readiness |
+| `wait_for_resource type/name ns timeout` | Wait for resource readiness (progress every 15s) |
+| `print_header "Title"` | Section header |
+| `apply_yaml_template file.yaml "Kind"` | envsubst + oc apply |
 | `print_summary "Key" "Val" ...` | Print formatted summary table |
 
 ## Log Levels
@@ -80,8 +84,8 @@ LOG_LEVEL=debug ./scripts/install-pebble.sh
 
 ```bash
 #!/bin/bash
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-source "$SCRIPT_DIR/lib/common.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/common.sh"
 
 setup_cleanup
 load_env

--- a/scripts/install-local-dns.sh
+++ b/scripts/install-local-dns.sh
@@ -55,11 +55,12 @@ display_next_steps() {
 	echo "   oc delete namespace pebble"
 	echo "   DNS_SERVER=${acmedns_dns}:53 PEBBLE_ALWAYS_VALID=1 make install-pebble"
 	echo
-	echo "2. Install cert-manager webhook for acme-dns:"
-	echo "   See docs/dns01-setup.md for Helm-based webhook installation"
+	echo "2. Register an acme-dns account (native cert-manager solver, no webhook):"
+	echo "   make register-acmedns"
+	echo "   See docs/dns01-setup.md"
 	echo
-	echo "3. Create a DNS-01 ClusterIssuer:"
-	echo "   make create-dns01-issuer"
+	echo "3. Create a ClusterIssuer using the native acmeDNS solver:"
+	echo "   See docs/dns01-setup.md"
 	echo
 	echo "4. Test with a wildcard certificate:"
 	echo "   make test-cert"

--- a/scripts/troubleshooting/README.md
+++ b/scripts/troubleshooting/README.md
@@ -224,6 +224,38 @@ API server certificates are critical for cluster access. This verifies that:
 
 ---
 
+### 8. check-cert-renewal.sh
+**Description:** Certificate renewal status and upcoming renewals  
+**Usage:**
+```bash
+./scripts/troubleshooting/check-cert-renewal.sh
+make check-cert-renewal
+```
+
+---
+
+### 9. verify-monitoring.sh
+**Description:** Verify cert-manager ServiceMonitor and PrometheusRule  
+**Usage:**
+```bash
+./scripts/troubleshooting/verify-monitoring.sh
+make verify-monitoring
+```
+
+---
+
+### 10. check-network-stack.sh
+**Description:** Detect IPv4, IPv6, or dual-stack  
+**Usage:**
+```bash
+./scripts/troubleshooting/check-network-stack.sh
+make check-network-stack
+```
+
+`make check-network` runs the broader `scripts/check-cluster-network.sh` check.
+
+---
+
 ## Common Workflows
 
 ### Diagnosing a Failed Certificate
@@ -287,7 +319,7 @@ Use the guide for step-by-step manual troubleshooting, or use these scripts for 
 ## Requirements
 
 - OpenShift CLI (`oc`) installed and logged in
-- `jq` for JSON parsing (optional, gracefully degrades without it)
+- `jq` for JSON parsing (`make troubleshoot` / `check-all.sh` requires it)
 - Access to the cluster with appropriate permissions
 
 ## Tips
@@ -311,8 +343,8 @@ Use the guide for step-by-step manual troubleshooting, or use these scripts for 
 ## Contributing
 
 When adding new troubleshooting scripts:
-1. Follow the existing format (colors, log functions)
+1. Source `lib/common.sh` — do not redefine colors or logging
 2. Provide clear error messages and suggestions
 3. Update this README
-4. Add corresponding make target to Makefile
+4. Add a Makefile target with a `## Description` comment
 

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -1,140 +1,27 @@
 # YAML Manifests
 
-This directory contains Kubernetes/OpenShift YAML manifests organized by purpose.
+Kubernetes/OpenShift templates, grouped by component. Placeholders use `${VARIABLE}` and are substituted at apply time by `apply_yaml_template` in `lib/common.sh` (envsubst + `oc apply`).
 
 ## Structure
 
-Each subdirectory represents a specific component or feature:
-
 | Directory | Description | Files |
 |-----------|-------------|-------|
-| [`acme-dns/`](acme-dns/) | ACME-DNS server for DNS-01 challenge automation | 4 |
-| [`cert-manager-operator/`](cert-manager-operator/) | OpenShift cert-manager operator installation | 2 |
-| [`certificates/`](certificates/) | Test certificate templates | 1 |
-| [`fake-dns-api/`](fake-dns-api/) | Air-gapped DNS testing server | 5 |
-| [`issuers/`](issuers/) | ClusterIssuer configurations (HTTP-01, DNS-01, CA, self-signed) | 6 |
-| [`pebble/`](pebble/) | Let's Encrypt Pebble ACME test server | 5 |
+| [`acme-dns/`](acme-dns/) | acme-dns server for DNS-01 | 4 |
+| [`cert-manager-operator/`](cert-manager-operator/) | OpenShift cert-manager operator install | 2 |
+| [`certificates/`](certificates/) | Test certificate templates | 2 |
+| [`fake-dns-api/`](fake-dns-api/) | Air-gapped RFC2136 DNS server | 5 |
+| [`ingress-test/`](ingress-test/) | Route/Ingress TLS integration test | 4 |
+| [`issuers/`](issuers/) | ClusterIssuers (HTTP-01, DNS-01, CA, self-signed) | 6 |
+| [`monitoring/`](monitoring/) | ServiceMonitor and PrometheusRule | 2 |
+| [`pebble/`](pebble/) | Pebble ACME test server | 5 |
 | [`pebble-challtestsrv/`](pebble-challtestsrv/) | Pebble challenge test server | 2 |
-| [`ibu/`](ibu/) | IBU testing resources (MinIO, OADP, backups) | 3 subdirs |
+| [`ibu/`](ibu/) | IBU testing (MinIO, OADP, backups) | 3 subdirs |
 
-See individual subdirectory READMEs for detailed documentation.
+Each subdirectory has a README except `ingress-test/` and `monitoring/` — those are applied by `make test-ingress-tls` and `make install-monitoring`.
 
-## Variable Substitution
+## Adding manifests
 
-The YAML files use environment variable placeholders in the format `${VARIABLE_NAME}`. These are substituted at runtime using the `envsubst` command.
-
-### Example
-
-**YAML template:**
-```yaml
-metadata:
-  name: ${OPERATOR_NAME}
-  namespace: ${OPERATOR_NAMESPACE}
-```
-
-**After substitution:**
-```yaml
-metadata:
-  name: openshift-cert-manager-operator
-  namespace: cert-manager-operator
-```
-
-## Adding New Manifests
-
-When adding new YAML manifests:
-
-1. Create a subdirectory for your component (e.g., `yaml/issuers/`)
-2. Use environment variable placeholders for configurable values
-3. Export the variables in your shell script
-4. Use `envsubst < template.yaml | oc apply -f -` to apply with substitution
-5. Document the variables in a README or comments
-
-## cert-manager-operator
-
-### Files
-
-- `operatorgroup.yaml` - Defines the OperatorGroup for the cert-manager-operator
-- `subscription.yaml` - Defines the Subscription to install the operator from RedHat catalog
-
-### Variables
-
-| Variable | Default Value | Description |
-|----------|---------------|-------------|
-| `OPERATOR_NAMESPACE` | `cert-manager-operator` | Namespace for the operator |
-| `OPERATOR_NAME` | `openshift-cert-manager-operator` | Name of the operator subscription |
-| `CHANNEL` | `stable-v1` | Update channel for the operator |
-
-### Usage
-
-These manifests are applied by `install-cert-manager-operator.sh`:
-
-```bash
-export OPERATOR_NAMESPACE="cert-manager-operator"
-export OPERATOR_NAME="openshift-cert-manager-operator"
-export CHANNEL="stable-v1"
-
-envsubst < yaml/cert-manager-operator/operatorgroup.yaml | oc apply -f -
-envsubst < yaml/cert-manager-operator/subscription.yaml | oc apply -f -
-```
-
----
-
-## pebble
-
-### Files
-
-- `namespace.yaml` - Namespace for Pebble deployment
-- `configmap.yaml` - Pebble configuration (ACME server settings)
-- `deployment.yaml` - Pebble deployment
-- `service.yaml` - Service to expose Pebble within the cluster
-- `route.yaml` - Route for external access to Pebble (if needed)
-
-### Variables
-
-| Variable | Default Value | Description |
-|----------|---------------|-------------|
-| `PEBBLE_NAMESPACE` | `pebble` | Namespace for Pebble |
-| `DNS_SERVER` | `8.8.8.8:53` | DNS server for ACME validation |
-| `PEBBLE_ALWAYS_VALID` | `0` | Auto-validate challenges (1=yes, 0=no) |
-
-### What is Pebble?
-
-Pebble is a lightweight ACME test server from Let's Encrypt. It:
-- Provides a local ACME server for testing cert-manager
-- Has no rate limits (unlike Let's Encrypt production)
-- Can be configured to auto-validate challenges for easier testing
-- Runs entirely in your OpenShift cluster
-
-### Usage
-
-These manifests are applied by `install-pebble.sh`:
-
-```bash
-export PEBBLE_NAMESPACE="pebble"
-export DNS_SERVER="8.8.8.8:53"
-export PEBBLE_ALWAYS_VALID="0"
-
-envsubst < yaml/pebble/namespace.yaml | oc apply -f -
-envsubst < yaml/pebble/configmap.yaml | oc apply -f -
-envsubst < yaml/pebble/deployment.yaml | oc apply -f -
-envsubst < yaml/pebble/service.yaml | oc apply -f -
-envsubst < yaml/pebble/route.yaml | oc apply -f -
-```
-
-### Pebble Configuration
-
-The `configmap.yaml` contains Pebble's configuration:
-- **listenAddress**: ACME API endpoint (port 14000)
-- **managementListenAddress**: Management API (port 15000)
-- **httpPort/tlsPort**: Ports for HTTP-01 challenge validation
-- **externalAccountBindingRequired**: Set to false for easier testing
-
-### Accessing Pebble
-
-After deployment, Pebble is accessible at:
-- **Internal**: `https://pebble.pebble.svc.cluster.local:14000/dir`
-- **External**: Through the OpenShift route (if route is created)
-
-Use the internal URL when configuring cert-manager ClusterIssuers.
-```
-
+1. Put files in the matching subdirectory (or add one).
+2. Use `${VARIABLE}` for anything callers should override.
+3. Export the variables in the install script (`export VAR="${VAR:-default}"`).
+4. Apply with `apply_yaml_template "$YAML_DIR/file.yaml" "ResourceType"` — do not pipe envsubst inline.

--- a/yaml/acme-dns/README.md
+++ b/yaml/acme-dns/README.md
@@ -15,6 +15,12 @@ ACME-DNS server for DNS-01 challenge automation. Provides a specialized DNS serv
 
 ```bash
 # Deploy ACME-DNS
+make install-local-dns
+
+# Register an account and create the credentials Secret
+make register-acmedns
+
+# Or apply manifests directly:
 export ACMEDNS_NAMESPACE="acme-dns"
 envsubst < yaml/acme-dns/namespace.yaml | oc apply -f -
 envsubst < yaml/acme-dns/configmap.yaml | oc apply -f -
@@ -30,7 +36,7 @@ envsubst < yaml/acme-dns/service.yaml | oc apply -f -
 
 ## How It Works
 
-ACME-DNS stores TXT records in sqlite3 and exposes both DNS (port 53) and HTTP API (port 8080) interfaces. cert-manager can use the ACME-DNS webhook solver to automate DNS-01 challenges.
+ACME-DNS stores TXT records in sqlite3 and exposes both DNS (port 53) and HTTP API (port 8080) interfaces. cert-manager uses the native `acmeDNS` solver against that API (`make register-acmedns`).
 
 ## Related Documentation
 

--- a/yaml/cert-manager-operator/README.md
+++ b/yaml/cert-manager-operator/README.md
@@ -19,6 +19,7 @@ make install-cert-manager-operator
 export OPERATOR_NAMESPACE="cert-manager-operator"
 export OPERATOR_NAME="openshift-cert-manager-operator"
 export CHANNEL="stable-v1"
+export CERT_MANAGER_VERSION="v1.19.0"
 
 envsubst < yaml/cert-manager-operator/operatorgroup.yaml | oc apply -f -
 envsubst < yaml/cert-manager-operator/subscription.yaml | oc apply -f -
@@ -31,6 +32,7 @@ envsubst < yaml/cert-manager-operator/subscription.yaml | oc apply -f -
 | `OPERATOR_NAMESPACE` | `cert-manager-operator` | Namespace for the operator |
 | `OPERATOR_NAME` | `openshift-cert-manager-operator` | Operator subscription name |
 | `CHANNEL` | `stable-v1` | Update channel |
+| `CERT_MANAGER_VERSION` | `v1.19.0` | `startingCSV` pin |
 
 ## Related Documentation
 

--- a/yaml/certificates/README.md
+++ b/yaml/certificates/README.md
@@ -7,14 +7,18 @@ Test certificate templates for cert-manager. Used to request certificates from C
 | File | Description |
 |------|-------------|
 | `test-certificate.yaml` | Template for requesting a test certificate with 90-day validity |
+| `short-lived-certificate.yaml` | Short-lived cert for renewal testing (`make test-cert-renewal`) |
 
 ## Usage
 
 ```bash
-# Request a test certificate
+# HTTP-01 test certs (test-cert-simple, test-cert-app, test-cert-api)
+make create-certs
+
+# DNS-01 wildcard cert (wildcard-test)
 make test-cert
 
-# Or manually:
+# Or apply the template directly:
 export CERT_NAME="test-cert"
 export CERT_NAMESPACE="default"
 export CERT_SECRET_NAME="test-cert-tls"
@@ -45,10 +49,10 @@ envsubst < yaml/certificates/test-certificate.yaml | oc apply -f -
 ## Verification
 
 ```bash
-# Check certificate status
+# wildcard-test (DNS-01)
 make verify-cert
 
-# View certificate details
+# any certificate
 oc get certificate -n $CERT_NAMESPACE $CERT_NAME -o yaml
 ```
 

--- a/yaml/fake-dns-api/README.md
+++ b/yaml/fake-dns-api/README.md
@@ -45,9 +45,9 @@ This enables testing DNS-01 challenges without public DNS or internet connectivi
 
 ## Use Case
 
-Combined with Pebble's `ALWAYS_VALID=1` mode, the fake DNS server allows complete air-gapped testing of cert-manager DNS-01 workflows.
+Combined with `PEBBLE_ALWAYS_VALID=1`, the fake DNS server allows complete air-gapped testing of cert-manager DNS-01 workflows.
 
 ## Related Documentation
 
 - [DNS-01 Setup](../../docs/dns01-setup.md) - DNS-01 challenge configuration
-- [Network Support](../../docs/network-support.md) - Air-gapped setup
+- [Network Support](../../docs/network-support.md) - IPv4/IPv6/dual-stack

--- a/yaml/ibu/README.md
+++ b/yaml/ibu/README.md
@@ -58,5 +58,5 @@ The key difference between scenarios is whether the `lca.openshift.io/backup` la
 ## Related Documentation
 
 - [IBU Testing](../../docs/ibu-testing.md) - Full IBU testing guide
-- [docs/IBU-FAQ.md](../../docs/IBU-FAQ.md) - Frequently asked questions
+- [IBU FAQ](../../docs/IBU-FAQ.md) - Frequently asked questions
 - [Validation Report](https://gist.github.com/sebrandon1/71f33b35aea2aa4cf9edda855201c8fc)

--- a/yaml/issuers/README.md
+++ b/yaml/issuers/README.md
@@ -8,7 +8,10 @@ ClusterIssuer configurations for cert-manager. These define how certificates are
 |------|-------------|
 | `pebble-clusterissuer.yaml` | HTTP-01 challenge issuer using ingress |
 | `pebble-dns01-clusterissuer.yaml` | DNS-01 issuer with webhook solver placeholder |
-| `pebble-dns01-simple-clusterissuer.yaml` | DNS-01 issuer using RFC2136 dynamic DNS |
+| `pebble-dns01-simple-clusterissuer.yaml` | DNS-01 issuer using RFC2136 (used by `make create-dns01-issuer`) |
+| `selfsigned-clusterissuer.yaml` | Self-signed issuer for the root CA |
+| `root-ca-certificate.yaml` | Self-signed root CA certificate |
+| `ca-clusterissuer.yaml` | CA issuer that signs with the root CA |
 
 ## Usage
 
@@ -44,7 +47,7 @@ envsubst < yaml/issuers/pebble-clusterissuer.yaml | oc apply -f -
 
 ### DNS-01 Webhook (`pebble-dns01-clusterissuer.yaml`)
 - Placeholder for webhook-based DNS solvers
-- Use with Pebble's `ALWAYS_VALID=1` mode
+- Use with `PEBBLE_ALWAYS_VALID=1`
 
 ### DNS-01 RFC2136 (`pebble-dns01-simple-clusterissuer.yaml`)
 - Uses RFC2136 dynamic DNS updates

--- a/yaml/pebble-challtestsrv/README.md
+++ b/yaml/pebble-challtestsrv/README.md
@@ -12,7 +12,10 @@ Mock DNS/HTTP server for ACME challenge testing. Companion service to Pebble tha
 ## Usage
 
 ```bash
-# Deploy alongside Pebble
+# Deploy alongside Pebble (separate target — not part of make install-pebble)
+make install-pebble-challtestsrv
+
+# Or apply manifests directly:
 export PEBBLE_NAMESPACE="pebble"
 envsubst < yaml/pebble-challtestsrv/deployment.yaml | oc apply -f -
 envsubst < yaml/pebble-challtestsrv/service.yaml | oc apply -f -
@@ -26,12 +29,12 @@ envsubst < yaml/pebble-challtestsrv/service.yaml | oc apply -f -
 
 ## Ports
 
-| Port | Protocol | Purpose |
-|------|----------|---------|
-| 8053 | UDP/TCP | DNS queries |
-| 5002 | TCP | HTTP-01 challenge responses |
-| 5001 | TCP | TLS-ALPN-01/HTTPS challenges |
-| 8055 | TCP | Management API |
+| Port | Protocol | Purpose | Exposed by Service |
+|------|----------|---------|--------------------|
+| 8053 | UDP/TCP | DNS queries | yes |
+| 8055 | TCP | Management API | yes |
+| 5002 | TCP | HTTP-01 challenge responses | container only |
+| 5001 | TCP | TLS-ALPN-01/HTTPS challenges | container only |
 
 ## Management API
 
@@ -42,7 +45,7 @@ The challenge test server provides an API (port 8055) to:
 
 ## When to Use
 
-Use pebble-challtestsrv when you need fine-grained control over challenge responses. For simple testing, Pebble's `ALWAYS_VALID=1` mode is often sufficient.
+Use pebble-challtestsrv when you need fine-grained control over challenge responses. For simple testing, `PEBBLE_ALWAYS_VALID=1` is often sufficient.
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary
- Verify and fix documentation against the Makefile, scripts, and current CI: broken public links, invalid command examples, and outdated job descriptions.
- Rewrite DNS-01 setup around fake DNS (`make quick-dns-test`) and the native acmeDNS solver; remove the 404 webhook install path.
- Slim READMEs and CLAUDE.md, and add the Apache-2.0 LICENSE file the repo already claimed.

## Test plan
- [ ] Spot-check relative links from README, docs/README.md, and yaml/*/README.md
- [ ] Confirm `make help` targets cited in docs still exist (`quick-dns-test`, `install-pebble-challtestsrv`, `register-acmedns`, `fmt`)
- [ ] Confirm CI description in CONTRIBUTING.md / CLAUDE.md matches `.github/workflows/pre-main.yml`
- [ ] `make lint` still passes (only `scripts/install-local-dns.sh` changed among scripts)


Made with [Cursor](https://cursor.com)