### PR TITLE
fix(install): wait for namespace termination before reinstalling pebble/fake-dns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 # ────────────────────────────────────────────────────────────────────────────────
 KUBE_CLI ?= $(shell command -v oc >/dev/null 2>&1 && echo oc || echo kubectl)
 CLUSTER_TYPE ?= $(shell command -v oc >/dev/null 2>&1 && oc whoami >/dev/null 2>&1 && echo openshift || echo kubernetes)
-# Lazily detect if make supports --output-sync
-SYNC_FLAG = $(shell $(MAKE) --help 2>&1 | grep -q "output-sync" && echo "--output-sync=target")
+SYNC_FLAG := $(shell $(MAKE) --help 2>&1 | grep -q "output-sync" && echo "--output-sync=target")
 export KUBE_CLI CLUSTER_TYPE
 
 # ────────────────────────────────────────────────────────────────────────────────

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -599,6 +599,32 @@ ensure_namespace() {
 	fi
 }
 
+# Wait for a namespace in Terminating phase to be fully deleted before recreating it.
+# Usage: wait_for_namespace_termination <namespace> [timeout_seconds]
+wait_for_namespace_termination() {
+	local namespace="$1"
+	local timeout="${2:-120}"
+
+	local phase
+	phase=$("$KUBE_CLI" get namespace "$namespace" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+
+	if [[ "$phase" != "Terminating" ]]; then
+		return 0
+	fi
+
+	log_info "Namespace '$namespace' is terminating; waiting up to ${timeout}s for full deletion..."
+	local elapsed=0
+	while "$KUBE_CLI" get namespace "$namespace" &>/dev/null; do
+		if [[ $elapsed -ge $timeout ]]; then
+			log_warn "Namespace '$namespace' still terminating after ${timeout}s — proceeding anyway."
+			return 0
+		fi
+		sleep 5
+		elapsed=$((elapsed + 5))
+	done
+	log_info "Namespace '$namespace' fully terminated."
+}
+
 # Check if a deployment exists and is healthy
 # Usage: check_deployment_exists <deployment> <namespace>
 # Returns 0 if deployment exists and has ready replicas

--- a/scripts/install-fake-dns.sh
+++ b/scripts/install-fake-dns.sh
@@ -231,6 +231,7 @@ main() {
 	require_cmd "$KUBE_CLI" envsubst
 	require_cluster
 	require_healthy_cluster
+	wait_for_namespace_termination "$FAKEDNS_NAMESPACE"
 
 	install_fake_dns
 	wait_for_resource "deployment/fake-dns-api" "$FAKEDNS_NAMESPACE" "${DEPLOYMENT_READY_TIMEOUT:-600s}"

--- a/scripts/install-pebble.sh
+++ b/scripts/install-pebble.sh
@@ -149,6 +149,8 @@ main() {
 	display_configuration
 	require_healthy_cluster
 
+	wait_for_namespace_termination "$PEBBLE_NAMESPACE"
+
 	if check_deployment_exists pebble "$PEBBLE_NAMESPACE"; then
 		log_info "Pebble is already installed and healthy."
 		log_info "Installation is idempotent - will verify and ensure components are ready."


### PR DESCRIPTION
## Problem

Nightly CI failed on OCP 4.20/v1.19.0 and OCP 4.21/v1.20.0 ([run 33748098976](https://github.com/sebrandon1/cert-manager-scripts/actions/runs/33748098976)):

```
[ERROR] ClusterIssuer 'pebble-issuer' not found.
make: *** [Makefile:224: create-apiserver-cert] Error 1
```

Root cause:

1. "Clean up DNS-01 test resources" runs `make clean-pebble`, which deletes the `pebble` namespace with `--wait=false` — namespace enters Terminating state.
2. ~6 minutes later, "Recreate issuer for API server cert test" runs `PEBBLE_ALWAYS_VALID=1 make install-pebble create-issuer || true`. `install-pebble` hits *"namespace is being terminated"* and exits 1. `make` stops; `create-issuer` never runs. The `|| true` hides the failure — CI shows the step as ✓.
3. `make create-apiserver-cert` finds no `pebble-issuer` ClusterIssuer and fails all 3 retry attempts.

More retries on `create-apiserver-cert` would not help — the issuer was genuinely absent.

## Fix

Add `wait_for_namespace_termination` to `lib/common.sh`. It checks whether a namespace is in Terminating phase and polls every 5s (up to 120s) until the namespace is fully gone, then returns so the caller can proceed with a clean slate.

Call it from `install-pebble.sh` and `install-fake-dns.sh` (both affected by the same `--wait=false` cleanup pattern) before applying any YAML into the namespace.

## Also included (from the branch)

- Parallelize `install-all` with `--output-sync` when the installed `make` supports it
- Track PIDs array in `check-all.sh` for safer `wait "${PIDS[@]}" || true`
- Fix shfmt heredoc formatting in `create-apiserver-certificate.sh`
- `SYNC_FLAG = ` → `SYNC_FLAG :=` so the shell probe evaluates once at parse time