### PR TITLE
Add BATS unit tests for lib/common.sh

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -108,14 +108,33 @@ jobs:
             exit 1
           fi
 
+  unit-tests:
+    name: Unit Tests (BATS)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install bats-core
+        run: |
+          curl -fsSL https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz | tar xz
+          sudo ./bats-core-1.11.1/install.sh /usr/local
+
+      - name: Install gettext (envsubst)
+        run: sudo apt-get update && sudo apt-get install -y gettext-base
+
+      - name: Run unit tests
+        run: make test-unit
+
   kind-integration-test:
     name: Kind Integration Test (CM ${{ matrix.cert-manager-version }})
-    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure]
+    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure, unit-tests]
     if: |
       needs.shell-format-check.result == 'success' &&
       needs.shellcheck.result == 'success' &&
       needs.workload-partitioning-check.result == 'success' &&
-      needs.verify-structure.result == 'success'
+      needs.verify-structure.result == 'success' &&
+      needs.unit-tests.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -127,13 +146,14 @@ jobs:
 
   integration-test:
     name: Integration Test (OCP ${{ matrix.ocp-version }} / CM ${{ matrix.cert-manager-version }})
-    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure]
+    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure, unit-tests]
     if: |
       github.actor != 'dependabot[bot]' &&
       needs.shell-format-check.result == 'success' &&
       needs.shellcheck.result == 'success' &&
       needs.workload-partitioning-check.result == 'success' &&
-      needs.verify-structure.result == 'success'
+      needs.verify-structure.result == 'success' &&
+      needs.unit-tests.result == 'success'
     strategy:
       fail-fast: false
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Automation toolkit for testing cert-manager-operator on OpenShift clusters using
 ### Linting & Validation
 ```bash
 make lint          # Run shellcheck + shfmt on all scripts (CI gate)
+make test-unit     # Run BATS unit tests (no cluster)
 make preflight     # Check all tool dependencies and cluster prerequisites
 ```
 
@@ -173,8 +174,9 @@ CI runs on PRs to main (`.github/workflows/pre-main.yml`):
 3. **workload-partitioning-check** — script exists, is executable, syntax + Makefile/docs mentions
 4. **verify-structure** — directory layout, key files, script references
 5. **version-query-check** — version query scripts for pebble, acme-dns, operator, minio, ubi9-python
-6. **kind-integration-test** — Kind cluster, cert-manager v1.19.0 / v1.20.0
-7. **integration-test** — OCP 4.20/4.21/4.22 × cert-manager v1.19.0/v1.20.0 CRC matrix (skipped for dependabot); `make quick-http-test`, API server cert, workload partitioning, network stack detection
+6. **unit-tests** — BATS (`make test-unit`), no cluster
+7. **kind-integration-test** — Kind cluster, cert-manager v1.19.0 / v1.20.0
+8. **integration-test** — OCP 4.20/4.21/4.22 × cert-manager v1.19.0/v1.20.0 CRC matrix (skipped for dependabot); `make quick-http-test`, API server cert, workload partitioning, network stack detection
 
 ## Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,8 +132,9 @@ Runs on every push and pull request to `main`:
 3. **Workload partitioning check** — script present, executable, valid syntax
 4. **Structure check** — directory layout, key files, script references
 5. **Version query check** — pebble, acme-dns, operator, minio, ubi9-python
