### PR TITLE
Fix nightly workflow: heredoc syntax for shfmt 3.14.0

### DIFF
--- a/scripts/create-apiserver-certificate.sh
+++ b/scripts/create-apiserver-certificate.sh
@@ -85,7 +85,7 @@ create_certificate() {
 	fi
 
 	# Create the Certificate CR
-	if cat <<EOF | oc apply -f -; then
+	if cat <<EOF | oc apply -f -
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -103,6 +103,7 @@ spec:
   - key encipherment
   - server auth
 EOF
+	then
 		log_info "Certificate '$CERT_NAME' created successfully in namespace '$CERT_NAMESPACE'"
 	else
 		log_error "Failed to create certificate '$CERT_NAME'"


### PR DESCRIPTION
## Summary

Fixes the nightly workflow lint failures that have been occurring since August 28, 2026.

## Problem

The nightly integration test workflow has been failing consistently in the "Quick lint gate" job due to a shell formatting violation in `scripts/create-apiserver-certificate.sh` at line 88.

**Root Cause**: shfmt 3.14.0 (used in CI) enforces stricter heredoc formatting than older versions. The pattern `if cmd <<EOF | pipe; then` violates the newer rules.

## Changes

- Line 88: Removed `; then` from the heredoc pipe command
- Line 106: Added standalone `then` keyword on new line after EOF marker

**Before:**
\`\`\`bash
if cat <<EOF | oc apply -f -; then
...