### PR TITLE
Use KUBE_CLI in troubleshooting and workflow scripts

### DIFF
--- a/scripts/troubleshooting/check-all.sh
+++ b/scripts/troubleshooting/check-all.sh
@@ -12,26 +12,35 @@ source "$SCRIPT_DIR/../../lib/common.sh"
 
 print_header "Complete System Diagnostics"
 
-require_cmd oc jq
+require_cmd "$KUBE_CLI" jq
 require_cluster
 
-log_info "Cluster: $(oc whoami --show-server)"
-log_info "User: $(oc whoami)"
+if [[ "$KUBE_CLI" == "oc" ]]; then
+	log_info "Cluster: $("$KUBE_CLI" whoami --show-server)"
+	log_info "User: $("$KUBE_CLI" whoami)"
+else
+	log_info "Cluster: $("$KUBE_CLI" config view --minify -o jsonpath='{.clusters[0].cluster.server}')"
+	log_info "Context: $("$KUBE_CLI" config current-context)"
+fi
 echo
 
 # Section 1: cert-manager
 print_header "cert-manager Components"
 
-log_info "Checking cert-manager operator..."
-if oc get csv -n cert-manager-operator 2>/dev/null | grep -q "Succeeded"; then
-	echo "✅ cert-manager operator is installed"
+if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+	log_info "Checking cert-manager operator..."
+	if "$KUBE_CLI" get csv -n cert-manager-operator 2>/dev/null | grep -q "Succeeded"; then
+		echo "✅ cert-manager operator is installed"
+	else
+		log_warn "cert-manager operator not found or not healthy"
+	fi
 else
-	log_warn "cert-manager operator not found or not healthy"
+	log_info "Skipping cert-manager operator CSV check (OpenShift-only)"
 fi
 
 log_info "Checking cert-manager pods..."
-if oc get pods -n cert-manager &>/dev/null; then
-	oc get pods -n cert-manager
+if "$KUBE_CLI" get pods -n cert-manager &>/dev/null; then
+	"$KUBE_CLI" get pods -n cert-manager
 else
 	log_warn "cert-manager namespace not found"
 fi
@@ -41,17 +50,19 @@ echo
 # Section 2: Pebble
 print_header "Pebble ACME Server"
 
-if oc get namespace pebble &>/dev/null; then
+if "$KUBE_CLI" get namespace pebble &>/dev/null; then
 	log_info "Checking Pebble pods..."
-	oc get pods -n pebble
+	"$KUBE_CLI" get pods -n pebble
 
-	echo
-	log_info "Checking Pebble route..."
-	if oc get route pebble-acme -n pebble &>/dev/null; then
-		ROUTE=$(oc get route pebble-acme -n pebble -o jsonpath='{.spec.host}')
-		echo "✅ Pebble route: https://$ROUTE"
-	else
-		log_warn "Pebble route not found"
+	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+		echo
+		log_info "Checking Pebble route..."
+		if "$KUBE_CLI" get route pebble-acme -n pebble &>/dev/null; then
+			ROUTE=$("$KUBE_CLI" get route pebble-acme -n pebble -o jsonpath='{.spec.host}')
+			echo "✅ Pebble route: https://$ROUTE"
+		else
+			log_warn "Pebble route not found"
+		fi
 	fi
 else
 	log_warn "Pebble namespace not found"
@@ -62,9 +73,9 @@ echo
 # Section 3: DNS Components
 print_header "DNS-01 Components"
 
-if oc get namespace fake-dns &>/dev/null; then
+if "$KUBE_CLI" get namespace fake-dns &>/dev/null; then
 	log_info "Checking fake DNS API..."
-	oc get pods -n fake-dns
+	"$KUBE_CLI" get pods -n fake-dns
 else
 	log_info "Fake DNS not installed (only needed for DNS-01)"
 fi
@@ -74,13 +85,13 @@ echo
 # Section 4: ClusterIssuers
 print_header "ClusterIssuers"
 
-if oc get clusterissuer &>/dev/null; then
-	oc get clusterissuer
+if "$KUBE_CLI" get clusterissuer &>/dev/null; then
+	"$KUBE_CLI" get clusterissuer
 	echo
 
 	# Check each issuer
