### PR TITLE
fix(ci): pin shfmt to 3.14.0 in all workflow files

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Install Shfmt
         uses: mfinelli/setup-shfmt@a25fda4c1fe115aec0f85e04126610841bc3141d # v4.0.1
+        with:
+          shfmt-version: "3.14.0"
 
       - name: Shfmt
         run: shfmt -d .

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install Shfmt
         uses: mfinelli/setup-shfmt@a25fda4c1fe115aec0f85e04126610841bc3141d # v4.0.1
+        with:
+          shfmt-version: "3.14.0"
 
       - name: Shfmt
         run: shfmt -d scripts/ lib/


### PR DESCRIPTION
## Problem

Using `shfmt-version: latest` in CI caused a failure when shfmt 3.14.0 was released with different heredoc formatting than 3.13.1 (the local toolchain). This surfaced as a conflict during [PR #171](https://github.com/sebrandon1/cert-manager-scripts/pull/171) and required a manual workaround.

## Fix

Pin `shfmt-version: "3.14.0"` in both:
- `.github/workflows/pre-main.yml`
- `.github/workflows/nightly.yml`

This makes the required shfmt version explicit and prevents future CI failures from version drift. When upgrading shfmt, update both files intentionally.

> **Note for local development:** if `make lint` reports a shfmt diff, ensure your local shfmt matches 3.14.0 (`shfmt --version`). Install with `brew upgrade shfmt` on macOS.