-6. **Kind integration test** — cert-manager v1.19.0 and v1.20.0
-7. **OCP integration test** — CRC via [quick-ocp](https://github.com/palmsoftware/quick-ocp), matrix of OCP 4.20/4.21/4.22 × cert-manager v1.19.0/v1.20.0. Runs `make quick-http-test` (HTTP-01, not DNS-01), API server cert verification, workload partitioning, and network stack detection. Skipped for dependabot.
+6. **Unit tests** — BATS (`make test-unit`), no cluster
+7. **Kind integration test** — cert-manager v1.19.0 and v1.20.0
+8. **OCP integration test** — CRC via [quick-ocp](https://github.com/palmsoftware/quick-ocp), matrix of OCP 4.20/4.21/4.22 × cert-manager v1.19.0/v1.20.0. Runs `make quick-http-test` (HTTP-01, not DNS-01), API server cert verification, workload partitioning, and network stack detection. Skipped for dependabot.
 
 OCP integration tests need the `CRC_PULL_SECRET` GitHub secret (upstream only). See [CI cluster health](docs/CRC-CLUSTER-HEALTH-IMPROVEMENTS.md) for the CRC health-check flow.
 
@@ -144,6 +145,9 @@ You can run the same checks that CI runs:
 ```bash
 # Format check (always run this before committing)
 make lint
+
+# Unit tests (no cluster)
+make test-unit
 
 # Integration test (requires OpenShift cluster access)
 make install-cert-manager-operator

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ BG_BLUE := \033[44m
 # ────────────────────────────────────────────────────────────────────────────────
 # Target Definitions
 # ────────────────────────────────────────────────────────────────────────────────
-.PHONY: all help banner preflight lint fmt _require-shfmt install-cert-manager-operator install-cert-manager-helm install-pebble \
+.PHONY: all help banner preflight lint fmt test-unit _require-shfmt install-cert-manager-operator install-cert-manager-helm install-pebble \
         install-fake-dns install-all install-monitoring create-issuer create-dns01-issuer \
         create-selfsigned-issuer create-certs create-apiserver-cert verify-apiserver-cert \
         test-all test-dns01 quick-http-test quick-dns-test quick-selfsigned-test \
@@ -69,7 +69,7 @@ help: banner ## Show this help message
 	@echo "$(BOLD)$(BLUE)Available Commands:$(RESET)"
 	@echo ""
 	@echo "$(YELLOW)Setup & Validation:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(preflight|lint|fmt|check-network|check-workload)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(preflight|lint|fmt|test-unit|check-network|check-workload)"
 	@echo ""
 	@echo "$(YELLOW)Installation:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(install-|register-)"
@@ -118,6 +118,17 @@ fmt: _require-shfmt ## Auto-fix shell script formatting with shfmt
 	@echo "$(BOLD)$(BLUE)Formatting shell scripts...$(RESET)"
 	@shfmt -w scripts/ lib/
 	@echo "$(GREEN)Shell scripts formatted!$(RESET)"
+
+test-unit: ## Run BATS unit tests (no cluster)
+	@if ! command -v bats >/dev/null 2>&1; then \
+	  echo "$(RED)bats not found. Please install it:$(RESET)"; \
+	  echo "$(DIM)  macOS: brew install bats-core$(RESET)"; \
+	  echo "$(DIM)  Linux: see https://github.com/bats-core/bats-core#install$(RESET)"; \
+	  exit 1; \
+	fi
+	@echo "$(BOLD)$(BLUE)Running BATS unit tests...$(RESET)"
+	@bats --recursive tests/
+	@echo "$(GREEN)Unit tests passed!$(RESET)"
 
 _require-shfmt:
 	@if ! command -v shfmt >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ cp .env.example .env
 make help       # Show all available targets
 make preflight  # Check tool dependencies and cluster prerequisites
 make lint       # Run shellcheck + shfmt (CI gate)
+make test-unit  # Run BATS unit tests (no cluster)
 make fmt        # Auto-fix shell formatting
 ```
 

--- a/tests/fixtures/sample-configmap.yaml
+++ b/tests/fixtures/sample-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ${FOO}
+  namespace: default
+data:
+  value: substituted

--- a/tests/lib/common.bats
+++ b/tests/lib/common.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# Unit tests for lib/common.sh. No cluster required.
+# Source common.sh after CLUSTER_TYPE/KUBE_CLI so detect_cluster_type is skipped.
+
+setup() {
+	export CLUSTER_TYPE=kubernetes
+	export KUBE_CLI=true
+	REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+	export REPO_ROOT
+	# shellcheck disable=SC1091
+	source "$REPO_ROOT/lib/common.sh"
+}
+
+pem_b64() {
+	printf '%s\n' "$1" | base64
+}
+
+@test "get_key_pem_type detects EC PRIVATE KEY" {
+	run get_key_pem_type "$(pem_b64 '-----BEGIN EC PRIVATE KEY-----')"
+	[ "$status" -eq 0 ]
+	[ "$output" = "EC PRIVATE KEY" ]
+}
+
+@test "get_key_pem_type detects RSA PRIVATE KEY" {
+	run get_key_pem_type "$(pem_b64 '-----BEGIN RSA PRIVATE KEY-----')"
+	[ "$status" -eq 0 ]
+	[ "$output" = "RSA PRIVATE KEY" ]
+}
+
+@test "get_key_pem_type detects PKCS#8 PRIVATE KEY" {
+	run get_key_pem_type "$(pem_b64 '-----BEGIN PRIVATE KEY-----')"
+	[ "$status" -eq 0 ]
+	[ "$output" = "PRIVATE KEY" ]
+}
+
+@test "get_key_pem_type returns UNKNOWN for empty input" {
+	run get_key_pem_type ""
+	[ "$status" -eq 0 ]
+	[ "$output" = "UNKNOWN" ]
+}
+
+@test "get_key_pem_type returns UNKNOWN for garbage" {
+	run get_key_pem_type "$(pem_b64 'not a pem header')"
+	[ "$status" -eq 0 ]
+	[ "$output" = "UNKNOWN" ]
+}
+
+@test "log_info is silent when LOG_LEVEL=quiet" {
+	run bash -c '
+		export LOG_LEVEL=quiet CLUSTER_TYPE=kubernetes KUBE_CLI=true
+		# shellcheck disable=SC1091
+		source "$1/lib/common.sh"
+		log_info "should not appear"
+	' _ "$REPO_ROOT"
+	[ "$status" -eq 0 ]
+	[ -z "$output" ]
+}
+
+@test "log_error still prints when LOG_LEVEL=error" {
+	run bash -c '
+		export LOG_LEVEL=error CLUSTER_TYPE=kubernetes KUBE_CLI=true
+		# shellcheck disable=SC1091
+		source "$1/lib/common.sh"
+		log_error "boom"
+	' _ "$REPO_ROOT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"[ERROR]"* ]]
+	[[ "$output" == *"boom"* ]]
+}
+
+@test "apply_yaml_template fails when the file is missing" {
+	run apply_yaml_template "$REPO_ROOT/tests/fixtures/does-not-exist.yaml" ConfigMap
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"not found"* ]]
+}
+
+@test "apply_yaml_template DRY_RUN prints substituted YAML without kube" {
+	export DRY_RUN=true
+	export FOO=unit-test-cm
+	run apply_yaml_template "$REPO_ROOT/tests/fixtures/sample-configmap.yaml" ConfigMap
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"name: unit-test-cm"* ]]
+	[[ "$output" != *'${FOO}'* ]]
+}
+
+@test "require_cmd succeeds for an existing binary" {
+	run require_cmd bash
+	[ "$status" -eq 0 ]
+}
+
+@test "require_cmd exits 1 for a missing binary" {
+	run require_cmd definitely_not_a_real_binary_xyzzy
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"definitely_not_a_real_binary_xyzzy"* ]]
+}


### PR DESCRIPTION
## Summary
- Add BATS coverage for `get_key_pem_type`, logging levels, `apply_yaml_template` (missing file / DRY_RUN), and `require_cmd`
- New `make test-unit` target (no cluster; install hint if `bats` is missing)
- CI job `unit-tests` (bats-core v1.11.1) is required by Kind and OCP integration jobs

Fixes #142

## Notes
- Unset-envsubst guard from #154 / #160 can get a BATS case after that PR merges. Not included here so this branch stays independent of `main`.
- `.bats` files are not in `make lint` for v1.

## Test Plan
- [ ] `make test-unit` on a machine with bats-core and **no** kubeconfig
- [ ] `make lint` still passes
- [ ] CI `Unit Tests (BATS)` job is green and listed in `needs:` of Kind/OCP jobs


Made with [Cursor](https://cursor.com)