-	for issuer in $(oc get clusterissuer -o name 2>/dev/null | cut -d'/' -f2); do
-		READY=$(oc get clusterissuer "$issuer" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+	for issuer in $("$KUBE_CLI" get clusterissuer -o name 2>/dev/null | cut -d'/' -f2); do
+		READY=$("$KUBE_CLI" get clusterissuer "$issuer" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 		if [ "$READY" = "True" ]; then
 			echo "✅ $issuer is ready"
 		else
@@ -96,16 +107,16 @@ echo
 # Section 5: Certificates
 print_header "Certificates"
 
-CERTS=$(oc get certificate -A -o json 2>/dev/null | jq -r '.items | length' || echo "0")
+CERTS=$("$KUBE_CLI" get certificate -A -o json 2>/dev/null | jq -r '.items | length' || echo "0")
 
 if [ "$CERTS" -gt 0 ]; then
 	log_info "Found $CERTS certificate(s):"
 	echo
-	oc get certificate -A
+	"$KUBE_CLI" get certificate -A
 	echo
 
 	# Check for failed certificates
-	FAILED=$(oc get certificate -A -o json | jq -r '.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="False")) | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null || echo "")
+	FAILED=$("$KUBE_CLI" get certificate -A -o json | jq -r '.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="False")) | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null || echo "")
 
 	if [ -n "$FAILED" ]; then
 		echo
@@ -127,12 +138,12 @@ echo
 # Section 6: Active Challenges
 print_header "Active Challenges"
 
-CHALLENGES=$(oc get challenge -A 2>/dev/null | grep -cv "^NAMESPACE" || echo "0")
+CHALLENGES=$("$KUBE_CLI" get challenge -A 2>/dev/null | grep -cv "^NAMESPACE" || echo "0")
 
 if [ "$CHALLENGES" -gt 0 ]; then
 	log_info "Found $CHALLENGES active challenge(s):"
 	echo
-	oc get challenge -A
+	"$KUBE_CLI" get challenge -A
 else
 	log_info "No active challenges"
 fi
@@ -145,20 +156,20 @@ print_header "Health Summary"
 ISSUES=0
 
 # Check cert-manager
-if ! oc get deployment cert-manager -n cert-manager &>/dev/null; then
+if ! "$KUBE_CLI" get deployment cert-manager -n cert-manager &>/dev/null; then
 	log_error "cert-manager not found"
 	ISSUES=$((ISSUES + 1))
 fi
 
 # Check if any issuer exists
-if ! oc get clusterissuer &>/dev/null; then
+if ! "$KUBE_CLI" get clusterissuer &>/dev/null; then
 	log_warn "No ClusterIssuers configured"
 	ISSUES=$((ISSUES + 1))
 fi
 
 # Check if any issuer is ready
-READY_ISSUERS=$(oc get clusterissuer -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="True")) | .metadata.name' | wc -l | xargs || echo "0")
-if [ "$READY_ISSUERS" -eq 0 ] && oc get clusterissuer &>/dev/null; then
+READY_ISSUERS=$("$KUBE_CLI" get clusterissuer -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="True")) | .metadata.name' | wc -l | xargs || echo "0")
+if [ "$READY_ISSUERS" -eq 0 ] && "$KUBE_CLI" get clusterissuer &>/dev/null; then
 	log_warn "No ClusterIssuers are ready"
 	ISSUES=$((ISSUES + 1))
 fi

--- a/scripts/troubleshooting/check-certificate.sh
+++ b/scripts/troubleshooting/check-certificate.sh
@@ -21,18 +21,18 @@ check_single_certificate() {
 	echo
 
 	# Check if certificate exists
-	if ! oc get certificate "$CERT_NAME" -n "$NAMESPACE" &>/dev/null; then
+	if ! "$KUBE_CLI" get certificate "$CERT_NAME" -n "$NAMESPACE" &>/dev/null; then
 		log_error "Certificate '$CERT_NAME' not found in namespace '$NAMESPACE'"
 		exit 1
 	fi
 
 	# Get certificate status
 	log_info "Certificate Status:"
-	oc get certificate "$CERT_NAME" -n "$NAMESPACE"
+	"$KUBE_CLI" get certificate "$CERT_NAME" -n "$NAMESPACE"
 	echo
 
 	# Check if certificate is ready
-	READY=$(oc get certificate "$CERT_NAME" -n "$NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+	READY=$("$KUBE_CLI" get certificate "$CERT_NAME" -n "$NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 
 	if [ "$READY" = "True" ]; then
 		echo "✅ Certificate is READY!"
@@ -40,13 +40,13 @@ check_single_certificate() {
 
 		# Show certificate details
 		log_info "Certificate Secret:"
-		SECRET_NAME=$(oc get certificate "$CERT_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.secretName}')
-		oc get secret "$SECRET_NAME" -n "$NAMESPACE" 2>/dev/null || log_warn "Secret not found"
+		SECRET_NAME=$("$KUBE_CLI" get certificate "$CERT_NAME" -n "$NAMESPACE" -o jsonpath='{.spec.secretName}')
+		"$KUBE_CLI" get secret "$SECRET_NAME" -n "$NAMESPACE" 2>/dev/null || log_warn "Secret not found"
 
 		echo
 		log_debug "Certificate Details:"
 		echo "To view certificate:"
-		echo "  oc get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout"
+		echo "  $KUBE_CLI get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout"
 
 	else
 		log_warn "Certificate is NOT ready (Status: $READY)"
@@ -54,18 +54,18 @@ check_single_certificate() {
 
 		# Show detailed certificate info
 		log_info "Certificate Details:"
-		oc describe certificate "$CERT_NAME" -n "$NAMESPACE"
+		"$KUBE_CLI" describe certificate "$CERT_NAME" -n "$NAMESPACE"
 
 		print_header "Checking Certificate Requests"
 
 		# Find related CertificateRequests
-		CR_LIST=$(oc get certificaterequest -n "$NAMESPACE" -o json | jq -r ".items[] | select(.metadata.ownerReferences[]?.name==\"$CERT_NAME\") | .metadata.name" 2>/dev/null || echo "")
+		CR_LIST=$("$KUBE_CLI" get certificaterequest -n "$NAMESPACE" -o json | jq -r ".items[] | select(.metadata.ownerReferences[]?.name==\"$CERT_NAME\") | .metadata.name" 2>/dev/null || echo "")
 
 		if [ -n "$CR_LIST" ]; then
 			while IFS= read -r cr; do
 				[[ -z "$cr" ]] && continue
 				log_info "CertificateRequest: $cr"
-				oc describe certificaterequest "$cr" -n "$NAMESPACE"
+				"$KUBE_CLI" describe certificaterequest "$cr" -n "$NAMESPACE"
 				echo
 			done <<<"$CR_LIST"
 		else
@@ -75,13 +75,13 @@ check_single_certificate() {
 		print_header "Checking ACME Orders"
 
 		# Check orders
-		if oc get order -n "$NAMESPACE" &>/dev/null; then
-			ORDERS=$(oc get order -n "$NAMESPACE" -o name 2>/dev/null || echo "")
+		if "$KUBE_CLI" get order -n "$NAMESPACE" &>/dev/null; then
+			ORDERS=$("$KUBE_CLI" get order -n "$NAMESPACE" -o name 2>/dev/null || echo "")
 			if [ -n "$ORDERS" ]; then
 				while IFS= read -r order; do
 					[[ -z "$order" ]] && continue
 					log_info "Order: $(basename "$order")"
-					oc describe "$order" -n "$NAMESPACE"
+					"$KUBE_CLI" describe "$order" -n "$NAMESPACE"
 					echo
 				done <<<"$ORDERS"
 			else
@@ -94,13 +94,13 @@ check_single_certificate() {
 		print_header "Checking ACME Challenges"
 
 		# Check challenges
-		if oc get challenge -n "$NAMESPACE" &>/dev/null; then
-			CHALLENGES=$(oc get challenge -n "$NAMESPACE" -o name 2>/dev/null || echo "")
+		if "$KUBE_CLI" get challenge -n "$NAMESPACE" &>/dev/null; then
+			CHALLENGES=$("$KUBE_CLI" get challenge -n "$NAMESPACE" -o name 2>/dev/null || echo "")
 			if [ -n "$CHALLENGES" ]; then
 				while IFS= read -r challenge; do
 					[[ -z "$challenge" ]] && continue
 					log_info "Challenge: $(basename "$challenge")"
-					oc describe "$challenge" -n "$NAMESPACE"
+					"$KUBE_CLI" describe "$challenge" -n "$NAMESPACE"
 					echo
 				done <<<"$CHALLENGES"
 			else
@@ -113,17 +113,17 @@ check_single_certificate() {
 
 	print_header "Troubleshooting Commands"
 	echo "Check cert-manager logs:"
-	echo "  oc logs -n cert-manager deployment/cert-manager --tail=50"
+	echo "  $KUBE_CLI logs -n cert-manager deployment/cert-manager --tail=50"
 	echo
 	echo "Check Pebble logs:"
-	echo "  oc logs -n pebble -l app=pebble --tail=50"
+	echo "  $KUBE_CLI logs -n pebble -l app=pebble --tail=50"
 	echo
 	echo "Watch certificate status:"
-	echo "  watch oc get certificate,certificaterequest,order,challenge -n $NAMESPACE"
+	echo "  watch $KUBE_CLI get certificate,certificaterequest,order,challenge -n $NAMESPACE"
 	echo
 }
 
-require_cmd oc jq
+require_cmd "$KUBE_CLI" jq
 
 # Main logic
 if [ $# -eq 0 ]; then
@@ -131,7 +131,7 @@ if [ $# -eq 0 ]; then
 	print_header "Checking All Certificates"
 
 	# Get all certificates across all namespaces
-	CERTS=$(oc get certificate -A -o json 2>/dev/null | jq -r '.items[] | "\(.metadata.namespace) \(.metadata.name)"' 2>/dev/null || echo "")
+	CERTS=$("$KUBE_CLI" get certificate -A -o json 2>/dev/null | jq -r '.items[] | "\(.metadata.namespace) \(.metadata.name)"' 2>/dev/null || echo "")
 
 	if [ -z "$CERTS" ]; then
 		log_warn "No certificates found in any namespace"

--- a/scripts/troubleshooting/check-issuer.sh
+++ b/scripts/troubleshooting/check-issuer.sh
@@ -20,11 +20,11 @@ check_single_issuer() {
 
 	# Get issuer status
 	log_info "ClusterIssuer Status:"
-	oc get clusterissuer "$ISSUER_NAME"
+	"$KUBE_CLI" get clusterissuer "$ISSUER_NAME"
 	echo
 
 	# Check if issuer is ready
-	READY=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+	READY=$("$KUBE_CLI" get clusterissuer "$ISSUER_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 
 	if [ "$READY" = "True" ]; then
 		echo "✅ ClusterIssuer is READY!"
@@ -37,21 +37,21 @@ check_single_issuer() {
 	echo
 
 	# Get ACME server URL
-	ACME_SERVER=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.server}' 2>/dev/null || echo "N/A")
+	ACME_SERVER=$("$KUBE_CLI" get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.server}' 2>/dev/null || echo "N/A")
 	log_debug "ACME Server: $ACME_SERVER"
 
 	# Get email
-	EMAIL=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.email}' 2>/dev/null || echo "N/A")
+	EMAIL=$("$KUBE_CLI" get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.email}' 2>/dev/null || echo "N/A")
 	log_debug "Email: $EMAIL"
 
 	# Check solver type
-	SOLVER_TYPE=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].http01}' 2>/dev/null)
+	SOLVER_TYPE=$("$KUBE_CLI" get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].http01}' 2>/dev/null)
 	if [ -n "$SOLVER_TYPE" ]; then
 		log_debug "Solver Type: HTTP-01"
-		INGRESS_CLASS=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].http01.ingress.class}' 2>/dev/null || echo "N/A")
+		INGRESS_CLASS=$("$KUBE_CLI" get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].http01.ingress.class}' 2>/dev/null || echo "N/A")
 		log_debug "Ingress Class: $INGRESS_CLASS"
 	else
-		SOLVER_TYPE=$(oc get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].dns01}' 2>/dev/null)
+		SOLVER_TYPE=$("$KUBE_CLI" get clusterissuer "$ISSUER_NAME" -o jsonpath='{.spec.acme.solvers[0].dns01}' 2>/dev/null)
 		if [ -n "$SOLVER_TYPE" ]; then
 			log_debug "Solver Type: DNS-01"
 		else
@@ -61,7 +61,7 @@ check_single_issuer() {
 
 	echo
 	log_info "Detailed Configuration:"
-	oc describe clusterissuer "$ISSUER_NAME"
+	"$KUBE_CLI" describe clusterissuer "$ISSUER_NAME"
 
 	print_header "Testing ACME Server Connectivity"
 
@@ -70,8 +70,8 @@ check_single_issuer() {
 		log_info "Testing Pebble connectivity..."
 
 		# Check if Pebble is running
-		if oc get deployment pebble -n pebble &>/dev/null; then
-			READY_REPLICAS=$(oc get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+		if "$KUBE_CLI" get deployment pebble -n pebble &>/dev/null; then
+			READY_REPLICAS=$("$KUBE_CLI" get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 			if [ "$READY_REPLICAS" -gt 0 ]; then
 				echo "✅ Pebble deployment is running"
 			else
@@ -80,7 +80,7 @@ check_single_issuer() {
 
 			# Try to access ACME directory
 			log_info "Testing ACME directory endpoint..."
-			if oc run --rm -i --restart=Never test-acme-$RANDOM --image=curlimages/curl -- curl -ks "$ACME_SERVER" 2>/dev/null | grep -q "directory"; then
+			if "$KUBE_CLI" run --rm -i --restart=Never test-acme-$RANDOM --image=curlimages/curl -- curl -ks "$ACME_SERVER" 2>/dev/null | grep -q "directory"; then
 				echo "✅ ACME directory is accessible"
 			else
 				log_warn "Could not access ACME directory"
@@ -94,17 +94,17 @@ check_single_issuer() {
 
 	print_header "Troubleshooting Commands"
 	echo "View full YAML configuration:"
-	echo "  oc get clusterissuer $ISSUER_NAME -o yaml"
+	echo "  $KUBE_CLI get clusterissuer $ISSUER_NAME -o yaml"
 	echo
 	echo "Check ACME account status:"
-	echo "  oc get clusterissuer $ISSUER_NAME -o jsonpath='{.status.acme.uri}'"
+	echo "  $KUBE_CLI get clusterissuer $ISSUER_NAME -o jsonpath='{.status.acme.uri}'"
 	echo
 	echo "Test certificate creation:"
 	echo "  make create-certs"
 	echo
 }
 
-require_cmd oc jq
+require_cmd "$KUBE_CLI" jq
 
 # Main logic
 if [ $# -eq 0 ]; then
@@ -112,7 +112,7 @@ if [ $# -eq 0 ]; then
 	print_header "Checking All ClusterIssuers"
 
 	# Get all ClusterIssuers
-	ISSUERS=$(oc get clusterissuer -o json 2>/dev/null | jq -r '.items[].metadata.name' 2>/dev/null || echo "")
+	ISSUERS=$("$KUBE_CLI" get clusterissuer -o json 2>/dev/null | jq -r '.items[].metadata.name' 2>/dev/null || echo "")
 
 	if [ -z "$ISSUERS" ]; then
 		log_warn "No ClusterIssuers found"
@@ -137,11 +137,11 @@ elif [ $# -eq 1 ]; then
 	ISSUER_NAME=$1
 
 	# Check if issuer exists
-	if ! oc get clusterissuer "$ISSUER_NAME" &>/dev/null; then
+	if ! "$KUBE_CLI" get clusterissuer "$ISSUER_NAME" &>/dev/null; then
 		log_error "ClusterIssuer '$ISSUER_NAME' not found"
 		echo
 		log_info "Available ClusterIssuers:"
-		oc get clusterissuer 2>/dev/null || echo "  None found"
+		"$KUBE_CLI" get clusterissuer 2>/dev/null || echo "  None found"
 		exit 1
 	fi
 

--- a/scripts/troubleshooting/check-network-stack.sh
+++ b/scripts/troubleshooting/check-network-stack.sh
@@ -17,10 +17,14 @@ detect_cluster_network() {
 	echo
 
 	# Get network configuration from cluster
-	local cluster_network
-	cluster_network=$(oc get network.config.openshift.io cluster -o jsonpath='{.spec.clusterNetwork[*].cidr}' 2>/dev/null || echo "")
-	local service_network
-	service_network=$(oc get network.config.openshift.io cluster -o jsonpath='{.spec.serviceNetwork[*]}' 2>/dev/null || echo "")
+	local cluster_network=""
+	local service_network=""
+	if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+		cluster_network=$("$KUBE_CLI" get network.config.openshift.io cluster -o jsonpath='{.spec.clusterNetwork[*].cidr}' 2>/dev/null || echo "")
+		service_network=$("$KUBE_CLI" get network.config.openshift.io cluster -o jsonpath='{.spec.serviceNetwork[*]}' 2>/dev/null || echo "")
+	else
+		log_debug "Skipping OpenShift network.config CRD (not on OpenShift)"
+	fi
 
 	log_debug "Cluster Networks: ${cluster_network:-Not found}"
 	log_debug "Service Networks: ${service_network:-Not found}"
@@ -63,7 +67,7 @@ check_node_addresses() {
 	echo
 
 	local nodes
-	nodes=$(oc get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}')
+	nodes=$("$KUBE_CLI" get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}')
 
 	local has_ipv4_nodes=false
 	local has_ipv6_nodes=false
@@ -102,7 +106,7 @@ check_certmanager_pods() {
 	echo
 
 	local pods
-	pods=$(oc get pods -n cert-manager -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.podIP}{"\n"}{end}' 2>/dev/null || echo "")
+	pods=$("$KUBE_CLI" get pods -n cert-manager -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.podIP}{"\n"}{end}' 2>/dev/null || echo "")
 
 	if [ -z "$pods" ]; then
 		log_warn "⚠️  cert-manager pods not found or not running"
@@ -148,9 +152,9 @@ check_webhook_connectivity() {
 	echo
 
 	local webhook_cluster_ip
-	webhook_cluster_ip=$(oc get service cert-manager-webhook -n cert-manager -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
+	webhook_cluster_ip=$("$KUBE_CLI" get service cert-manager-webhook -n cert-manager -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo "")
 	local webhook_cluster_ips
-	webhook_cluster_ips=$(oc get service cert-manager-webhook -n cert-manager -o jsonpath='{.spec.clusterIPs[*]}' 2>/dev/null || echo "")
+	webhook_cluster_ips=$("$KUBE_CLI" get service cert-manager-webhook -n cert-manager -o jsonpath='{.spec.clusterIPs[*]}' 2>/dev/null || echo "")
 
 	if [ -n "$webhook_cluster_ip" ]; then
 		log_debug "Webhook ClusterIP: $webhook_cluster_ip"
@@ -174,7 +178,7 @@ check_webhook_connectivity() {
 main() {
 	print_header "Network Stack Detection"
 
-	require_cmd oc
+	require_cmd "$KUBE_CLI"
 	require_cluster
 
 	# Detect stack type

--- a/scripts/troubleshooting/check-workload-partitioning.sh
+++ b/scripts/troubleshooting/check-workload-partitioning.sh
@@ -16,7 +16,7 @@ source "$SCRIPT_DIR/../../lib/common.sh"
 
 # Check if cert-manager is installed
 check_cert_manager_exists() {
-	if ! oc get namespace cert-manager &>/dev/null; then
+	if ! "$KUBE_CLI" get namespace cert-manager &>/dev/null; then
 		log_error "cert-manager namespace not found"
 		log_info "cert-manager does not appear to be installed"
 		exit 1
@@ -33,7 +33,7 @@ check_workload_partitioning() {
 
 	# Get all pods in the cert-manager namespace
 	local pods
-	pods=$(oc get pods -n "$namespace" -o json 2>/dev/null)
+	pods=$("$KUBE_CLI" get pods -n "$namespace" -o json 2>/dev/null)
 
 	if [ -z "$pods" ] || [ "$(echo "$pods" | jq -r '.items | length')" -eq 0 ]; then
 		log_warn "No pods found in namespace $namespace"
@@ -96,7 +96,7 @@ check_deployment_configs() {
 
 	# Check deployments
 	local deployments
-	deployments=$(oc get deployments -n "$namespace" -o json 2>/dev/null)
+	deployments=$("$KUBE_CLI" get deployments -n "$namespace" -o json 2>/dev/null)
 	if [ -n "$deployments" ]; then
 		local deploy_count
 		deploy_count=$(echo "$deployments" | jq -r '.items | length')
@@ -165,7 +165,7 @@ provide_recommendations() {
 # Main execution
 main() {
 	print_header "Workload Partitioning Check"
-	require_cmd oc jq
+	require_cmd "$KUBE_CLI" jq
 	require_cluster
 	check_cert_manager_exists
 

--- a/scripts/troubleshooting/diagnose-dns01.sh
+++ b/scripts/troubleshooting/diagnose-dns01.sh
@@ -10,14 +10,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
-require_cmd oc jq
+require_cmd "$KUBE_CLI" jq
 
 print_header "DNS-01 Challenge Diagnostics"
 
 # Check cert-manager
 log_info "Checking cert-manager..."
-if oc get deployment cert-manager -n cert-manager &>/dev/null; then
-	READY=$(oc get deployment cert-manager -n cert-manager -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+if "$KUBE_CLI" get deployment cert-manager -n cert-manager &>/dev/null; then
+	READY=$("$KUBE_CLI" get deployment cert-manager -n cert-manager -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 	if [ "$READY" -gt 0 ]; then
 		echo "✅ cert-manager is running"
 	else
@@ -31,13 +31,13 @@ echo
 
 # Check Pebble
 log_info "Checking Pebble ACME server..."
-if oc get deployment pebble -n pebble &>/dev/null; then
-	READY=$(oc get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+if "$KUBE_CLI" get deployment pebble -n pebble &>/dev/null; then
+	READY=$("$KUBE_CLI" get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 	if [ "$READY" -gt 0 ]; then
 		echo "✅ Pebble is running"
 
 		# Check if using ALWAYS_VALID
-		ALWAYS_VALID=$(oc get deployment pebble -n pebble -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="PEBBLE_VA_ALWAYS_VALID")].value}' 2>/dev/null || echo "0")
+		ALWAYS_VALID=$("$KUBE_CLI" get deployment pebble -n pebble -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="PEBBLE_VA_ALWAYS_VALID")].value}' 2>/dev/null || echo "0")
 		if [ "$ALWAYS_VALID" = "1" ]; then
 			log_debug "Pebble ALWAYS_VALID: enabled (all challenges auto-succeed)"
 		else
@@ -54,8 +54,8 @@ echo
 
 # Check challenge test server
 log_info "Checking Pebble challenge test server..."
-if oc get deployment pebble-challtestsrv -n pebble &>/dev/null; then
-	READY=$(oc get deployment pebble-challtestsrv -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+if "$KUBE_CLI" get deployment pebble-challtestsrv -n pebble &>/dev/null; then
+	READY=$("$KUBE_CLI" get deployment pebble-challtestsrv -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 	if [ "$READY" -gt 0 ]; then
 		echo "✅ Challenge test server is running"
 	else
@@ -69,8 +69,8 @@ echo
 
 # Check fake DNS API
 log_info "Checking fake DNS API..."
-if oc get deployment fake-dns-api -n fake-dns &>/dev/null; then
-	READY=$(oc get deployment fake-dns-api -n fake-dns -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+if "$KUBE_CLI" get deployment fake-dns-api -n fake-dns &>/dev/null; then
+	READY=$("$KUBE_CLI" get deployment fake-dns-api -n fake-dns -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 	if [ "$READY" -gt 0 ]; then
 		echo "✅ Fake DNS API is running"
 	else
@@ -84,12 +84,12 @@ echo
 
 # Check DNS-01 ClusterIssuers
 log_info "Checking DNS-01 ClusterIssuers..."
-DNS01_ISSUERS=$(oc get clusterissuer -o json | jq -r '.items[] | select(.spec.acme.solvers[]?.dns01 != null) | .metadata.name' 2>/dev/null || echo "")
+DNS01_ISSUERS=$("$KUBE_CLI" get clusterissuer -o json | jq -r '.items[] | select(.spec.acme.solvers[]?.dns01 != null) | .metadata.name' 2>/dev/null || echo "")
 
 if [ -n "$DNS01_ISSUERS" ]; then
 	while IFS= read -r issuer; do
 		[[ -z "$issuer" ]] && continue
-		READY=$(oc get clusterissuer "$issuer" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+		READY=$("$KUBE_CLI" get clusterissuer "$issuer" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 		if [ "$READY" = "True" ]; then
 			echo "✅ $issuer is ready"
 		else
@@ -104,7 +104,7 @@ echo
 
 # Check for active DNS-01 challenges
 log_info "Checking for active DNS-01 challenges..."
-CHALLENGES=$(oc get challenge -A -o json 2>/dev/null | jq -r '.items[] | select(.spec.solver.dns01 != null) | "\(.metadata.namespace)/\(.metadata.name)"' || echo "")
+CHALLENGES=$("$KUBE_CLI" get challenge -A -o json 2>/dev/null | jq -r '.items[] | select(.spec.solver.dns01 != null) | "\(.metadata.namespace)/\(.metadata.name)"' || echo "")
 
 if [ -n "$CHALLENGES" ]; then
 	echo "Found DNS-01 challenges:"
@@ -117,12 +117,12 @@ if [ -n "$CHALLENGES" ]; then
 
 		log_debug "Challenge: $NAME (namespace: $NAMESPACE)"
 
-		STATE=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.status.state}' 2>/dev/null || echo "unknown")
+		STATE=$("$KUBE_CLI" get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.status.state}' 2>/dev/null || echo "unknown")
 		log_debug "  State: $STATE"
 
 		# Get challenge details
-		DOMAIN=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.dnsName}' 2>/dev/null || echo "unknown")
-		KEY=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.key}' 2>/dev/null || echo "unknown")
+		DOMAIN=$("$KUBE_CLI" get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.dnsName}' 2>/dev/null || echo "unknown")
+		KEY=$("$KUBE_CLI" get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.key}' 2>/dev/null || echo "unknown")
 
 		log_debug "  Domain: $DOMAIN"
 		log_debug "  DNS Record: _acme-challenge.$DOMAIN"
@@ -142,20 +142,20 @@ echo
 
 # Check RFC2136 credentials secret
 log_info "Checking RFC2136 credentials..."
-if oc get secret rfc2136-credentials -n cert-manager &>/dev/null; then
+if "$KUBE_CLI" get secret rfc2136-credentials -n cert-manager &>/dev/null; then
 	echo "✅ RFC2136 credentials secret exists"
 else
 	log_warn "RFC2136 credentials secret not found in cert-manager namespace"
 fi
 
 print_header "Recent cert-manager Logs"
-oc logs -n cert-manager deployment/cert-manager --tail=20 2>/dev/null || log_warn "Could not fetch logs"
+"$KUBE_CLI" logs -n cert-manager deployment/cert-manager --tail=20 2>/dev/null || log_warn "Could not fetch logs"
 
 print_header "Recent Pebble Logs"
-oc logs -n pebble -l app=pebble --tail=20 2>/dev/null || log_warn "Could not fetch Pebble logs"
+"$KUBE_CLI" logs -n pebble -l app=pebble --tail=20 2>/dev/null || log_warn "Could not fetch Pebble logs"
 
 print_header "Recent Fake DNS API Logs"
-oc logs -n fake-dns -l app=fake-dns-api --tail=20 2>/dev/null || log_warn "Could not fetch fake DNS API logs"
+"$KUBE_CLI" logs -n fake-dns -l app=fake-dns-api --tail=20 2>/dev/null || log_warn "Could not fetch fake DNS API logs"
 
 print_header "Recommendations"
 echo "1. For air-gapped DNS-01 testing, ensure Pebble has ALWAYS_VALID=1:"
@@ -168,8 +168,8 @@ echo "3. Check specific certificate:"
 echo "   ./scripts/troubleshooting/check-certificate.sh <cert-name> <namespace>"
 echo
 echo "4. View fake DNS API logs:"
-echo "   oc logs -n fake-dns -l app=fake-dns-api -f"
+echo "   $KUBE_CLI logs -n fake-dns -l app=fake-dns-api -f"
 echo
 echo "5. View Pebble challenge test server logs:"
-echo "   oc logs -n pebble -l app=pebble-challtestsrv -f"
+echo "   $KUBE_CLI logs -n pebble -l app=pebble-challtestsrv -f"
 echo

--- a/scripts/troubleshooting/diagnose-http01.sh
+++ b/scripts/troubleshooting/diagnose-http01.sh
@@ -10,14 +10,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
-require_cmd oc jq
+require_cmd "$KUBE_CLI" jq
 
 print_header "HTTP-01 Challenge Diagnostics"
 
 # Check cert-manager
 log_info "Checking cert-manager..."
-if oc get deployment cert-manager -n cert-manager &>/dev/null; then
-	READY=$(oc get deployment cert-manager -n cert-manager -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+if "$KUBE_CLI" get deployment cert-manager -n cert-manager &>/dev/null; then
+	READY=$("$KUBE_CLI" get deployment cert-manager -n cert-manager -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 	if [ "$READY" -gt 0 ]; then
 		echo "✅ cert-manager is running"
 	else
@@ -31,13 +31,13 @@ echo
 
 # Check Pebble
 log_info "Checking Pebble ACME server..."
-if oc get deployment pebble -n pebble &>/dev/null; then
-	READY=$(oc get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+if "$KUBE_CLI" get deployment pebble -n pebble &>/dev/null; then
+	READY=$("$KUBE_CLI" get deployment pebble -n pebble -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
 	if [ "$READY" -gt 0 ]; then
 		echo "✅ Pebble is running"
 
 		# Get Pebble route
-		ROUTE=$(oc get route pebble-acme -n pebble -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
+		ROUTE=$("$KUBE_CLI" get route pebble-acme -n pebble -o jsonpath='{.spec.host}' 2>/dev/null || echo "")
 		if [ -n "$ROUTE" ]; then
 			log_debug "Pebble route: https://$ROUTE"
 		fi
@@ -52,12 +52,12 @@ echo
 
 # Check HTTP-01 ClusterIssuers
 log_info "Checking HTTP-01 ClusterIssuers..."
-HTTP01_ISSUERS=$(oc get clusterissuer -o json | jq -r '.items[] | select(.spec.acme.solvers[]?.http01 != null) | .metadata.name' 2>/dev/null || echo "")
+HTTP01_ISSUERS=$("$KUBE_CLI" get clusterissuer -o json | jq -r '.items[] | select(.spec.acme.solvers[]?.http01 != null) | .metadata.name' 2>/dev/null || echo "")
 
 if [ -n "$HTTP01_ISSUERS" ]; then
 	while IFS= read -r issuer; do
 		[[ -z "$issuer" ]] && continue
-		READY=$(oc get clusterissuer "$issuer" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+		READY=$("$KUBE_CLI" get clusterissuer "$issuer" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 		if [ "$READY" = "True" ]; then
 			echo "✅ $issuer is ready"
 		else
@@ -72,7 +72,7 @@ echo
 
 # Check for active HTTP-01 challenges
 log_info "Checking for active HTTP-01 challenges..."
-CHALLENGES=$(oc get challenge -A -o json 2>/dev/null | jq -r '.items[] | select(.spec.solver.http01 != null) | "\(.metadata.namespace)/\(.metadata.name)"' || echo "")
+CHALLENGES=$("$KUBE_CLI" get challenge -A -o json 2>/dev/null | jq -r '.items[] | select(.spec.solver.http01 != null) | "\(.metadata.namespace)/\(.metadata.name)"' || echo "")
 
 if [ -n "$CHALLENGES" ]; then
 	echo "Found HTTP-01 challenges:"
@@ -85,19 +85,19 @@ if [ -n "$CHALLENGES" ]; then
 
 		log_debug "Challenge: $NAME (namespace: $NAMESPACE)"
 
-		STATE=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.status.state}' 2>/dev/null || echo "unknown")
+		STATE=$("$KUBE_CLI" get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.status.state}' 2>/dev/null || echo "unknown")
 		log_debug "  State: $STATE"
 
 		# Get challenge details
-		DOMAIN=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.dnsName}' 2>/dev/null || echo "unknown")
-		TOKEN=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.token}' 2>/dev/null || echo "unknown")
-		KEY=$(oc get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.key}' 2>/dev/null || echo "unknown")
+		DOMAIN=$("$KUBE_CLI" get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.dnsName}' 2>/dev/null || echo "unknown")
+		TOKEN=$("$KUBE_CLI" get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.token}' 2>/dev/null || echo "unknown")
+		KEY=$("$KUBE_CLI" get challenge "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.key}' 2>/dev/null || echo "unknown")
 
 		log_debug "  Domain: $DOMAIN"
 		log_debug "  Token: ${TOKEN:0:20}..."
 
 		# Check if challenge service exists
-		if oc get service -n "$NAMESPACE" -l "acme.cert-manager.io/http01-solver=true" &>/dev/null; then
+		if "$KUBE_CLI" get service -n "$NAMESPACE" -l "acme.cert-manager.io/http01-solver=true" &>/dev/null; then
 			echo "  ✅ Challenge solver service exists"
 		else
 			log_warn "  Challenge solver service not found"
@@ -120,10 +120,10 @@ else
 fi
 
 print_header "Recent cert-manager Logs"
-oc logs -n cert-manager deployment/cert-manager --tail=20 2>/dev/null || log_warn "Could not fetch logs"
+"$KUBE_CLI" logs -n cert-manager deployment/cert-manager --tail=20 2>/dev/null || log_warn "Could not fetch logs"
 
 print_header "Recent Pebble Logs"
-oc logs -n pebble -l app=pebble --tail=20 2>/dev/null || log_warn "Could not fetch Pebble logs"
+"$KUBE_CLI" logs -n pebble -l app=pebble --tail=20 2>/dev/null || log_warn "Could not fetch Pebble logs"
 
 print_header "Recommendations"
 echo "1. Ensure Pebble is configured with PEBBLE_ALWAYS_VALID=1 for testing:"
@@ -136,5 +136,5 @@ echo "3. Check specific certificate:"
 echo "   ./scripts/troubleshooting/check-certificate.sh <cert-name> <namespace>"
 echo
 echo "4. View full cert-manager logs:"
-echo "   oc logs -n cert-manager deployment/cert-manager -f"
+echo "   $KUBE_CLI logs -n cert-manager deployment/cert-manager -f"
 echo

--- a/scripts/troubleshooting/verify-apiserver-certificate.sh
+++ b/scripts/troubleshooting/verify-apiserver-certificate.sh
@@ -24,9 +24,19 @@ CERT_NAME="apiserver-cert"
 SECRET_NAME="apiserver-cert-tls"
 
 check_prerequisites() {
-	require_cmd oc jq
+	require_cmd "$KUBE_CLI" jq
 
-	if ! retry 3 5 oc whoami; then
+	if [[ "$CLUSTER_TYPE" != "openshift" ]]; then
+		log_info "Skipping API server certificate verification (OpenShift-only)"
+		exit 0
+	fi
+
+	if [[ "$KUBE_CLI" == "oc" ]]; then
+		if ! retry 3 5 "$KUBE_CLI" whoami; then
+			log_error "Cluster may be unstable. Please check cluster connectivity."
+			exit 1
+		fi
+	elif ! retry 3 5 "$KUBE_CLI" get namespace default; then
 		log_error "Cluster may be unstable. Please check cluster connectivity."
 		exit 1
 	fi
@@ -37,28 +47,38 @@ verify_api_server_access() {
 	local has_issues=0
 
 	# Test 1: Can we run basic oc commands?
-	if oc version --client &>/dev/null; then
-		log_info "  ✅ oc client works"
+	if "$KUBE_CLI" version --client &>/dev/null; then
+		log_info "  ✅ $KUBE_CLI client works"
 	else
-		log_error "  ❌ oc client failed"
+		log_error "  ❌ $KUBE_CLI client failed"
 		has_issues=1
 	fi
 
 	# Test 2: Can we reach the API server?
-	if oc whoami &>/dev/null; then
+	if [[ "$KUBE_CLI" == "oc" ]]; then
+		if "$KUBE_CLI" whoami &>/dev/null; then
+			log_info "  ✅ API server is accessible (authenticated)"
+			local username
+			username=$("$KUBE_CLI" whoami 2>/dev/null || echo "unknown")
+			log_debug "     Logged in as: $username"
+		else
+			log_error "  ❌ Cannot authenticate with API server"
+			has_issues=1
+		fi
+	elif "$KUBE_CLI" get namespace default &>/dev/null; then
 		log_info "  ✅ API server is accessible (authenticated)"
 		local username
-		username=$(oc whoami 2>/dev/null || echo "unknown")
-		log_debug "     Logged in as: $username"
+		username=$("$KUBE_CLI" config current-context 2>/dev/null || echo "unknown")
+		log_debug "     Context: $username"
 	else
 		log_error "  ❌ Cannot authenticate with API server"
 		has_issues=1
 	fi
 
 	# Test 3: Can we list resources?
-	if oc get nodes &>/dev/null; then
+	if "$KUBE_CLI" get nodes &>/dev/null; then
 		local node_count
-		node_count=$(oc get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
+		node_count=$("$KUBE_CLI" get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')
 		log_info "  ✅ Can list cluster resources ($node_count nodes)"
 	else
 		log_error "  ❌ Cannot list cluster resources"
@@ -67,7 +87,11 @@ verify_api_server_access() {
 
 	# Test 4: Can we get API server info?
 	local api_url
-	api_url=$(oc whoami --show-server 2>/dev/null || echo "")
+	if [[ "$KUBE_CLI" == "oc" ]]; then
+		api_url=$("$KUBE_CLI" whoami --show-server 2>/dev/null || echo "")
+	else
+		api_url=$("$KUBE_CLI" config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null || echo "")
+	fi
 	if [ -n "$api_url" ]; then
 		log_info "  ✅ API server URL: $api_url"
 	else
@@ -82,17 +106,17 @@ verify_certificate_exists() {
 	log_info "Verifying certificate resource..."
 	local has_issues=0
 
-	if ! oc get namespace "$CERT_NAMESPACE" &>/dev/null; then
+	if ! "$KUBE_CLI" get namespace "$CERT_NAMESPACE" &>/dev/null; then
 		log_error "  ❌ Namespace '$CERT_NAMESPACE' not found"
 		return 1
 	fi
 
-	if oc get certificate "$CERT_NAME" -n "$CERT_NAMESPACE" &>/dev/null; then
+	if "$KUBE_CLI" get certificate "$CERT_NAME" -n "$CERT_NAMESPACE" &>/dev/null; then
 		log_info "  ✅ Certificate '$CERT_NAME' exists"
 
 		# Check if certificate is ready
 		local ready
-		ready=$(oc get certificate "$CERT_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+		ready=$("$KUBE_CLI" get certificate "$CERT_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
 
 		if [ "$ready" = "True" ]; then
 			log_info "  ✅ Certificate is READY"
@@ -113,14 +137,14 @@ verify_certificate_secret() {
 	log_info "Verifying certificate secret..."
 	local has_issues=0
 
-	if oc get secret "$SECRET_NAME" -n "$CERT_NAMESPACE" &>/dev/null; then
+	if "$KUBE_CLI" get secret "$SECRET_NAME" -n "$CERT_NAMESPACE" &>/dev/null; then
 		log_info "  ✅ Secret '$SECRET_NAME' exists"
 
 		# Check if secret has required keys
 		local has_tls_crt
-		has_tls_crt=$(oc get secret "$SECRET_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.data.tls\.crt}' 2>/dev/null)
+		has_tls_crt=$("$KUBE_CLI" get secret "$SECRET_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.data.tls\.crt}' 2>/dev/null)
 		local has_tls_key
-		has_tls_key=$(oc get secret "$SECRET_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.data.tls\.key}' 2>/dev/null)
+		has_tls_key=$("$KUBE_CLI" get secret "$SECRET_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.data.tls\.key}' 2>/dev/null)
 
 		if [ -n "$has_tls_crt" ]; then
 			log_info "  ✅ Secret contains tls.crt"
@@ -150,7 +174,7 @@ verify_certificate_details() {
 
 	# Extract and verify certificate
 	local cert_pem
-	cert_pem=$(oc get secret "$SECRET_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d)
+	cert_pem=$("$KUBE_CLI" get secret "$SECRET_NAME" -n "$CERT_NAMESPACE" -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d)
 
 	if [ -n "$cert_pem" ]; then
 		# Check expiration
@@ -202,7 +226,7 @@ check_apiserver_configuration() {
 
 	# Check if the API server is configured to use our certificate
 	local apiserver_config
-	apiserver_config=$(oc get apiserver cluster -o json 2>/dev/null)
+	apiserver_config=$("$KUBE_CLI" get apiserver cluster -o json 2>/dev/null)
 
 	if [ -n "$apiserver_config" ]; then
 		local serving_certs
@@ -244,16 +268,16 @@ provide_recommendations() {
 		echo
 		log_info "Troubleshooting steps:"
 		echo "  1. Check certificate status:"
-		echo "     oc describe certificate $CERT_NAME -n $CERT_NAMESPACE"
+		echo "     $KUBE_CLI describe certificate $CERT_NAME -n $CERT_NAMESPACE"
 		echo
 		echo "  2. Check certificate secret:"
-		echo "     oc get secret $SECRET_NAME -n $CERT_NAMESPACE"
+		echo "     $KUBE_CLI get secret $SECRET_NAME -n $CERT_NAMESPACE"
 		echo
 		echo "  3. Check API server logs:"
-		echo "     oc logs -n openshift-apiserver -l app=openshift-apiserver"
+		echo "     $KUBE_CLI logs -n openshift-apiserver -l app=openshift-apiserver"
 		echo
 		echo "  4. Verify cert-manager logs:"
-		echo "     oc logs -n cert-manager deployment/cert-manager"
+		echo "     $KUBE_CLI logs -n cert-manager deployment/cert-manager"
 	fi
 
 	echo

--- a/scripts/workflows/display-component-status.sh
+++ b/scripts/workflows/display-component-status.sh
@@ -15,7 +15,12 @@ source "$SCRIPT_DIR/../../lib/common.sh"
 print_header "Component Status"
 
 # Check if cluster is accessible
-if ! oc whoami &>/dev/null; then
+if [[ "$KUBE_CLI" == "oc" ]]; then
+	cluster_ok=$("$KUBE_CLI" whoami &>/dev/null && echo yes || echo no)
+else
+	cluster_ok=$("$KUBE_CLI" get namespace default &>/dev/null && echo yes || echo no)
+fi
+if [[ "$cluster_ok" != "yes" ]]; then
 	log_error "❌ Cluster is not accessible"
 	log_warn "Cannot display component status - cluster connection failed"
 	echo
@@ -31,27 +36,27 @@ log_info "Cluster is accessible, displaying component status..."
 echo
 
 echo "cert-manager pods:"
-oc get pods -n cert-manager || log_warn "Cannot retrieve cert-manager pods"
+"$KUBE_CLI" get pods -n cert-manager || log_warn "Cannot retrieve cert-manager pods"
 echo ""
 echo "Pebble pods:"
-oc get pods -n pebble || log_warn "Cannot retrieve Pebble pods"
+"$KUBE_CLI" get pods -n pebble || log_warn "Cannot retrieve Pebble pods"
 echo ""
 echo "ClusterIssuer status:"
-oc get clusterissuer -o wide || log_warn "Cannot retrieve ClusterIssuers"
+"$KUBE_CLI" get clusterissuer -o wide || log_warn "Cannot retrieve ClusterIssuers"
 echo ""
 echo "Certificate status:"
-oc get certificate -n default || log_warn "Cannot retrieve Certificates"
+"$KUBE_CLI" get certificate -n default || log_warn "Cannot retrieve Certificates"
 echo ""
 echo "CertificateRequest status:"
-oc get certificaterequest -n default || log_warn "Cannot retrieve CertificateRequests"
+"$KUBE_CLI" get certificaterequest -n default || log_warn "Cannot retrieve CertificateRequests"
 echo ""
 echo "Order status:"
-oc get order -n default || log_warn "Cannot retrieve Orders"
+"$KUBE_CLI" get order -n default || log_warn "Cannot retrieve Orders"
 echo ""
 echo "Challenge status:"
-oc get challenge -n default || log_warn "Cannot retrieve Challenges"
+"$KUBE_CLI" get challenge -n default || log_warn "Cannot retrieve Challenges"
 echo ""
 echo "Recent cert-manager logs:"
-oc logs -n cert-manager deployment/cert-manager --tail=30 || log_warn "Cannot retrieve cert-manager logs"
+"$KUBE_CLI" logs -n cert-manager deployment/cert-manager --tail=30 || log_warn "Cannot retrieve cert-manager logs"
 echo
 print_header "Status Display Complete"

--- a/scripts/workflows/recover-cluster.sh
+++ b/scripts/workflows/recover-cluster.sh
@@ -16,7 +16,7 @@ print_header "CRC Cluster Recovery Attempt"
 
 # Test 1: Check if DNS resolution is working
 log_info "Checking DNS resolution..."
-API_HOST=$(oc config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null | sed 's|https://||' | cut -d: -f1 || echo "")
+API_HOST=$("$KUBE_CLI" config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null | sed 's|https://||' | cut -d: -f1 || echo "")
 
 if [ -z "$API_HOST" ]; then
 	log_error "Cannot determine API server hostname"
@@ -41,14 +41,19 @@ fi
 
 # Test 2: Check if we can authenticate
 log_info "Checking cluster authentication..."
-if ! oc whoami &>/dev/null; then
+if [[ "$KUBE_CLI" == "oc" ]]; then
+	auth_cmd=("$KUBE_CLI" whoami)
+else
+	auth_cmd=("$KUBE_CLI" get namespace default)
+fi
+if ! "${auth_cmd[@]}" &>/dev/null; then
 	log_warn "Cannot authenticate with cluster"
 	log_info "Attempting to refresh authentication..."
 
 	# Try to force a token refresh
-	oc version &>/dev/null || true
+	"$KUBE_CLI" version &>/dev/null || true
 
-	if retry 3 3 oc whoami; then
+	if retry 3 3 "${auth_cmd[@]}"; then
 		log_info "✅ Authentication recovered"
 	else
 		log_error "❌ Authentication still failing"
@@ -58,7 +63,7 @@ fi
 
 # Test 3: Check API server responsiveness
 log_info "Checking API server responsiveness..."
-if retry 5 5 oc get namespace default; then
+if retry 5 5 "$KUBE_CLI" get namespace default; then
 	log_info "✅ API server is responsive"
 else
 	log_error "❌ API server not responsive after 5 attempts"

--- a/scripts/workflows/verify-apiserver-cert-with-retry.sh
+++ b/scripts/workflows/verify-apiserver-cert-with-retry.sh
@@ -13,8 +13,17 @@ source "$SCRIPT_DIR/../../lib/common.sh"
 
 # shellcheck disable=SC2329
 check_cluster() {
-	oc whoami &>/dev/null && oc get nodes &>/dev/null
+	if [[ "$KUBE_CLI" == "oc" ]]; then
+		"$KUBE_CLI" whoami &>/dev/null && "$KUBE_CLI" get nodes &>/dev/null
+	else
+		"$KUBE_CLI" get namespace default &>/dev/null && "$KUBE_CLI" get nodes &>/dev/null
+	fi
 }
+
+if [[ "$CLUSTER_TYPE" != "openshift" ]]; then
+	log_info "Skipping API server certificate verification (OpenShift-only)"
+	exit 0
+fi
 
 log_info "Waiting for cluster connectivity before verification..."
 if wait_for_condition 5 5 check_cluster; then

--- a/scripts/workflows/verify-cluster-access.sh
+++ b/scripts/workflows/verify-cluster-access.sh
@@ -14,18 +14,18 @@ source "$SCRIPT_DIR/../../lib/common.sh"
 
 print_header "CRC Cluster Health Check"
 
-# Test 1: Check oc command is available
-log_info "Checking oc CLI availability..."
-if ! command -v oc &>/dev/null; then
-	log_error "oc command not found"
+# Test 1: Check cluster CLI is available
+log_info "Checking $KUBE_CLI CLI availability..."
+if ! command -v "$KUBE_CLI" &>/dev/null; then
+	log_error "$KUBE_CLI command not found"
 	exit 1
 fi
-oc version --client
+"$KUBE_CLI" version --client
 echo
 
 # Test 2: Check DNS resolution for API server
 log_info "Checking API server DNS resolution..."
-API_HOST=$(oc config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null | sed 's|https://||' | cut -d: -f1)
+API_HOST=$("$KUBE_CLI" config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null | sed 's|https://||' | cut -d: -f1)
 if [ -z "$API_HOST" ]; then
 	log_error "Could not determine API server hostname from kubeconfig"
 	exit 1
@@ -58,7 +58,11 @@ echo
 
 # Test 4: Check authentication
 log_info "Checking cluster authentication..."
-USERNAME=$(oc whoami 2>/dev/null || echo "")
+if [[ "$KUBE_CLI" == "oc" ]]; then
+	USERNAME=$("$KUBE_CLI" whoami 2>/dev/null || echo "")
+else
+	USERNAME=$("$KUBE_CLI" config current-context 2>/dev/null || echo "")
+fi
 if [ -n "$USERNAME" ]; then
 	log_info "✅ Authenticated as: $USERNAME"
 else
@@ -70,9 +74,9 @@ echo
 
 # Test 5: Check API server reachability
 log_info "Checking API server reachability..."
-if oc version &>/dev/null; then
+if "$KUBE_CLI" version &>/dev/null; then
 	log_info "✅ API server is reachable"
-	oc version | grep -E "Server Version|Kubernetes Version" || true
+	"$KUBE_CLI" version | grep -E "Server Version|Kubernetes Version" || true
 else
 	log_error "❌ Cannot reach API server"
 	exit 1
@@ -81,10 +85,10 @@ echo
 
 # Test 6: Check cluster nodes
 log_info "Checking cluster nodes..."
-NODE_COUNT=$(oc get nodes --no-headers 2>/dev/null | wc -l | xargs)
+NODE_COUNT=$("$KUBE_CLI" get nodes --no-headers 2>/dev/null | wc -l | xargs)
 if [ "$NODE_COUNT" -gt 0 ]; then
 	log_info "✅ Cluster has $NODE_COUNT node(s)"
-	oc get nodes
+	"$KUBE_CLI" get nodes
 else
 	log_error "❌ No nodes found in cluster"
 	exit 1
@@ -94,31 +98,36 @@ echo
 # Test 7: Check node readiness
 log_info "Checking node readiness..."
 # Use || true to prevent grep from failing when all nodes are Ready (grep returns 1 on no match)
-NOT_READY=$(oc get nodes --no-headers 2>/dev/null | { grep -v " Ready " || true; } | wc -l | xargs)
+NOT_READY=$("$KUBE_CLI" get nodes --no-headers 2>/dev/null | { grep -v " Ready " || true; } | wc -l | xargs)
 if [ "$NOT_READY" -eq 0 ]; then
 	log_info "✅ All nodes are Ready"
 else
 	log_warn "⚠️  $NOT_READY node(s) not ready"
-	oc get nodes | grep -v " Ready " || true
+	"$KUBE_CLI" get nodes | grep -v " Ready " || true
 fi
 echo
 
-# Test 8: Check critical cluster operators
-log_info "Checking critical cluster operators..."
-DEGRADED_OPS=$(oc get clusteroperators --no-headers 2>/dev/null | awk '$3=="True" || $4=="True" || $5=="True"' | wc -l | xargs)
-if [ "$DEGRADED_OPS" -eq 0 ]; then
-	log_info "✅ No degraded cluster operators"
+# Test 8: Check critical cluster operators (OpenShift-only)
+if [[ "$CLUSTER_TYPE" == "openshift" ]]; then
+	log_info "Checking critical cluster operators..."
+	DEGRADED_OPS=$("$KUBE_CLI" get clusteroperators --no-headers 2>/dev/null | awk '$3=="True" || $4=="True" || $5=="True"' | wc -l | xargs)
+	if [ "$DEGRADED_OPS" -eq 0 ]; then
+		log_info "✅ No degraded cluster operators"
+	else
+		log_warn "⚠️  $DEGRADED_OPS cluster operator(s) degraded"
+		"$KUBE_CLI" get clusteroperators | grep -E "DEGRADED.*True|PROGRESSING.*True|AVAILABLE.*False" || true
+		log_warn "Continuing despite degraded operators (may cause test issues)"
+	fi
+	echo
 else
-	log_warn "⚠️  $DEGRADED_OPS cluster operator(s) degraded"
-	oc get clusteroperators | grep -E "DEGRADED.*True|PROGRESSING.*True|AVAILABLE.*False" || true
-	log_warn "Continuing despite degraded operators (may cause test issues)"
+	log_info "Skipping cluster operator check (OpenShift-only)"
+	echo
 fi
-echo
 
 # Test 9: Quick API responsiveness check
 log_info "Checking API responsiveness..."
 START_TIME=$(date +%s)
-if oc get namespace default &>/dev/null; then
+if "$KUBE_CLI" get namespace default &>/dev/null; then
 	END_TIME=$(date +%s)
 	DURATION=$((END_TIME - START_TIME))
 	log_info "✅ API responded in ${DURATION}s"

--- a/scripts/workflows/wait-for-cluster-operators.sh
+++ b/scripts/workflows/wait-for-cluster-operators.sh
@@ -11,9 +11,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../../lib/common.sh"
 
+if [[ "$CLUSTER_TYPE" != "openshift" ]]; then
+	log_info "Skipping cluster operator wait (OpenShift-only)"
+	exit 0
+fi
+
 check_operators_healthy() {
 	local degraded
-	degraded=$(oc get clusteroperators --no-headers | awk '($3!="True" || $4=="True" || $5=="True")' | wc -l | xargs)
+	degraded=$("$KUBE_CLI" get clusteroperators --no-headers | awk '($3!="True" || $4=="True" || $5=="True")' | wc -l | xargs)
 	[ "$degraded" -eq 0 ]
 }
 
@@ -24,6 +29,6 @@ else
 	log_warn "Timeout waiting for all cluster operators. Checking critical operators..."
 fi
 log_info "Cluster operator status:"
-oc get clusteroperators || true
+"$KUBE_CLI" get clusteroperators || true
 
 require_healthy_cluster 30 10


### PR DESCRIPTION
## Summary
- Replace hardcoded `oc` in troubleshooting and cluster-facing workflow scripts with `"$KUBE_CLI"`
- Skip OpenShift-only APIs on Kubernetes/Kind (CSV, Route, `clusteroperators`, `network.config`, API server cert) instead of failing on missing CRDs
- Keep `oc whoami` behind `KUBE_CLI=oc`; kubectl uses `config current-context` / `get namespace default`

Fixes #146

## Notes
- Overlaps with #153 (`check-all.sh` parallelize): this PR is the mechanical `KUBE_CLI` rename; #153 can layer on top.
- `lib/common.sh` `wait_for_csv` still uses bare `oc` — out of scope here.

## Test Plan
- [ ] `make lint`
- [ ] `grep -nE '(^|[^"])\boc\b' scripts/troubleshooting/*.sh` — leftover `oc` only in comments
- [ ] `KUBE_CLI=kubectl CLUSTER_TYPE=kubernetes` smoke-run `scripts/troubleshooting/check-all.sh` (generic checks run; CSV/Route skip)
- [ ] OpenShift: `make troubleshoot` still works with `oc`


Made with [Cursor](https://cursor.com)