### PR TITLE
Add kubeconform validation for rendered YAML manifests

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -120,21 +120,37 @@ jobs:
           curl -fsSL https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz | tar xz
           sudo ./bats-core-1.11.1/install.sh /usr/local
 
-      - name: Install gettext (envsubst)
-        run: sudo apt-get update && sudo apt-get install -y gettext-base
-
       - name: Run unit tests
         run: make test-unit
 
+  yaml-validate:
+    name: YAML Schema Validation
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install kubeconform
+        run: |
+          curl -fsSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin/kubeconform
+
+      - name: Install gettext (envsubst)
+        run: sudo apt-get update && sudo apt-get install -y gettext-base
+
+      - name: Validate YAML manifests
+        run: make validate-yaml
+
   kind-integration-test:
     name: Kind Integration Test (CM ${{ matrix.cert-manager-version }})
-    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure, unit-tests]
+    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure, unit-tests, yaml-validate]
     if: |
       needs.shell-format-check.result == 'success' &&
       needs.shellcheck.result == 'success' &&
       needs.workload-partitioning-check.result == 'success' &&
       needs.verify-structure.result == 'success' &&
-      needs.unit-tests.result == 'success'
+      needs.unit-tests.result == 'success' &&
+      needs.yaml-validate.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -146,14 +162,15 @@ jobs:
 
   integration-test:
     name: Integration Test (OCP ${{ matrix.ocp-version }} / CM ${{ matrix.cert-manager-version }})
-    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure, unit-tests]
+    needs: [shell-format-check, shellcheck, workload-partitioning-check, verify-structure, unit-tests, yaml-validate]
     if: |
       github.actor != 'dependabot[bot]' &&
       needs.shell-format-check.result == 'success' &&
       needs.shellcheck.result == 'success' &&
       needs.workload-partitioning-check.result == 'success' &&
       needs.verify-structure.result == 'success' &&
-      needs.unit-tests.result == 'success'
+      needs.unit-tests.result == 'success' &&
+      needs.yaml-validate.result == 'success'
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ BG_BLUE := \033[44m
         create-multi-algo-certs verify-key-formats test-ibu-multi-algo clean-multi-algo-certs \
         quick-multi-algo-test \
         install-pebble-challtestsrv install-local-dns register-acmedns \
-        label-cert-resources simulate-ibu validate-cert-loss validate-post-restore
+        label-cert-resources simulate-ibu validate-cert-loss validate-post-restore \
+        validate-yaml
 
 # Default target
 all: help
@@ -69,7 +70,7 @@ help: banner ## Show this help message
 	@echo "$(BOLD)$(BLUE)Available Commands:$(RESET)"
 	@echo ""
 	@echo "$(YELLOW)Setup & Validation:$(RESET)"
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(preflight|lint|fmt|test-unit|check-network|check-workload)"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(preflight|lint|fmt|test-unit|validate-yaml|check-network|check-workload)"
 	@echo ""
 	@echo "$(YELLOW)Installation:$(RESET)"
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(CYAN)%-30s$(RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(install-|register-)"
@@ -129,6 +130,9 @@ test-unit: ## Run BATS unit tests (no cluster)
 	@echo "$(BOLD)$(BLUE)Running BATS unit tests...$(RESET)"
 	@bats --recursive tests/
 	@echo "$(GREEN)Unit tests passed!$(RESET)"
+
+validate-yaml: ## Validate YAML manifests with kubeconform
+	@./scripts/workflows/validate-yaml.sh
 
 _require-shfmt:
 	@if ! command -v shfmt >/dev/null 2>&1; then \

--- a/scripts/workflows/validate-yaml.sh
+++ b/scripts/workflows/validate-yaml.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+################################################################################
+# Script: validate-yaml.sh
+# Description: Render yaml/ templates with dummy envsubst values and validate
+#              Kubernetes objects with kubeconform (no cluster required).
+################################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=../../lib/common.sh
+source "$SCRIPT_DIR/../../lib/common.sh"
+
+cd "$REPO_ROOT"
+
+if ! command -v kubeconform >/dev/null 2>&1; then
+	log_error "kubeconform not found."
+	log_hint "Install: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.6.7"
+	exit 1
+fi
+require_cmd envsubst
+
+print_header "YAML schema validation (kubeconform)"
+
+# Dummy-export every ${VAR} referenced in templates so envsubst does not emit
+# empty names/namespaces. Do not load .env.
+while IFS= read -r name; do
+	[[ -z "$name" ]] && continue
+	eval "export ${name}=\"\${${name}:-dummy}\""
+done < <(grep -rhoE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' yaml --include='*.yaml' | sed 's/[${}]//g' | sort -u)
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+count=0
+while IFS= read -r -d '' yaml_file; do
+	rel="${yaml_file#yaml/}"
+	dest="$tmpdir/$rel"
+	mkdir -p "$(dirname "$dest")"
+	envsubst <"$yaml_file" >"$dest"
+	count=$((count + 1))
+done < <(find yaml -name '*.yaml' -type f -print0)
+
+log_info "Rendered $count YAML file(s) into $tmpdir"
+log_info "Running kubeconform -strict -ignore-missing-schemas..."
+
+kubeconform -strict -summary -ignore-missing-schemas "$tmpdir"
+
+log_success "kubeconform validation passed."


### PR DESCRIPTION
## Summary
- Render `yaml/**/*.yaml` with dummy envsubst values (no `.env`) and run kubeconform `-strict -ignore-missing-schemas`
- New `make validate-yaml` target (install hint if kubeconform is missing)
- CI job `yaml-validate` (kubeconform v0.6.7) is required by Kind and OCP integration jobs

Fixes #139

## Notes
- Overlap with #154: this dummy-exports template vars for CI rendering. The runtime unset-var guard in `apply_yaml_template` is separate and not required here.
- CRDs (Certificate, ClusterIssuer, Route, OLM, OADP, PrometheusRule, …) are skipped via `--ignore-missing-schemas`. Core kinds (Namespace, Deployment, Service, ConfigMap, Secret, PVC, Ingress) are validated.

## Test Plan
- [ ] `make validate-yaml` (47 resources: 25 valid, 22 skipped, 0 invalid)
- [ ] `make lint` unchanged / still passes
- [ ] Throwaway invalid Deployment (`spec.replicas: "not-an-int"`) is rejected by kubeconform
- [ ] CI `YAML Schema Validation` job is green and in `needs:` of Kind/OCP jobs


Made with [Cursor](https://cursor.com)